### PR TITLE
Io refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "laythe_native"
+version = "0.1.0"
+dependencies = [
+ "laythe_env 0.1.0",
+]
+
+[[package]]
 name = "laythe_vm"
 version = "0.1.0"
 dependencies = [
@@ -278,6 +285,7 @@ dependencies = [
  "laythe_core 0.1.0",
  "laythe_env 0.1.0",
  "laythe_lib 0.1.0",
+ "laythe_native 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "laythe_compiler_bench",
+  "laythe_native",
   "laythe_core",
   "laythe_lib",
   "laythe_macro",
@@ -12,6 +13,7 @@ members = [
 
 default-members = [
   "laythe_core",
+  "laythe_native",
   "laythe_lib",
   "laythe_macro",
   "laythe_env",

--- a/laythe/src/main.rs
+++ b/laythe/src/main.rs
@@ -22,6 +22,7 @@ fn main() {
           ExecuteResult::FunResult(_) => panic!("Fun result should only be returned internally"),
           ExecuteResult::CompileError => process::exit(2),
           ExecuteResult::RuntimeError => process::exit(3),
+          ExecuteResult::InternalError => process::exit(4),
         },
         Err(e) => {
           eprintln!("{}", e);

--- a/laythe_compiler_bench/src/main.rs
+++ b/laythe_compiler_bench/src/main.rs
@@ -1,9 +1,6 @@
 use laythe_core::hooks::{GcHooks, NoContext};
 use laythe_core::module::Module;
-use laythe_env::{
-  io::{Io, NativeIo},
-  memory::Gc,
-};
+use laythe_env::{memory::Gc, stdio::Stdio};
 use laythe_vm::compiler::{Compiler, Parser};
 use std::env;
 use std::fs::File;
@@ -29,12 +26,11 @@ fn main() {
         let gc = Gc::default();
         let mut context = NoContext::new(&gc);
         let hooks = GcHooks::new(&mut context);
-        let io = NativeIo::default();
-        let mut parser = Parser::new(io.stdio(), &source);
+        let mut parser = Parser::new(Stdio::default(), &source);
         let module =
           Module::from_path(&hooks, hooks.manage(PathBuf::from("/Benchmark.ly"))).unwrap();
         let module = hooks.manage(module);
-        let compiler = Compiler::new(module, io, &mut parser, &hooks);
+        let compiler = Compiler::new(module, &mut parser, &hooks);
         compiler.compile().unwrap();
       }
       println!("{}", ((now.elapsed().as_micros() as f64) / 1000000.0));

--- a/laythe_core/src/iterator.rs
+++ b/laythe_core/src/iterator.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use laythe_env::{
   managed::{Manage, Managed, Trace},
-  stdio::StdIo,
+  stdio::Stdio,
 };
 use std::fmt;
 use std::mem;
@@ -15,17 +15,17 @@ use std::mem;
 /// the need for hashing when the special IterCurrent and IterNext
 /// bytecodes are used
 #[derive(Debug)]
-pub struct SlIterator {
+pub struct LyIterator {
   /// The underlying iterator
-  iterator: Box<dyn SlIter>,
+  iterator: Box<dyn LyIter>,
 
   /// The current value of the iterator
   current: Value,
 }
 
-impl SlIterator {
+impl LyIterator {
   /// Create a new iterator container
-  pub fn new(iterator: Box<dyn SlIter>) -> Self {
+  pub fn new(iterator: Box<dyn LyIter>) -> Self {
     Self {
       iterator,
       current: VALUE_NIL,
@@ -63,7 +63,7 @@ impl SlIterator {
   }
 }
 
-impl Trace for SlIterator {
+impl Trace for LyIterator {
   fn trace(&self) -> bool {
     self.current.trace();
     self.iterator.trace();
@@ -71,7 +71,7 @@ impl Trace for SlIterator {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.current.trace_debug(stdio);
     self.iterator.trace_debug(stdio);
 
@@ -79,7 +79,7 @@ impl Trace for SlIterator {
   }
 }
 
-impl Manage for SlIterator {
+impl Manage for LyIterator {
   fn alloc_type(&self) -> &str {
     "iterator"
   }
@@ -93,11 +93,11 @@ impl Manage for SlIterator {
   }
 
   fn size(&self) -> usize {
-    mem::size_of::<SlIterator>() + self.iterator.size()
+    mem::size_of::<LyIterator>() + self.iterator.size()
   }
 }
 
-pub trait SlIter: Trace + fmt::Debug {
+pub trait LyIter: Trace + fmt::Debug {
   /// The name of the iterator mostly for debugging purposes
   fn name(&self) -> &str;
 

--- a/laythe_core/src/native.rs
+++ b/laythe_core/src/native.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use laythe_env::{
   managed::{Manage, Trace},
-  stdio::StdIo,
+  stdio::Stdio,
 };
 use std::fmt;
 use std::{mem, ptr};
@@ -67,7 +67,7 @@ impl Trace for Box<dyn NativeFun> {
     inner.trace()
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     let inner: &dyn NativeFun = &**self;
     inner.trace_debug(stdio)
   }
@@ -128,7 +128,7 @@ impl Trace for Box<dyn NativeMethod> {
     inner.trace()
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     let inner: &dyn NativeMethod = &**self;
     inner.trace_debug(stdio)
   }

--- a/laythe_core/src/object.rs
+++ b/laythe_core/src/object.rs
@@ -13,7 +13,7 @@ use hash_map::Entry;
 use hashbrown::{hash_map, HashMap};
 use laythe_env::{
   managed::{Manage, Managed, Trace},
-  stdio::StdIo,
+  stdio::Stdio,
 };
 use slice::SliceIndex;
 use std::{
@@ -35,7 +35,7 @@ impl Trace for BuiltIn {
     self.primitives.trace()
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.primitives.trace_debug(stdio)
   }
 }
@@ -128,7 +128,7 @@ impl Trace for BuiltinPrimitives {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.bool.trace_debug(stdio);
     self.nil.trace_debug(stdio);
     self.class.trace_debug(stdio);
@@ -218,7 +218,7 @@ impl Trace for Upvalue {
     }
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     match self {
       Upvalue::Closed(upvalue) => upvalue.trace_debug(stdio),
       _ => true,
@@ -381,7 +381,7 @@ impl Trace for Fun {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.name.trace_debug(stdio);
     self.chunk.constants.iter().for_each(|constant| {
       constant.trace_debug(stdio);
@@ -505,7 +505,6 @@ impl<T: Clone> From<&[T]> for LyVec<T> {
   }
 }
 
-
 impl<T: 'static + Trace> Trace for LyVec<T> {
   fn trace(&self) -> bool {
     self.iter().for_each(|value| {
@@ -515,7 +514,7 @@ impl<T: 'static + Trace> Trace for LyVec<T> {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.iter().for_each(|value| {
       value.trace_debug(stdio);
     });
@@ -605,7 +604,7 @@ impl<T: 'static + Trace> Trace for LyHashMap<T, T> {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.iter().for_each(|(key, value)| {
       key.trace_debug(stdio);
       value.trace_debug(stdio);
@@ -693,7 +692,7 @@ impl Trace for Closure {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.upvalues.iter().for_each(|upvalue| {
       upvalue.trace_debug(stdio);
     });
@@ -841,7 +840,7 @@ impl Trace for Class {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.name.trace_debug(stdio);
     self.init.map(|init| init.trace_debug(stdio));
 
@@ -926,7 +925,7 @@ impl Trace for Instance {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.class.trace_debug(stdio);
 
     self.fields.for_each(|(key, val)| {
@@ -985,7 +984,7 @@ impl Trace for Method {
     true
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.receiver.trace_debug(stdio);
     self.method.trace_debug(stdio);
     true

--- a/laythe_core/src/package.rs
+++ b/laythe_core/src/package.rs
@@ -2,7 +2,7 @@ use crate::{hooks::GcHooks, module::Module, object::LyHashMap, LyResult};
 use hashbrown::hash_map::{Entry, Iter};
 use laythe_env::{
   managed::{Manage, Managed, Trace},
-  stdio::StdIo,
+  stdio::Stdio,
 };
 use std::fmt;
 use std::mem;
@@ -165,7 +165,7 @@ impl Trace for Package {
 
     true
   }
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.name.trace_debug(stdio);
 
     self.entities.iter().for_each(|(key, value)| {

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -36,7 +36,7 @@ mod unboxed {
   };
   use laythe_env::{
     managed::{Managed, Trace},
-    stdio::StdioWrapper,
+    stdio::Stdio,
   };
 
   use std::fmt;
@@ -820,7 +820,7 @@ mod unboxed {
       }
     }
 
-    fn trace_debug(&self, stdio: &mut StdioWrapper) -> bool {
+    fn trace_debug(&self, stdio: &mut Stdio) -> bool {
       match self {
         Value::Nil => true,
         Value::Bool(_) => true,

--- a/laythe_env/src/env.rs
+++ b/laythe_env/src/env.rs
@@ -1,26 +1,40 @@
-use std::env;
-use std::{io::Result, path::PathBuf};
+use std::{io, path::PathBuf};
 
-pub trait EnvIo {
-  fn current_dir(&self) -> Result<PathBuf>;
+/// A wrapper around environmental facilities provided to Laythe
+pub struct Env {
+  env: Box<dyn EnvImpl>,
+}
+
+impl Env {
+  /// Create a new wrapper around the provided environmental facilities
+  pub fn new(env: Box<dyn EnvImpl>) -> Self {
+    Self { env }
+  }
+
+  /// Get the current working directory
+  pub fn current_dir(&self) -> io::Result<PathBuf> {
+    self.env.current_dir()
+  }
+
+  /// Get the arguments pass to this script
+  pub fn args(&self) -> Vec<String> {
+    self.env.args()
+  }
+}
+
+pub trait EnvImpl {
+  fn current_dir(&self) -> io::Result<PathBuf>;
   fn args(&self) -> Vec<String>;
 }
 
-#[derive(Clone)]
-pub struct NativeEnvIo();
+pub struct EnvMock();
 
-impl Default for NativeEnvIo {
-  fn default() -> Self {
-    Self()
-  }
-}
-
-impl EnvIo for NativeEnvIo {
-  fn current_dir(&self) -> Result<PathBuf> {
-    env::current_dir()
+impl EnvImpl for EnvMock {
+  fn current_dir(&self) -> io::Result<PathBuf> {
+    Ok(PathBuf::new())
   }
 
   fn args(&self) -> Vec<String> {
-    env::args().collect()
+    vec![]
   }
 }

--- a/laythe_env/src/impls.rs
+++ b/laythe_env/src/impls.rs
@@ -1,6 +1,6 @@
 use crate::{
   managed::{Manage, Trace},
-  stdio::StdIo,
+  stdio::Stdio,
 };
 use std::{mem, path::PathBuf};
 
@@ -8,7 +8,7 @@ impl Trace for PathBuf {
   fn trace(&self) -> bool {
     true
   }
-  fn trace_debug(&self, _: &dyn StdIo) -> bool {
+  fn trace_debug(&self, _: &mut Stdio) -> bool {
     true
   }
 }
@@ -33,7 +33,7 @@ impl Trace for String {
     true
   }
 
-  fn trace_debug(&self, _: &dyn StdIo) -> bool {
+  fn trace_debug(&self, _: &mut Stdio) -> bool {
     true
   }
 }

--- a/laythe_env/src/io.rs
+++ b/laythe_env/src/io.rs
@@ -1,7 +1,7 @@
 use crate::{
   env::{Env, EnvMock},
   fs::{Fs, FsMock},
-  stdio::{Stdio},
+  stdio::Stdio,
 };
 use std::fmt;
 
@@ -78,5 +78,42 @@ impl IoImpl for MockIo {
   }
   fn clone_box(&self) -> Box<dyn IoImpl> {
     Box::new(MockIo())
+  }
+}
+
+pub mod support {
+  use super::*;
+  use crate::stdio::support::{StdioTest, StdioTestContainer};
+
+  #[derive(Debug, Clone)]
+  /// A mock implementation of the io systems
+  pub struct IoTest {
+    pub stdio: StdioTest,
+  }
+
+  impl IoTest {
+    pub fn new(stdio_container: &mut StdioTestContainer) -> Self {
+      Self {
+        stdio: stdio_container.make_stdio(),
+      }
+    }
+  }
+
+  impl IoImpl for IoTest {
+    fn stdio(&self) -> Stdio {
+      Stdio::new(Box::new(self.stdio.clone()))
+    }
+
+    fn fsio(&self) -> Fs {
+      Fs::new(Box::new(FsMock()))
+    }
+
+    fn envio(&self) -> Env {
+      Env::new(Box::new(EnvMock()))
+    }
+
+    fn clone_box(&self) -> Box<dyn IoImpl> {
+      Box::new(self.clone())
+    }
   }
 }

--- a/laythe_env/src/io.rs
+++ b/laythe_env/src/io.rs
@@ -1,7 +1,7 @@
 use crate::{
   env::{Env, EnvMock},
   fs::{Fs, FsMock},
-  stdio::{Stdio, StdioMock},
+  stdio::{Stdio},
 };
 use std::fmt;
 

--- a/laythe_env/src/io.rs
+++ b/laythe_env/src/io.rs
@@ -1,37 +1,82 @@
 use crate::{
-  env::{EnvIo, NativeEnvIo},
-  fs::{FsIo, NativeFsIo},
-  stdio::{NativeStdIo, StdIo},
+  env::{Env, EnvMock},
+  fs::{Fs, FsMock},
+  stdio::{Stdio, StdioMock},
 };
 use std::fmt;
 
-pub trait Io: fmt::Debug + Default + Clone {
-  type StdIo: StdIo + Clone;
-  type FsIo: FsIo + Clone;
-  type EnvIo: EnvIo + Clone;
-
-  fn stdio(&self) -> Self::StdIo;
-  fn fsio(&self) -> Self::FsIo;
-  fn envio(&self) -> Self::EnvIo;
+#[derive(Debug)]
+/// A struct wrapping the externally provided io to Laythe
+pub struct Io {
+  io: Box<dyn IoImpl>,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-pub struct NativeIo();
+impl Default for Io {
+  fn default() -> Self {
+    Self::new(Box::new(MockIo()))
+  }
+}
 
-impl Io for NativeIo {
-  type StdIo = NativeStdIo;
-  type FsIo = NativeFsIo;
-  type EnvIo = NativeEnvIo;
-
-  fn stdio(&self) -> Self::StdIo {
-    NativeStdIo()
+impl Io {
+  /// Create a new io wrapper uses the provided io impl
+  pub fn new(io: Box<dyn IoImpl>) -> Self {
+    Self { io }
   }
 
-  fn fsio(&self) -> Self::FsIo {
-    NativeFsIo()
+  /// Generate a wrapper to stdio facilities
+  pub fn stdio(&self) -> Stdio {
+    self.io.stdio()
   }
 
-  fn envio(&self) -> Self::EnvIo {
-    NativeEnvIo()
+  /// Generate a wrapper to file system facilities
+  pub fn fsio(&self) -> Fs {
+    self.io.fsio()
+  }
+
+  /// Generate a wrapper to environment facilities
+  pub fn envio(&self) -> Env {
+    self.io.envio()
+  }
+}
+
+impl Clone for Io {
+  fn clone(&self) -> Self {
+    Io::new(self.io.clone_box())
+  }
+}
+
+/// A trait defining what facilities need to be provided
+/// to Laythe in terms of io
+pub trait IoImpl: fmt::Debug {
+  /// homebrew clone as trait objects can't be cloned. Trait objects
+  /// are unsized and clone requires Sized trait
+  fn clone_box(&self) -> Box<dyn IoImpl>;
+
+  /// Create a handle to stdio facilities
+  fn stdio(&self) -> Stdio;
+
+  /// Create a handle to file system facilities
+  fn fsio(&self) -> Fs;
+
+  /// Create a handle to environment facilities
+  fn envio(&self) -> Env;
+}
+
+#[derive(Debug)]
+/// A mock implementation of the io systems
+pub struct MockIo();
+
+impl IoImpl for MockIo {
+  fn stdio(&self) -> Stdio {
+    Stdio::default()
+  }
+  fn fsio(&self) -> Fs {
+    Fs::new(Box::new(FsMock()))
+  }
+  fn envio(&self) -> Env {
+    Env::new(Box::new(EnvMock()))
+  }
+  fn clone_box(&self) -> Box<dyn IoImpl> {
+    Box::new(MockIo())
   }
 }

--- a/laythe_env/src/lib.rs
+++ b/laythe_env/src/lib.rs
@@ -6,17 +6,12 @@ pub mod managed;
 pub mod memory;
 pub mod stdio;
 
-pub enum Error {
-  InvalidPath,
-}
-
-pub struct SlIoError {
-  pub kind: Error,
+pub struct LyIoError {
   pub message: String,
 }
 
-impl SlIoError {
-  pub fn new(kind: Error, message: String) -> Self {
-    Self { kind, message }
+impl LyIoError {
+  pub fn new(message: String) -> Self {
+    Self { message }
   }
 }

--- a/laythe_env/src/memory.rs
+++ b/laythe_env/src/memory.rs
@@ -43,9 +43,9 @@ impl<'a> Gc {
   /// # Examples
   /// ```
   /// use laythe_env::memory::Gc;
-  /// use laythe_env::stdio::StdioWrapper;
+  /// use laythe_env::stdio::Stdio;
   ///
-  /// let gc = Gc::new(StdioWrapper::default());
+  /// let gc = Gc::new(Stdio::default());
   /// ```
   pub fn new(stdio: Stdio) -> Self {
     Gc {

--- a/laythe_env/src/memory.rs
+++ b/laythe_env/src/memory.rs
@@ -1,5 +1,5 @@
 use crate::managed::{Allocation, Manage, Managed, Trace};
-use crate::stdio::StdIo;
+use crate::stdio::Stdio;
 use hashbrown::HashMap;
 use std::cell::{Cell, RefCell};
 use std::fmt;
@@ -11,7 +11,7 @@ use std::ptr::NonNull;
 pub struct Gc {
   /// Io in the given environment
   #[allow(dead_code)]
-  stdio: Box<dyn StdIo>,
+  stdio: Stdio,
 
   /// The nursery heap for new objects initially allocated into this gc
   nursery_heap: RefCell<Vec<Box<Allocation<dyn Manage>>>>,
@@ -43,11 +43,11 @@ impl<'a> Gc {
   /// # Examples
   /// ```
   /// use laythe_env::memory::Gc;
-  /// use laythe_env::stdio::NativeStdIo;
+  /// use laythe_env::stdio::StdioWrapper;
   ///
-  /// let gc = Gc::new(Box::new(NativeStdIo()));
+  /// let gc = Gc::new(StdioWrapper::default());
   /// ```
-  pub fn new(stdio: Box<dyn StdIo>) -> Self {
+  pub fn new(stdio: Stdio) -> Self {
     Gc {
       stdio,
       nursery_heap: RefCell::new(Vec::with_capacity(1000)),
@@ -413,9 +413,7 @@ impl<'a> Gc {
 
 impl<'a> Default for Gc {
   fn default() -> Self {
-    use crate::stdio::NativeStdIo;
-
-    Gc::new(Box::new(NativeStdIo()))
+    Gc::new(Stdio::default())
   }
 }
 pub struct NoGc();
@@ -431,7 +429,7 @@ impl Trace for NoGc {
     false
   }
 
-  fn trace_debug(&self, _: &dyn StdIo) -> bool {
+  fn trace_debug(&self, _: &mut Stdio) -> bool {
     false
   }
 }
@@ -441,12 +439,11 @@ pub static NO_GC: NoGc = NoGc();
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::stdio::NativeStdIo;
 
   #[test]
   fn dyn_manage() {
     let dyn_trace: Box<dyn Trace> = Box::new(NoGc());
-    let gc = Gc::new(Box::new(NativeStdIo()));
+    let gc = Gc::default();
 
     let dyn_manged_str = gc.manage("managed".to_string(), &*dyn_trace);
     assert_eq!(*dyn_manged_str, "managed".to_string());

--- a/laythe_env/src/stdio.rs
+++ b/laythe_env/src/stdio.rs
@@ -99,3 +99,101 @@ impl Read for MockRead {
     Ok(0)
   }
 }
+
+pub mod support {
+  use super::StdioImpl;
+  use std::io::{Cursor, Write};
+  use std::str;
+
+  #[derive(Debug)]
+  pub struct StdioTestContainer {
+    pub stdout: Box<Vec<u8>>,
+    pub stderr: Box<Vec<u8>>,
+    pub stdin: Box<Cursor<Vec<u8>>>,
+    pub lines: Box<Vec<String>>,
+    pub line_index: Box<usize>,
+  }
+
+  impl Default for StdioTestContainer {
+    fn default() -> Self {
+      Self {
+        stdout: Box::new(vec![]),
+        stderr: Box::new(vec![]),
+        stdin: Box::new(Cursor::new(vec![])),
+        lines: Box::new(vec![]),
+        line_index: Box::new(0),
+      }
+    }
+  }
+
+  impl StdioTestContainer {
+    pub fn with_lines(lines: Vec<String>) -> Self {
+      Self {
+        stdout: Box::new(vec![]),
+        stderr: Box::new(vec![]),
+        stdin: Box::new(Cursor::new(vec![])),
+        lines: Box::new(lines),
+        line_index: Box::new(0),
+      }
+    }
+
+    pub fn with_stdin(buf: &[u8]) -> Self {
+      Self {
+        stdout: Box::new(vec![]),
+        stderr: Box::new(vec![]),
+        stdin: Box::new(Cursor::new(Vec::from(buf))),
+        lines: Box::new(vec![]),
+        line_index: Box::new(0),
+      }
+    }
+
+    pub fn make_stdio(&mut self) -> StdioTest {
+      StdioTest {
+        stdout: &mut *self.stdout,
+        stdin: &mut *self.stdin,
+        stderr: &mut *self.stderr,
+        lines: &mut *self.lines,
+        line_index: &mut *self.line_index,
+      }
+    }
+
+    pub fn log_stdio(&self) {
+      eprintln!("{}", str::from_utf8(&*self.stdout).expect("Could not unwrap stdout"));
+      eprintln!("{}", str::from_utf8(&*self.stderr).expect("Could not unwrap stderr"));
+    }
+  }
+
+  #[derive(Debug, Clone)]
+  pub struct StdioTest {
+    pub stdout: *mut Vec<u8>,
+    pub stderr: *mut Vec<u8>,
+    pub stdin: *mut Cursor<Vec<u8>>,
+    pub lines: *mut Vec<String>,
+    line_index: *mut usize,
+  }
+
+  impl StdioImpl for StdioTest {
+    fn stdout(&mut self) -> &mut dyn Write {
+      unsafe { &mut *self.stdout }
+    }
+    fn stderr(&mut self) -> &mut dyn Write {
+      unsafe { &mut *self.stderr }
+    }
+    fn stdin(&mut self) -> &mut dyn std::io::Read {
+      unsafe { &mut *self.stdin }
+    }
+    fn read_line(&self, buffer: &mut String) -> std::io::Result<usize> {
+      unsafe {
+        let line = match (&*self.lines).get(*self.line_index) {
+          Some(line) => line.clone(),
+          None => panic!("Not enough test lines"),
+        };
+
+        buffer.push_str(&line);
+
+        *self.line_index = *self.line_index + 1;
+        Ok(line.len())
+      }
+    }
+  }
+}

--- a/laythe_env/src/stdio.rs
+++ b/laythe_env/src/stdio.rs
@@ -1,40 +1,101 @@
-use std::io::{stdin, stdout, Result, Write};
+use io::{Read, Write};
+use std::io;
 
-pub trait StdIo {
-  fn print(&self, message: &str);
-  fn println(&self, message: &str);
-  fn eprint(&self, message: &str);
-  fn eprintln(&self, message: &str);
-  fn flush(&self) -> Result<()>;
-  fn read_line(&self, buffer: &mut String) -> Result<usize>;
+/// A wrapper the provided facilities around standard input output and err
+pub struct Stdio {
+  stdio: Box<dyn StdioImpl>,
 }
 
-#[derive(Debug, Clone)]
-pub struct NativeStdIo();
-
-impl Default for NativeStdIo {
+impl Default for Stdio {
   fn default() -> Self {
-    Self()
+    Self {
+      stdio: Box::new(StdioMock::default()),
+    }
   }
 }
 
-impl StdIo for NativeStdIo {
-  fn print(&self, message: &str) {
-    print!("{}", message);
+impl Stdio {
+  /// Create a new wrapper from the provided stdio facilities
+  pub fn new(stdio: Box<dyn StdioImpl>) -> Self {
+    Self { stdio }
   }
-  fn println(&self, message: &str) {
-    println!("{}", message);
+
+  /// Get a Write to stdout
+  pub fn stdout(&mut self) -> &mut dyn Write {
+    self.stdio.stdout()
   }
-  fn eprint(&self, message: &str) {
-    eprint!("{}", message);
+
+  /// Get a Write to stderr
+  pub fn stderr(&mut self) -> &mut dyn Write {
+    self.stdio.stderr()
   }
-  fn eprintln(&self, message: &str) {
-    eprintln!("{}", message);
+
+  /// Get a Read to stdin
+  pub fn stdin(&mut self) -> &mut dyn Read {
+    self.stdio.stdin()
   }
-  fn flush(&self) -> Result<()> {
-    stdout().flush()
+
+  /// Read a line from standard in
+  pub fn read_line(&self, buffer: &mut String) -> io::Result<usize> {
+    self.stdio.read_line(buffer)
   }
-  fn read_line(&self, buffer: &mut String) -> Result<usize> {
-    stdin().read_line(buffer)
+}
+
+pub trait StdioImpl {
+  fn stdout(&mut self) -> &mut dyn Write;
+  fn stderr(&mut self) -> &mut dyn Write;
+  fn stdin(&mut self) -> &mut dyn Read;
+
+  fn read_line(&self, buffer: &mut String) -> io::Result<usize>;
+}
+
+pub struct StdioMock {
+  write: MockWrite,
+  read: MockRead,
+}
+
+impl Default for StdioMock {
+  fn default() -> Self {
+    Self {
+      write: MockWrite(),
+      read: MockRead(),
+    }
+  }
+}
+
+impl StdioImpl for StdioMock {
+  fn stdout(&mut self) -> &mut dyn Write {
+    &mut self.write
+  }
+  fn stderr(&mut self) -> &mut dyn Write {
+    &mut self.write
+  }
+  fn stdin(&mut self) -> &mut dyn Read {
+    &mut self.read
+  }
+  fn read_line(&self, buffer: &mut String) -> io::Result<usize> {
+    const LINE: &str = "let x = 10;";
+    buffer.push_str(LINE);
+
+    Ok(LINE.len())
+  }
+}
+
+pub struct MockWrite();
+
+impl Write for MockWrite {
+  fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    Ok(buf.len())
+  }
+  fn flush(&mut self) -> io::Result<()> {
+    Ok(())
+  }
+}
+
+pub struct MockRead();
+
+impl Read for MockRead {
+  fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+    Ok(0)
   }
 }

--- a/laythe_lib/src/global/assert/assert.rs
+++ b/laythe_lib/src/global/assert/assert.rs
@@ -9,7 +9,7 @@ use laythe_core::{
 };
 use laythe_env::{
   managed::{Managed, Trace},
-  stdio::StdIo,
+  stdio::Stdio,
 };
 
 const ASSERT_META: NativeMeta = NativeMeta::new(

--- a/laythe_lib/src/global/assert/assert.rs
+++ b/laythe_lib/src/global/assert/assert.rs
@@ -187,8 +187,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let assert = Assert::new(hooks.manage_str("str".to_string()));
@@ -226,8 +225,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
       let assert_eq = AssertEq::new(hooks.manage_str("str".to_string()));
 
@@ -265,8 +263,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
       let assert_eq = AssertNe::new(hooks.manage_str("str".to_string()));
 

--- a/laythe_lib/src/global/assert/mod.rs
+++ b/laythe_lib/src/global/assert/mod.rs
@@ -4,7 +4,7 @@ use assert::declare_assert_funs;
 use laythe_core::{hooks::GcHooks, module::Module, package::Package, LyResult};
 use laythe_env::managed::Managed;
 
-pub(crate) fn create_assert_funs(
+pub(crate) fn add_assert_funs(
   hooks: &GcHooks,
   mut module: Managed<Module>,
   _package: Managed<Package>,

--- a/laythe_lib/src/global/dependencies/mod.rs
+++ b/laythe_lib/src/global/dependencies/mod.rs
@@ -4,7 +4,7 @@ use laythe_core::{hooks::GcHooks, module::Module, package::Package, LyResult};
 use laythe_env::managed::Managed;
 use module::{declare_module_class, define_module_class};
 
-pub(crate) fn create_dependency_classes(
+pub(crate) fn add_dependency_classes(
   hooks: &GcHooks,
   mut module: Managed<Module>,
   package: Managed<Package>,

--- a/laythe_lib/src/global/mod.rs
+++ b/laythe_lib/src/global/mod.rs
@@ -7,8 +7,8 @@ mod time;
 mod support;
 
 use crate::GLOBAL_PATH;
-use assert::create_assert_funs;
-use dependencies::create_dependency_classes;
+use assert::add_assert_funs;
+use dependencies::add_dependency_classes;
 use dependencies::module::MODULE_CLASS_NAME;
 use laythe_core::{
   hooks::GcHooks,
@@ -19,30 +19,26 @@ use laythe_core::{
 };
 use laythe_env::managed::Managed;
 use primitives::{
-  bool::BOOL_CLASS_NAME, class::CLASS_CLASS_NAME, closure::CLOSURE_CLASS_NAME,
-  create_primitive_classes, iter::ITER_CLASS_NAME, list::LIST_CLASS_NAME, map::MAP_CLASS_NAME,
+  add_primitive_classes, bool::BOOL_CLASS_NAME, class::CLASS_CLASS_NAME,
+  closure::CLOSURE_CLASS_NAME, iter::ITER_CLASS_NAME, list::LIST_CLASS_NAME, map::MAP_CLASS_NAME,
   method::METHOD_CLASS_NAME, native_fun::NATIVE_FUN_CLASS_NAME,
   native_method::NATIVE_METHOD_CLASS_NAME, nil::NIL_CLASS_NAME, number::NUMBER_CLASS_NAME,
   object::OBJECT_CLASS_NAME, string::STRING_CLASS_NAME,
 };
 use std::path::PathBuf;
-use time::create_clock_funs;
+use time::add_clock_funs;
 
-pub fn add_global(hooks: &GcHooks, mut std: Managed<Package>) -> LyResult<()> {
-  let module = match Module::from_path(&hooks, hooks.manage(PathBuf::from(GLOBAL_PATH))) {
-    Some(module) => module,
-    None => {
-      return Err(hooks.make_error("Could not create global module, path malformed.".to_string()));
-    }
-  };
-
-  let module = hooks.manage(module);
+pub fn add_global_module(hooks: &GcHooks, mut std: Managed<Package>) -> LyResult<()> {
+  let module = hooks.manage(Module::from_path(
+    &hooks,
+    hooks.manage(PathBuf::from(GLOBAL_PATH)),
+  )?);
   std.add_module(hooks, module)?;
 
-  create_primitive_classes(hooks, module, std)?;
-  create_dependency_classes(hooks, module, std)?;
-  create_assert_funs(hooks, module, std)?;
-  create_clock_funs(hooks, module, std)?;
+  add_primitive_classes(hooks, module, std)?;
+  add_dependency_classes(hooks, module, std)?;
+  add_assert_funs(hooks, module, std)?;
+  add_clock_funs(hooks, module, std)?;
 
   Ok(())
 }

--- a/laythe_lib/src/global/primitives/bool.rs
+++ b/laythe_lib/src/global/primitives/bool.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   value::{Value, VALUE_TRUE},
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 pub const BOOL_CLASS_NAME: &'static str = "Bool";
 const BOOL_STR: NativeMeta = NativeMeta::new("str", Arity::Fixed(0), &[]);

--- a/laythe_lib/src/global/primitives/bool.rs
+++ b/laythe_lib/src/global/primitives/bool.rs
@@ -55,7 +55,7 @@ mod test {
 
   mod str {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -68,8 +68,7 @@ mod test {
     #[test]
     fn call() {
       let bool_str = BoolStr();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let b_true = Value::from(true);

--- a/laythe_lib/src/global/primitives/class.rs
+++ b/laythe_lib/src/global/primitives/class.rs
@@ -1,8 +1,15 @@
-use crate::support::{load_class_from_module, export_and_insert, to_dyn_method};
+use crate::support::{export_and_insert, load_class_from_module, to_dyn_method};
 use laythe_core::{
-  hooks::{Hooks, GcHooks}, module::Module, object::Class, package::Package, value::{VALUE_NIL, Value}, LyResult, native::{NativeMethod, NativeMeta}, signature::Arity, CallResult,
+  hooks::{GcHooks, Hooks},
+  module::Module,
+  native::{NativeMeta, NativeMethod},
+  object::Class,
+  package::Package,
+  signature::Arity,
+  value::{Value, VALUE_NIL},
+  CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 pub const CLASS_CLASS_NAME: &'static str = "Class";
 
@@ -15,7 +22,7 @@ pub fn declare_class_class(hooks: &GcHooks, module: &mut Module) -> LyResult<()>
   export_and_insert(hooks, module, name, Value::from(class))
 }
 
-pub fn define_class_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()>  {
+pub fn define_class_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
   let mut class_class = load_class_from_module(hooks, module, CLASS_CLASS_NAME)?;
 
   class_class.add_method(
@@ -36,7 +43,8 @@ impl NativeMethod for ClassSuperClass {
   }
 
   fn call(&self, _hooks: &mut Hooks, this: Value, _args: &[Value]) -> CallResult {
-    let super_class = this.to_class()
+    let super_class = this
+      .to_class()
       .super_class()
       .map(|super_class| Value::from(super_class))
       .unwrap_or(VALUE_NIL);
@@ -68,16 +76,11 @@ mod test {
       let mut context = MockedContext::new(&gc, &[]);
       let mut hooks = Hooks::new(&mut context);
 
-      let mut class = hooks.manage(Class::bare(
-        hooks.manage_str("someClass".to_string())
-      ));
+      let mut class = hooks.manage(Class::bare(hooks.manage_str("someClass".to_string())));
 
-      let super_class = hooks.manage(Class::bare(
-        hooks.manage_str("someSuperClass".to_string())
-      ));
+      let super_class = hooks.manage(Class::bare(hooks.manage_str("someSuperClass".to_string())));
 
       class.inherit(&hooks.to_gc(), super_class);
-
 
       let class_value = Value::from(class);
       let super_class_value = Value::from(super_class);

--- a/laythe_lib/src/global/primitives/class.rs
+++ b/laythe_lib/src/global/primitives/class.rs
@@ -59,7 +59,7 @@ mod test {
 
   mod super_class {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -72,8 +72,7 @@ mod test {
     #[test]
     fn call() {
       let class_super_class = ClassSuperClass();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let mut class = hooks.manage(Class::bare(hooks.manage_str("someClass".to_string())));

--- a/laythe_lib/src/global/primitives/closure.rs
+++ b/laythe_lib/src/global/primitives/closure.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 pub const CLOSURE_CLASS_NAME: &'static str = "Fun";
 

--- a/laythe_lib/src/global/primitives/closure.rs
+++ b/laythe_lib/src/global/primitives/closure.rs
@@ -106,7 +106,7 @@ mod test {
 
   mod name {
     use super::*;
-    use crate::support::{fun_from_hooks, test_native_dependencies, MockedContext};
+    use crate::support::{fun_from_hooks, MockedContext};
     use laythe_core::object::Closure;
 
     #[test]
@@ -120,8 +120,7 @@ mod test {
     #[test]
     fn call() {
       let closure_name = ClosureName();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let fun = fun_from_hooks(&hooks.to_gc(), "example".to_string(), "module");
@@ -138,7 +137,7 @@ mod test {
 
   mod size {
     use super::*;
-    use crate::support::{fun_from_hooks, test_native_dependencies, MockedContext};
+    use crate::support::{fun_from_hooks, MockedContext};
     use laythe_core::object::Closure;
 
     #[test]
@@ -152,8 +151,7 @@ mod test {
     #[test]
     fn call() {
       let closure_name = ClosureSize();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let mut fun = fun_from_hooks(&hooks.to_gc(), "example".to_string(), "module");
@@ -185,7 +183,7 @@ mod test {
 
   mod call {
     use super::*;
-    use crate::support::{fun_from_hooks, test_native_dependencies, MockedContext};
+    use crate::support::{fun_from_hooks, MockedContext};
     use laythe_core::object::Closure;
 
     #[test]
@@ -203,8 +201,7 @@ mod test {
     #[test]
     fn call() {
       let closure_call = ClosureCall();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[Value::from(4.3)]);
+      let mut context = MockedContext::new(&[Value::from(4.3)]);
       let mut hooks = Hooks::new(&mut context);
 
       let mut fun = fun_from_hooks(&hooks.to_gc(), "example".to_string(), "module");

--- a/laythe_lib/src/global/primitives/iter.rs
+++ b/laythe_lib/src/global/primitives/iter.rs
@@ -477,7 +477,7 @@ impl NativeMethod for IterInto {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::support::{test_iter, test_native_dependencies, MockedContext};
+  use crate::support::{test_iter, MockedContext};
   use laythe_core::iterator::LyIterator;
 
   #[cfg(test)]
@@ -495,8 +495,7 @@ mod test {
     #[test]
     fn call() {
       let iter_str = IterStr();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let iter = test_iter();
@@ -525,8 +524,7 @@ mod test {
     #[test]
     fn call() {
       let iter_next = IterNext();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let iter = test_iter();
@@ -554,8 +552,7 @@ mod test {
     #[test]
     fn call() {
       let iter_iter = IterIter();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let iter = test_iter();
@@ -590,8 +587,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[Value::from(5.0)]);
+      let mut context = MockedContext::new(&[Value::from(5.0)]);
       let mut hooks = Hooks::new(&mut context);
       let iter_map = IterMap();
 
@@ -620,7 +616,7 @@ mod test {
 
   mod filter {
     use super::*;
-    use crate::support::{fun_from_hooks, test_native_dependencies, MockedContext};
+    use crate::support::{fun_from_hooks, MockedContext};
     use laythe_core::{iterator::LyIterator, object::Closure};
 
     #[test]
@@ -637,11 +633,8 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(
-        &gc,
-        &[Value::from(false), Value::from(true), Value::from(true)],
-      );
+      let mut context =
+        MockedContext::new(&[Value::from(false), Value::from(true), Value::from(true)]);
       let mut hooks = Hooks::new(&mut context);
       let iter_filter = IterFilter();
 
@@ -672,7 +665,7 @@ mod test {
 
   mod reduce {
     use super::*;
-    use crate::support::{fun_from_hooks, test_native_dependencies, MockedContext};
+    use crate::support::{fun_from_hooks, MockedContext};
     use laythe_core::{iterator::LyIterator, object::Closure};
 
     #[test]
@@ -693,17 +686,13 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(
-        &gc,
-        &[
-          Value::from(false),
-          Value::from(false),
-          Value::from(false),
-          Value::from(false),
-          Value::from(10.1),
-        ],
-      );
+      let mut context = MockedContext::new(&[
+        Value::from(false),
+        Value::from(false),
+        Value::from(false),
+        Value::from(false),
+        Value::from(10.1),
+      ]);
       let mut hooks = Hooks::new(&mut context);
       let iter_reduce = IterReduce();
 
@@ -731,7 +720,7 @@ mod test {
 
   mod each {
     use super::*;
-    use crate::support::{fun_from_hooks, test_native_dependencies, MockedContext};
+    use crate::support::{fun_from_hooks, MockedContext};
     use laythe_core::{iterator::LyIterator, object::Closure};
 
     #[test]
@@ -748,8 +737,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[Value::from(false); 5]);
+      let mut context = MockedContext::new(&[Value::from(false); 5]);
       let mut hooks = Hooks::new(&mut context);
       let iter_each = IterEach();
 
@@ -774,8 +762,8 @@ mod test {
 
   mod zip {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
-    use laythe_core::{iterator::LyIterator};
+    use crate::support::MockedContext;
+    use laythe_core::iterator::LyIterator;
 
     #[test]
     fn new() {
@@ -791,15 +779,14 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[Value::from(1.0); 10]);
+      let mut context = MockedContext::new(&[Value::from(1.0); 10]);
       let mut hooks = Hooks::new(&mut context);
       let iter_zip = IterZip();
 
       let iter = test_iter();
       let managed = hooks.manage(LyIterator::new(iter));
       let this = Value::from(managed);
-     
+
       let iter2 = test_iter();
       let managed = hooks.manage(LyIterator::new(iter2));
       let arg = Value::from(managed);
@@ -821,7 +808,7 @@ mod test {
 
   mod into {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
     use laythe_core::{iterator::LyIterator, native::NativeFun};
 
     const M: NativeMeta = NativeMeta::new(
@@ -857,8 +844,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[Value::from(true); 5]);
+      let mut context = MockedContext::new(&[Value::from(true); 5]);
       let mut hooks = Hooks::new(&mut context);
       let iter_into = IterInto();
 

--- a/laythe_lib/src/global/primitives/list.rs
+++ b/laythe_lib/src/global/primitives/list.rs
@@ -457,8 +457,7 @@ mod test {
 
     #[test]
     fn new() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let hooks = Hooks::new(&mut context);
 
       let list_str = ListStr::new(hooks.manage_str("str".to_string()));
@@ -470,14 +469,11 @@ mod test {
     #[test]
     fn call() {
       let gc = test_native_dependencies();
-      let mut context = MockedContext::new(
-        &gc,
-        &[
-          Value::from(gc.manage_str("nil".to_string(), &NO_GC)),
-          Value::from(gc.manage_str("10".to_string(), &NO_GC)),
-          Value::from(gc.manage_str("[5]".to_string(), &NO_GC)),
-        ],
-      );
+      let mut context = MockedContext::new(&[
+        Value::from(gc.manage_str("nil".to_string(), &NO_GC)),
+        Value::from(gc.manage_str("10".to_string(), &NO_GC)),
+        Value::from(gc.manage_str("[5]".to_string(), &NO_GC)),
+      ]);
       let mut hooks = Hooks::new(&mut context);
       let list_str = ListStr::new(hooks.manage_str("str".to_string()));
 
@@ -500,7 +496,7 @@ mod test {
 
   mod size {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
     use laythe_core::hooks::Hooks;
 
     #[test]
@@ -514,8 +510,7 @@ mod test {
     #[test]
     fn call() {
       let list_size = ListSize();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let values = &[];
@@ -533,7 +528,7 @@ mod test {
 
   mod push {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -550,8 +545,7 @@ mod test {
     #[test]
     fn call() {
       let list_push = ListPush();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let list = LyVec::from(vec![VALUE_NIL, Value::from(10.0)]);
@@ -587,7 +581,7 @@ mod test {
 
   mod pop {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -600,8 +594,7 @@ mod test {
     #[test]
     fn call() {
       let list_pop = ListPop();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let list = LyVec::from(vec![Value::from(true)]);
@@ -630,7 +623,7 @@ mod test {
 
   mod remove {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -647,8 +640,7 @@ mod test {
     #[test]
     fn call() {
       let list_remove = ListRemove();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let list = LyVec::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
@@ -680,7 +672,7 @@ mod test {
 
   mod index {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -697,8 +689,7 @@ mod test {
     #[test]
     fn call() {
       let list_index = ListIndex();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let list = LyVec::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
@@ -717,7 +708,7 @@ mod test {
 
   mod insert {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -738,8 +729,7 @@ mod test {
     #[test]
     fn call() {
       let list_insert = ListInsert();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let list = LyVec::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
@@ -776,7 +766,7 @@ mod test {
 
   mod clear {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -789,8 +779,7 @@ mod test {
     #[test]
     fn call() {
       let list_clear = ListClear();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let list = LyVec::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
@@ -819,7 +808,7 @@ mod test {
 
   mod has {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -836,8 +825,7 @@ mod test {
     #[test]
     fn call() {
       let list_has = ListHas();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let list = LyVec::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
@@ -864,7 +852,7 @@ mod test {
 
   mod iter {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -876,8 +864,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
       let list_iter = ListIter();
 
@@ -900,7 +887,7 @@ mod test {
 
   mod collect {
     use super::*;
-    use crate::support::{test_iter, test_native_dependencies, MockedContext};
+    use crate::support::{test_iter, MockedContext};
 
     #[test]
     fn new() {
@@ -916,8 +903,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
       let list_iter = ListCollect();
 

--- a/laythe_lib/src/global/primitives/map.rs
+++ b/laythe_lib/src/global/primitives/map.rs
@@ -4,7 +4,7 @@ use crate::support::{
 use hashbrown::hash_map::Iter;
 use laythe_core::{
   hooks::{GcHooks, Hooks},
-  iterator::{SlIter, SlIterator},
+  iterator::{LyIter, LyIterator},
   module::Module,
   native::{NativeMeta, NativeMethod},
   object::{LyHashMap, LyVec},
@@ -15,7 +15,7 @@ use laythe_core::{
 };
 use laythe_env::{
   managed::{Managed, Trace},
-  stdio::StdIo,
+  stdio::Stdio,
 };
 use std::fmt;
 use std::mem;
@@ -26,6 +26,14 @@ const MAP_GET: NativeMeta = NativeMeta::new(
   "get",
   Arity::Fixed(1),
   &[Parameter::new("key", ParameterKind::Any)],
+);
+const MAP_SET: NativeMeta = NativeMeta::new(
+  "set",
+  Arity::Fixed(2),
+  &[
+    Parameter::new("key", ParameterKind::Any),
+    Parameter::new("value", ParameterKind::Any),
+  ],
 );
 const MAP_HAS: NativeMeta = NativeMeta::new(
   "has",
@@ -172,7 +180,7 @@ impl Trace for MapStr {
     self.method_name.trace()
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.method_name.trace_debug(stdio)
   }
 }
@@ -260,8 +268,8 @@ impl NativeMethod for MapIter {
   }
 
   fn call(&self, hooks: &mut Hooks, this: Value, _args: &[Value]) -> CallResult {
-    let inner_iter: Box<dyn SlIter> = Box::new(MapIterator::new(this.to_map()));
-    let iter = SlIterator::new(inner_iter);
+    let inner_iter: Box<dyn LyIter> = Box::new(MapIterator::new(this.to_map()));
+    let iter = LyIterator::new(inner_iter);
     let iter = hooks.manage(iter);
 
     Ok(Value::from(iter))
@@ -286,7 +294,7 @@ impl MapIterator {
   }
 }
 
-impl SlIter for MapIterator {
+impl LyIter for MapIterator {
   fn name(&self) -> &str {
     "Map Iterator"
   }
@@ -322,7 +330,7 @@ impl Trace for MapIterator {
     self.map.trace()
   }
 
-  fn trace_debug(&self, stdio: &dyn StdIo) -> bool {
+  fn trace_debug(&self, stdio: &mut Stdio) -> bool {
     self.map.trace_debug(stdio)
   }
 }

--- a/laythe_lib/src/global/primitives/map.rs
+++ b/laythe_lib/src/global/primitives/map.rs
@@ -373,12 +373,11 @@ mod test {
   #[cfg(test)]
   mod str {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let hooks = Hooks::new(&mut context);
       let map_str = MapStr::new(hooks.manage_str("str".to_string()));
 
@@ -388,14 +387,13 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(
-        &gc,
-        &[
-          Value::from(gc.manage_str("nil".to_string(), &NO_GC)),
-          Value::from(gc.manage_str("nil".to_string(), &NO_GC)),
-        ],
-      );
+      let mut context = MockedContext::default();
+      let response = &[
+        Value::from(context.gc.manage_str("nil".to_string(), &NO_GC)),
+        Value::from(context.gc.manage_str("nil".to_string(), &NO_GC)),
+      ];
+      context.responses.extend_from_slice(response);
+
       let mut hooks = Hooks::new(&mut context);
       let map_str = MapStr::new(hooks.manage_str("str".to_string()));
 
@@ -416,7 +414,7 @@ mod test {
   #[cfg(test)]
   mod size {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -429,8 +427,7 @@ mod test {
     #[test]
     fn call() {
       let map_str = MapSize();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let values = &[];
@@ -450,7 +447,7 @@ mod test {
   #[cfg(test)]
   mod has {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -463,8 +460,7 @@ mod test {
     #[test]
     fn call() {
       let map_has = MapHas();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let mut map = LyHashMap::default();
@@ -488,7 +484,7 @@ mod test {
   #[cfg(test)]
   mod get {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -505,8 +501,7 @@ mod test {
     #[test]
     fn call() {
       let map_get = MapGet();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let mut map = LyHashMap::default();
@@ -530,7 +525,7 @@ mod test {
   #[cfg(test)]
   mod set {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -551,8 +546,7 @@ mod test {
     #[test]
     fn call() {
       let map_set = MapSet();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let map = LyHashMap::default();
@@ -589,7 +583,7 @@ mod test {
   #[cfg(test)]
   mod insert {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -610,8 +604,7 @@ mod test {
     #[test]
     fn call() {
       let map_insert = MapInsert();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let mut map = LyHashMap::default();
@@ -643,7 +636,7 @@ mod test {
   #[cfg(test)]
   mod remove {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -660,8 +653,7 @@ mod test {
     #[test]
     fn call() {
       let map_remove = MapRemove();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let mut map = LyHashMap::default();

--- a/laythe_lib/src/global/primitives/method.rs
+++ b/laythe_lib/src/global/primitives/method.rs
@@ -12,7 +12,7 @@ use laythe_core::{
 };
 use laythe_env::{
   managed::{Managed, Trace},
-  stdio::StdIo,
+  stdio::Stdio,
 };
 
 pub const METHOD_CLASS_NAME: &'static str = "Method";

--- a/laythe_lib/src/global/primitives/method.rs
+++ b/laythe_lib/src/global/primitives/method.rs
@@ -118,11 +118,12 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(
-        &gc,
-        &[Value::from(gc.manage_str("example".to_string(), &NO_GC))],
-      );
+      let mut context = MockedContext::default();
+      let responses = &[Value::from(
+        context.gc.manage_str("example".to_string(), &NO_GC),
+      )];
+      context.responses.extend_from_slice(responses);
+
       let mut hooks = Hooks::new(&mut context);
       let method_name = MethodName::new(hooks.manage_str("name".to_string()));
 
@@ -143,7 +144,7 @@ mod test {
 
   mod call {
     use super::*;
-    use crate::support::{fun_from_hooks, test_native_dependencies, MockedContext};
+    use crate::support::{fun_from_hooks, MockedContext};
     use laythe_core::object::{Class, Closure, Instance, Method};
 
     #[test]
@@ -161,8 +162,7 @@ mod test {
     #[test]
     fn call() {
       let method_call = MethodCall();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[Value::from(14.3)]);
+      let mut context = MockedContext::new(&[Value::from(14.3)]);
       let mut hooks = Hooks::new(&mut context);
 
       let fun = fun_from_hooks(&hooks.to_gc(), "example".to_string(), "module");

--- a/laythe_lib/src/global/primitives/mod.rs
+++ b/laythe_lib/src/global/primitives/mod.rs
@@ -29,7 +29,7 @@ use number::{declare_number_class, define_number_class};
 use object::{declare_object_class, define_object_class, OBJECT_CLASS_NAME};
 use string::{declare_string_class, define_string_class};
 
-pub(crate) fn create_primitive_classes(
+pub(crate) fn add_primitive_classes(
   hooks: &GcHooks,
   mut module: Managed<Module>,
   package: Managed<Package>,

--- a/laythe_lib/src/global/primitives/native_fun.rs
+++ b/laythe_lib/src/global/primitives/native_fun.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 pub const NATIVE_FUN_CLASS_NAME: &'static str = "Native Fun";
 

--- a/laythe_lib/src/global/primitives/native_fun.rs
+++ b/laythe_lib/src/global/primitives/native_fun.rs
@@ -79,10 +79,7 @@ impl NativeMethod for NativeFunCall {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::{
-    global::support::TestNative,
-    support::{test_native_dependencies, MockedContext},
-  };
+  use crate::{global::support::TestNative, support::MockedContext};
   use laythe_env::managed::Managed;
 
   mod name {
@@ -100,8 +97,7 @@ mod test {
     #[test]
     fn call() {
       let native_fun_name = NativeFunName();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let managed: Managed<Box<dyn NativeFun>> = hooks.manage(Box::new(TestNative()));
@@ -115,10 +111,7 @@ mod test {
 
   mod call {
     use super::*;
-    use crate::{
-      global::support::TestNative,
-      support::{test_native_dependencies, MockedContext},
-    };
+    use crate::{global::support::TestNative, support::MockedContext};
     use laythe_core::{native::NativeFun, value::VALUE_NIL};
 
     #[test]
@@ -136,8 +129,7 @@ mod test {
     #[test]
     fn call() {
       let native_fun_call = NativeFunCall();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[VALUE_NIL]);
+      let mut context = MockedContext::new(&[VALUE_NIL]);
       let mut hooks = Hooks::new(&mut context);
 
       let managed: Managed<Box<dyn NativeFun>> = hooks.manage(Box::new(TestNative()));

--- a/laythe_lib/src/global/primitives/native_method.rs
+++ b/laythe_lib/src/global/primitives/native_method.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 pub const NATIVE_METHOD_CLASS_NAME: &'static str = "Native Method";
 

--- a/laythe_lib/src/global/primitives/native_method.rs
+++ b/laythe_lib/src/global/primitives/native_method.rs
@@ -79,7 +79,7 @@ impl NativeMethod for NativeMethodCall {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::support::{test_native_dependencies, MockedContext};
+  use crate::support::MockedContext;
   use laythe_env::managed::Managed;
 
   mod name {
@@ -96,8 +96,7 @@ mod test {
     #[test]
     fn call() {
       let native_method_name = NativeMethodName();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let managed: Managed<Box<dyn NativeMethod>> = hooks.manage(Box::new(NativeMethodName()));
@@ -129,8 +128,7 @@ mod test {
     #[test]
     fn call() {
       let native_fun_call = NativeMethodCall();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[VALUE_NIL]);
+      let mut context = MockedContext::new(&[VALUE_NIL]);
       let mut hooks = Hooks::new(&mut context);
 
       let managed: Managed<Box<dyn NativeFun>> = hooks.manage(Box::new(TestNative()));

--- a/laythe_lib/src/global/primitives/nil.rs
+++ b/laythe_lib/src/global/primitives/nil.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 pub const NIL_CLASS_NAME: &'static str = "Nil";
 const NIL_STR: NativeMeta = NativeMeta::new("str", Arity::Fixed(0), &[]);

--- a/laythe_lib/src/global/primitives/nil.rs
+++ b/laythe_lib/src/global/primitives/nil.rs
@@ -59,7 +59,7 @@ mod test {
 
   mod str {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
     use laythe_core::value::VALUE_NIL;
 
     #[test]
@@ -73,8 +73,7 @@ mod test {
     #[test]
     fn call() {
       let nil_str = NilStr::new();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let result = nil_str.call(&mut hooks, VALUE_NIL, &[]);

--- a/laythe_lib/src/global/primitives/number.rs
+++ b/laythe_lib/src/global/primitives/number.rs
@@ -3,7 +3,7 @@ use crate::support::{
 };
 use laythe_core::{
   hooks::{GcHooks, Hooks},
-  iterator::{SlIter, SlIterator},
+  iterator::{LyIter, LyIterator},
   module::Module,
   native::{NativeMeta, NativeMethod},
   package::Package,
@@ -11,7 +11,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 use std::mem;
 
 pub const NUMBER_CLASS_NAME: &'static str = "Number";
@@ -72,8 +72,8 @@ impl NativeMethod for NumberTimes {
       return Err(hooks.make_error("times requires a positive number.".to_string()));
     }
 
-    let inner_iter: Box<dyn SlIter> = Box::new(TimesIterator::new(max));
-    let iter = SlIterator::new(inner_iter);
+    let inner_iter: Box<dyn LyIter> = Box::new(TimesIterator::new(max));
+    let iter = LyIterator::new(inner_iter);
     let iter = hooks.manage(iter);
 
     Ok(Value::from(iter))
@@ -95,7 +95,7 @@ impl TimesIterator {
   }
 }
 
-impl SlIter for TimesIterator {
+impl LyIter for TimesIterator {
   fn name(&self) -> &str {
     "Times Iterator"
   }

--- a/laythe_lib/src/global/primitives/number.rs
+++ b/laythe_lib/src/global/primitives/number.rs
@@ -128,7 +128,7 @@ mod test {
 
   mod str {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -141,8 +141,7 @@ mod test {
     #[test]
     fn call() {
       let number_str = NumberStr();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let result = number_str.call(&mut hooks, Value::from(10.0), &[]);
@@ -155,7 +154,7 @@ mod test {
 
   mod times {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -167,8 +166,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[Value::from(5.0)]);
+      let mut context = MockedContext::new(&[Value::from(5.0)]);
       let mut hooks = Hooks::new(&mut context);
       let number_times = NumberTimes();
 

--- a/laythe_lib/src/global/primitives/object.rs
+++ b/laythe_lib/src/global/primitives/object.rs
@@ -9,7 +9,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 pub const OBJECT_CLASS_NAME: &'static str = "Object";
 

--- a/laythe_lib/src/global/primitives/object.rs
+++ b/laythe_lib/src/global/primitives/object.rs
@@ -57,7 +57,7 @@ mod test {
 
   mod equals {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -74,8 +74,7 @@ mod test {
     #[test]
     fn call() {
       let bool_str = ObjectEquals();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let ten_1 = Value::from(10.0);

--- a/laythe_lib/src/global/primitives/string.rs
+++ b/laythe_lib/src/global/primitives/string.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 pub const STRING_CLASS_NAME: &str = "String";
 const STRING_STR: NativeMeta = NativeMeta::new("str", Arity::Fixed(0), &[]);

--- a/laythe_lib/src/global/primitives/string.rs
+++ b/laythe_lib/src/global/primitives/string.rs
@@ -80,7 +80,7 @@ mod test {
 
   mod str {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -93,8 +93,7 @@ mod test {
     #[test]
     fn call() {
       let string_str = StringStr();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let this = Value::from(hooks.manage_str("test".to_string()));
@@ -108,7 +107,7 @@ mod test {
 
   mod has {
     use super::*;
-    use crate::support::{test_native_dependencies, MockedContext};
+    use crate::support::MockedContext;
 
     #[test]
     fn new() {
@@ -121,8 +120,7 @@ mod test {
     #[test]
     fn call() {
       let string_str = StringHas();
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let this = Value::from(hooks.manage_str("some string".to_string()));

--- a/laythe_lib/src/global/support/mod.rs
+++ b/laythe_lib/src/global/support/mod.rs
@@ -5,7 +5,7 @@ use laythe_core::{
   value::{Value, VALUE_NIL},
   CallResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 const TEST_META: NativeMeta = NativeMeta::new("test", Arity::Fixed(0), &[]);
 

--- a/laythe_lib/src/global/time/clock.rs
+++ b/laythe_lib/src/global/time/clock.rs
@@ -7,7 +7,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 use std::time::SystemTime;
 
 const CLOCK_META: NativeMeta = NativeMeta::new("clock", Arity::Fixed(0), &[]);

--- a/laythe_lib/src/global/time/clock.rs
+++ b/laythe_lib/src/global/time/clock.rs
@@ -56,7 +56,7 @@ impl NativeFun for Clock {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::support::{test_native_dependencies, MockedContext};
+  use crate::support::MockedContext;
 
   #[test]
   fn new() {
@@ -69,8 +69,7 @@ mod test {
   #[test]
   fn call() {
     let clock = Clock::new();
-    let gc = test_native_dependencies();
-    let mut context = MockedContext::new(&gc, &[]);
+    let mut context = MockedContext::default();
     let mut hooks = Hooks::new(&mut context);
 
     let values = &[];

--- a/laythe_lib/src/global/time/mod.rs
+++ b/laythe_lib/src/global/time/mod.rs
@@ -4,7 +4,7 @@ use clock::declare_clock_funs;
 use laythe_core::{hooks::GcHooks, module::Module, package::Package, LyResult};
 use laythe_env::managed::Managed;
 
-pub(crate) fn create_clock_funs(
+pub(crate) fn add_clock_funs(
   hooks: &GcHooks,
   mut module: Managed<Module>,
   _package: Managed<Package>,

--- a/laythe_lib/src/io/mod.rs
+++ b/laythe_lib/src/io/mod.rs
@@ -1,0 +1,17 @@
+mod stdio;
+
+use laythe_core::{hooks::GcHooks, package::Package, LyResult};
+use laythe_env::managed::Managed;
+use stdio::stdio_module;
+
+const IO_PACKAGE_NAME: &str = "io";
+
+pub fn io_package(hooks: &GcHooks, std: Managed<Package>) -> LyResult<Managed<Package>> {
+  let mut package = hooks.manage(Package::new(hooks.manage_str(IO_PACKAGE_NAME.to_string())));
+
+  let stdio = stdio_module(hooks, std)?;
+
+  package.add_module(hooks, stdio)?;
+
+  Ok(package)
+}

--- a/laythe_lib/src/io/stdio/mod.rs
+++ b/laythe_lib/src/io/stdio/mod.rs
@@ -1,0 +1,25 @@
+mod stdin;
+mod stdout;
+
+use laythe_core::{hooks::GcHooks, module::Module, package::Package, LyResult};
+use laythe_env::managed::Managed;
+use std::path::PathBuf;
+use stdin::{declare_stdin, define_stdin};
+use stdout::{declare_stdout, define_stdout};
+
+const STDIO_PATH: &str = "std/io/stdio.ly";
+
+pub fn stdio_module(hooks: &GcHooks, std: Managed<Package>) -> LyResult<Managed<Module>> {
+  let mut module = hooks.manage(Module::from_path(
+    &hooks,
+    hooks.manage(PathBuf::from(STDIO_PATH)),
+  )?);
+
+  declare_stdout(hooks, &mut module, &*std)?;
+  declare_stdin(hooks, &mut module, &*std)?;
+
+  define_stdout(hooks, &mut module, &*std)?;
+  define_stdin(hooks, &mut module, &*std)?;
+
+  Ok(module)
+}

--- a/laythe_lib/src/io/stdio/stdin.rs
+++ b/laythe_lib/src/io/stdio/stdin.rs
@@ -1,0 +1,168 @@
+use crate::support::{
+  default_class_inheritance, export_and_insert, load_instance_from_module, to_dyn_method,
+};
+use laythe_core::{
+  hooks::{GcHooks, Hooks},
+  module::Module,
+  native::{NativeMeta, NativeMethod},
+  object::Instance,
+  package::Package,
+  signature::Arity,
+  value::Value,
+  CallResult, LyResult,
+};
+use laythe_env::{managed::Trace, stdio::Stdio};
+
+const STDIN_CLASS_NAME: &str = "Stdin";
+const STDIN_INSTANCE_NAME: &str = "stdin";
+
+const STDIN_READ: NativeMeta = NativeMeta::new("read", Arity::Fixed(0), &[]);
+const STDIN_READ_LINE: NativeMeta = NativeMeta::new("readLine", Arity::Fixed(0), &[]);
+
+pub fn declare_stdin(hooks: &GcHooks, module: &mut Module, std: &Package) -> LyResult<()> {
+  let class = default_class_inheritance(hooks, std, STDIN_CLASS_NAME)?;
+  let instance = hooks.manage(Instance::new(class));
+
+  export_and_insert(
+    hooks,
+    module,
+    hooks.manage_str(STDIN_INSTANCE_NAME.to_string()),
+    Value::from(instance),
+  )
+}
+
+pub fn define_stdin(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
+  let instance = load_instance_from_module(hooks, module, STDIN_INSTANCE_NAME)?;
+  let mut class = instance.class;
+
+  class.add_method(
+    hooks,
+    hooks.manage_str(String::from(STDIN_READ.name)),
+    Value::from(to_dyn_method(hooks, StdinRead())),
+  );
+
+  class.add_method(
+    hooks,
+    hooks.manage_str(String::from(STDIN_READ_LINE.name)),
+    Value::from(to_dyn_method(hooks, StdinReadLine())),
+  );
+
+  Ok(())
+}
+
+#[derive(Clone, Debug, Trace)]
+struct StdinRead();
+
+impl NativeMethod for StdinRead {
+  fn meta(&self) -> &NativeMeta {
+    &STDIN_READ
+  }
+
+  fn call(&self, hooks: &mut Hooks, _this: Value, _args: &[Value]) -> CallResult {
+    let io = hooks.to_io();
+    let mut stdio = io.stdio();
+    let stdin = stdio.stdin();
+
+    let mut buf = String::new();
+    match stdin.read_to_string(&mut buf) {
+      Ok(_) => Ok(Value::from(hooks.manage_str(buf))),
+      Err(err) => Err(hooks.make_error(err.to_string())),
+    }
+  }
+}
+
+#[derive(Clone, Debug, Trace)]
+struct StdinReadLine();
+
+impl NativeMethod for StdinReadLine {
+  fn meta(&self) -> &NativeMeta {
+    &STDIN_READ_LINE
+  }
+
+  fn call(&self, hooks: &mut Hooks, _this: Value, _args: &[Value]) -> CallResult {
+    let io = hooks.to_io();
+    let stdio = io.stdio();
+
+    let mut buf = String::new();
+
+    match stdio.read_line(&mut buf) {
+      Ok(_) => {
+        if buf.ends_with('\n') {
+          buf.pop();
+        }
+        Ok(Value::from(hooks.manage_str(buf)))
+      }
+      Err(err) => Err(hooks.make_error(err.to_string())),
+    }
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  mod read {
+    use super::*;
+    use crate::support::MockedContext;
+    use laythe_core::value::VALUE_NIL;
+    use laythe_env::stdio::support::StdioTestContainer;
+
+    #[test]
+    fn new() {
+      let stdin_read = StdinRead();
+
+      assert_eq!(stdin_read.meta().name, "read");
+      assert_eq!(stdin_read.meta().signature.arity, Arity::Fixed(0));
+    }
+
+    #[test]
+    fn call() {
+      let stdin_read = StdinRead();
+      let mut stdio_container = StdioTestContainer::with_stdin(&"dude".as_bytes());
+
+      let mut context = MockedContext::new_with_io(&mut stdio_container);
+      let mut hooks = Hooks::new(&mut context);
+
+      let result = stdin_read.call(&mut hooks, VALUE_NIL, &[]);
+
+      assert!(result.is_ok());
+      let unwrapped = result.unwrap();
+
+      assert!(unwrapped.is_str());
+      assert_eq!(&**unwrapped.to_str(), "dude");
+    }
+  }
+
+  mod readlines {
+    use super::*;
+    use crate::support::MockedContext;
+    use laythe_core::value::VALUE_NIL;
+    use laythe_env::stdio::support::StdioTestContainer;
+
+    #[test]
+    fn new() {
+      let stdin_readline = StdinReadLine();
+
+      assert_eq!(stdin_readline.meta().name, "readLine");
+      assert_eq!(stdin_readline.meta().signature.arity, Arity::Fixed(0));
+    }
+
+    #[test]
+    fn call() {
+      let stdin_readline = StdinReadLine();
+      let mut stdio_container =
+        StdioTestContainer::with_lines(vec!["dude".to_string(), "sup".to_string()]);
+
+      let mut context = MockedContext::new_with_io(&mut stdio_container);
+      let mut hooks = Hooks::new(&mut context);
+
+      let result = stdin_readline.call(&mut hooks, VALUE_NIL, &[]);
+
+      assert!(result.is_ok());
+      let unwrapped = result.unwrap();
+
+      assert!(unwrapped.is_str());
+      assert_eq!(&**unwrapped.to_str(), "dude");
+    }
+  }
+}

--- a/laythe_lib/src/io/stdio/stdout.rs
+++ b/laythe_lib/src/io/stdio/stdout.rs
@@ -1,0 +1,212 @@
+use crate::support::{
+  default_class_inheritance, export_and_insert, load_instance_from_module, to_dyn_method,
+};
+use laythe_core::{
+  hooks::{GcHooks, Hooks},
+  module::Module,
+  native::{NativeMeta, NativeMethod},
+  object::Instance,
+  package::Package,
+  signature::{Arity, Parameter, ParameterKind},
+  value::{Value, VALUE_NIL},
+  CallResult, LyResult,
+};
+use laythe_env::{managed::Trace, stdio::Stdio};
+
+const STDOUT_CLASS_NAME: &str = "Stdout";
+const STDOUT_INSTANCE_NAME: &str = "stdout";
+
+const STDOUT_WRITE: NativeMeta = NativeMeta::new(
+  "write",
+  Arity::Fixed(1),
+  &[Parameter::new("string", ParameterKind::String)],
+);
+
+const STDOUT_WRITELN: NativeMeta = NativeMeta::new(
+  "writeln",
+  Arity::Fixed(1),
+  &[Parameter::new("string", ParameterKind::String)],
+);
+
+const STDOUT_FLUSH: NativeMeta = NativeMeta::new(
+  "flush",
+  Arity::Fixed(0),
+  &[],
+);
+
+pub fn declare_stdout(hooks: &GcHooks, module: &mut Module, std: &Package) -> LyResult<()> {
+  let class = default_class_inheritance(hooks, std, STDOUT_CLASS_NAME)?;
+  let instance = hooks.manage(Instance::new(class));
+
+  export_and_insert(
+    hooks,
+    module,
+    hooks.manage_str(STDOUT_INSTANCE_NAME.to_string()),
+    Value::from(instance),
+  )
+}
+
+pub fn define_stdout(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
+  let instance = load_instance_from_module(hooks, module, STDOUT_INSTANCE_NAME)?;
+  let mut class = instance.class;
+
+  class.add_method(
+    hooks,
+    hooks.manage_str(String::from(STDOUT_WRITE.name)),
+    Value::from(to_dyn_method(hooks, StdoutWrite())),
+  );
+
+  class.add_method(
+    hooks,
+    hooks.manage_str(String::from(STDOUT_WRITELN.name)),
+    Value::from(to_dyn_method(hooks, StdoutWriteln())),
+  );
+
+  class.add_method(
+    hooks,
+    hooks.manage_str(String::from(STDOUT_FLUSH.name)),
+    Value::from(to_dyn_method(hooks, StdoutFlush())),
+  );
+
+  Ok(())
+}
+
+#[derive(Clone, Debug, Trace)]
+struct StdoutWrite();
+
+impl NativeMethod for StdoutWrite {
+  fn meta(&self) -> &NativeMeta {
+    &STDOUT_WRITE
+  }
+
+  fn call(&self, hooks: &mut Hooks, _this: Value, args: &[Value]) -> CallResult {
+    let io = hooks.to_io();
+    let mut stdio = io.stdio();
+    let stdout = stdio.stdout();
+
+    match stdout.write(args[0].to_str().as_bytes()) {
+      Ok(_) => Ok(VALUE_NIL),
+      Err(err) => Err(hooks.make_error(err.to_string())),
+    }
+  }
+}
+
+#[derive(Clone, Debug, Trace)]
+struct StdoutWriteln();
+
+impl NativeMethod for StdoutWriteln {
+  fn meta(&self) -> &NativeMeta {
+    &STDOUT_WRITELN
+  }
+
+  fn call(&self, hooks: &mut Hooks, _this: Value, args: &[Value]) -> CallResult {
+    let io = hooks.to_io();
+    let mut stdio = io.stdio();
+    let stdout = stdio.stdout();
+
+    match writeln!(stdout, "{}", args[0].to_str()) {
+      Ok(_) => Ok(VALUE_NIL),
+      Err(err) => Err(hooks.make_error(err.to_string())),
+    }
+  }
+}
+
+#[derive(Clone, Debug, Trace)]
+struct StdoutFlush();
+
+impl NativeMethod for StdoutFlush {
+  fn meta(&self) -> &NativeMeta {
+    &STDOUT_FLUSH
+  }
+  fn call(&self, hooks: &mut Hooks, _this: Value, _args: &[Value]) -> CallResult {
+    let io = hooks.to_io();
+    let mut stdio = io.stdio();
+    let stdout = stdio.stdout();
+
+    match stdout.flush() {
+      Ok(_) => Ok(VALUE_NIL),
+      Err(err) => Err(hooks.make_error(err.to_string())),
+    }
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  mod write {
+    use super::*;
+    use crate::support::MockedContext;
+    use laythe_env::stdio::support::StdioTestContainer;
+    use std::str;
+
+    #[test]
+    fn new() {
+      let stdout_write = StdoutWrite();
+
+      assert_eq!(stdout_write.meta().name, "write");
+      assert_eq!(stdout_write.meta().signature.arity, Arity::Fixed(1));
+      assert_eq!(
+        stdout_write.meta().signature.parameters[0].kind,
+        ParameterKind::String
+      );
+    }
+
+    #[test]
+    fn call() {
+      let stdout_write = StdoutWrite();
+      let mut stdio_container = StdioTestContainer::default();
+
+      let mut context = MockedContext::new_with_io(&mut stdio_container);
+      let mut hooks = Hooks::new(&mut context);
+
+      let string = Value::from(hooks.manage_str("some string".to_string()));
+      let result = stdout_write.call(&mut hooks, VALUE_NIL, &[string]);
+
+      assert!(result.is_ok());
+      assert!(result.unwrap().is_nil());
+
+      let stdout = str::from_utf8(&*stdio_container.stdout);
+      assert!(stdout.is_ok());
+      assert_eq!(stdout.unwrap(), "some string");
+    }
+  }
+
+  mod writeln {
+    use super::*;
+    use crate::support::MockedContext;
+    use laythe_env::stdio::support::StdioTestContainer;
+    use std::str;
+
+    #[test]
+    fn new() {
+      let stdout_writeln = StdoutWriteln();
+
+      assert_eq!(stdout_writeln.meta().name, "writeln");
+      assert_eq!(stdout_writeln.meta().signature.arity, Arity::Fixed(1));
+      assert_eq!(
+        stdout_writeln.meta().signature.parameters[0].kind,
+        ParameterKind::String
+      );
+    }
+
+    #[test]
+    fn call() {
+      let stdout_write = StdoutWriteln();
+      let mut stdio_container = StdioTestContainer::default();
+
+      let mut context = MockedContext::new_with_io(&mut stdio_container);
+      let mut hooks = Hooks::new(&mut context);
+
+      let string = Value::from(hooks.manage_str("some string".to_string()));
+      let result = stdout_write.call(&mut hooks, VALUE_NIL, &[string]);
+
+      assert!(result.is_ok());
+      assert!(result.unwrap().is_nil());
+
+      let stdout = str::from_utf8(&*stdio_container.stdout);
+      assert!(stdout.is_ok());
+      assert_eq!(stdout.unwrap(), "some string\n");
+    }
+  }
+}

--- a/laythe_lib/src/lib.rs
+++ b/laythe_lib/src/lib.rs
@@ -31,7 +31,7 @@ pub fn create_std_lib(hooks: &GcHooks) -> LyResult<Managed<Package>> {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::support::{test_native_dependencies, MockedContext};
+  use crate::support::MockedContext;
   use laythe_core::{package::PackageEntity, signature::Arity, value::ValueKind};
 
   fn check_inner(hooks: &GcHooks, package: Managed<Package>) {
@@ -68,8 +68,7 @@ mod test {
 
   #[test]
   fn new() {
-    let gc = test_native_dependencies();
-    let mut context = MockedContext::new(&gc, &[]);
+    let mut context = MockedContext::default();
     let hooks = GcHooks::new(&mut context);
 
     let std_lib = create_std_lib(&hooks);

--- a/laythe_lib/src/lib.rs
+++ b/laythe_lib/src/lib.rs
@@ -1,22 +1,29 @@
 #![deny(clippy::all)]
 pub mod global;
+mod io;
 mod math;
 mod support;
 
-use global::add_global;
+use global::add_global_module;
+use io::io_package;
 use laythe_core::{hooks::GcHooks, package::Package, LyResult};
 use laythe_env::managed::Managed;
-use math::add_math;
+use math::math_module;
 
 pub const STD: &str = "std";
 pub const GLOBAL: &str = "global";
 pub const GLOBAL_PATH: &str = "std/global.ly";
 
 pub fn create_std_lib(hooks: &GcHooks) -> LyResult<Managed<Package>> {
-  let std = hooks.manage(Package::new(hooks.manage_str(STD.to_string())));
+  let mut std = hooks.manage(Package::new(hooks.manage_str(STD.to_string())));
 
-  add_global(hooks, std)?;
-  add_math(hooks, std)?;
+  add_global_module(hooks, std)?;
+
+  let math = math_module(hooks, std)?;
+  let io = io_package(hooks, std)?;
+
+  std.add_module(hooks, math)?;
+  std.add_package(hooks, io)?;
 
   Ok(std)
 }

--- a/laythe_lib/src/math/mod.rs
+++ b/laythe_lib/src/math/mod.rs
@@ -7,19 +7,14 @@ use utils::{declare_math_module, define_math_module};
 
 const MATH_PATH: &str = "std/math.ly";
 
-pub fn add_math(hooks: &GcHooks, mut std: Managed<Package>) -> LyResult<()> {
-  let module = match Module::from_path(&hooks, hooks.manage(PathBuf::from(MATH_PATH))) {
-    Some(module) => module,
-    None => {
-      return Err(hooks.make_error("Could not create math module, path malformed.".to_string()));
-    }
-  };
-
-  let mut module = hooks.manage(module);
-  std.add_module(hooks, module)?;
+pub fn math_module(hooks: &GcHooks, mut _std: Managed<Package>) -> LyResult<Managed<Module>> {
+  let mut module = hooks.manage(Module::from_path(
+    &hooks,
+    hooks.manage(PathBuf::from(MATH_PATH)),
+  )?);
 
   declare_math_module(hooks, &mut module)?;
   define_math_module(hooks, &mut module)?;
 
-  Ok(())
+  Ok(module)
 }

--- a/laythe_lib/src/math/utils.rs
+++ b/laythe_lib/src/math/utils.rs
@@ -7,7 +7,7 @@ use laythe_core::{
   value::Value,
   CallResult, LyResult,
 };
-use laythe_env::{managed::Trace, stdio::StdIo};
+use laythe_env::{managed::Trace, stdio::Stdio};
 
 const PI: &str = "pi";
 const E: &str = "e";
@@ -37,7 +37,7 @@ const REM_META: NativeMeta = NativeMeta::new(
   Arity::Fixed(2),
   &[
     Parameter::new("val", ParameterKind::Number),
-    Parameter::new("divisor", ParameterKind::Number)
+    Parameter::new("divisor", ParameterKind::Number),
   ],
 );
 

--- a/laythe_lib/src/math/utils.rs
+++ b/laythe_lib/src/math/utils.rs
@@ -164,7 +164,7 @@ impl NativeFun for Rem {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::support::{test_native_dependencies, MockedContext};
+  use crate::support::MockedContext;
 
   #[cfg(test)]
   mod sin {
@@ -184,8 +184,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let sin = Sin();
@@ -215,8 +214,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let cos = Cos();
@@ -246,8 +244,7 @@ mod test {
 
     #[test]
     fn call() {
-      let gc = test_native_dependencies();
-      let mut context = MockedContext::new(&gc, &[]);
+      let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let ln = Ln();

--- a/laythe_macro/src/lib.rs
+++ b/laythe_macro/src/lib.rs
@@ -17,7 +17,7 @@ pub fn derive_trace(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         true
       }
 
-      fn trace_debug(&self, _: &dyn StdIo) -> bool {
+      fn trace_debug(&self, _: &mut Stdio) -> bool {
         true
       }
     }

--- a/laythe_native/Cargo.toml
+++ b/laythe_native/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "laythe_native"
+version = "0.1.0"
+authors = ["John Chabot <johnchabot2013@gmail.com>"]
+edition = "2018"
+
+[lib]
+name = "laythe_native"
+path = "src/lib.rs"
+
+[dependencies]
+laythe_env = { path = "../laythe_env" }

--- a/laythe_native/src/env.rs
+++ b/laythe_native/src/env.rs
@@ -1,0 +1,21 @@
+use laythe_env::env::EnvImpl;
+use std::{env, io, path::PathBuf};
+
+#[derive(Clone)]
+pub struct NativeEnvio();
+
+impl Default for NativeEnvio {
+  fn default() -> Self {
+    Self()
+  }
+}
+
+impl EnvImpl for NativeEnvio {
+  fn current_dir(&self) -> io::Result<PathBuf> {
+    env::current_dir()
+  }
+
+  fn args(&self) -> Vec<String> {
+    env::args().collect()
+  }
+}

--- a/laythe_native/src/fs.rs
+++ b/laythe_native/src/fs.rs
@@ -1,0 +1,39 @@
+use laythe_env::{
+  fs::{FsImpl, SlDirEntry},
+  LyIoError,
+};
+use std::{
+  fs::{canonicalize, read_to_string},
+  io,
+  path::{Path, PathBuf},
+};
+
+#[derive(Clone)]
+pub struct NativeFsio();
+
+impl Default for NativeFsio {
+  fn default() -> Self {
+    Self()
+  }
+}
+
+impl FsImpl for NativeFsio {
+  fn read_to_string(&self, path: &Path) -> io::Result<String> {
+    read_to_string(path)
+  }
+
+  fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+    canonicalize(path)
+  }
+
+  fn read_directory(&self, _path: &Path) -> io::Result<SlDirEntry> {
+    todo!()
+  }
+
+  fn relative_path(&self, base: &PathBuf, import: &Path) -> Result<PathBuf, LyIoError> {
+    import
+      .strip_prefix(base)
+      .map(|prefix| prefix.to_path_buf())
+      .map_err(|err| LyIoError::new(err.to_string()))
+  }
+}

--- a/laythe_native/src/io.rs
+++ b/laythe_native/src/io.rs
@@ -1,0 +1,23 @@
+use crate::{env::NativeEnvio, fs::NativeFsio, stdio::NativeStdio};
+use laythe_env::{env::Env, fs::Fs, io::IoImpl, stdio::Stdio};
+
+#[derive(Debug, Default)]
+pub struct NativeIo();
+
+impl IoImpl for NativeIo {
+  fn stdio(&self) -> Stdio {
+    Stdio::new(Box::new(NativeStdio::default()))
+  }
+
+  fn fsio(&self) -> Fs {
+    Fs::new(Box::new(NativeFsio()))
+  }
+
+  fn envio(&self) -> Env {
+    Env::new(Box::new(NativeEnvio()))
+  }
+
+  fn clone_box(&self) -> Box<dyn IoImpl> {
+    Box::new(NativeIo())
+  }
+}

--- a/laythe_native/src/lib.rs
+++ b/laythe_native/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod env;
+pub mod fs;
+pub mod io;
+pub mod stdio;

--- a/laythe_native/src/stdio.rs
+++ b/laythe_native/src/stdio.rs
@@ -1,0 +1,38 @@
+use io::{Stderr, Stdin, Stdout};
+use laythe_env::stdio::StdioImpl;
+use std::io::{self, stderr, stdin, stdout};
+
+#[derive(Debug)]
+pub struct NativeStdio {
+  stdout: Stdout,
+  stderr: Stderr,
+  stdin: Stdin,
+}
+
+impl Default for NativeStdio {
+  fn default() -> Self {
+    Self {
+      stdout: stdout(),
+      stderr: stderr(),
+      stdin: stdin(),
+    }
+  }
+}
+
+impl StdioImpl for NativeStdio {
+  fn stdout(&mut self) -> &mut dyn std::io::Write {
+    &mut self.stdout
+  }
+
+  fn stderr(&mut self) -> &mut dyn std::io::Write {
+    &mut self.stderr
+  }
+
+  fn stdin(&mut self) -> &mut dyn std::io::Read {
+    &mut self.stdin
+  }
+
+  fn read_line(&self, buffer: &mut String) -> io::Result<usize> {
+    stdin().read_line(buffer)
+  }
+}

--- a/laythe_vm/Cargo.toml
+++ b/laythe_vm/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 laythe_core = { path = "../laythe_core", features = ["nan_boxing"]  }
 laythe_lib = { path = "../laythe_lib" }
 laythe_env = { path = "../laythe_env" }
+laythe_native = { path = "../laythe_native" }
 fnv = "1.0.3"
 
 [dev-dependencies]

--- a/laythe_vm/benches/compiler_benches.rs
+++ b/laythe_vm/benches/compiler_benches.rs
@@ -1,10 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use laythe_core::hooks::{GcHooks, NoContext};
 use laythe_core::module::Module;
-use laythe_env::{
-  io::{Io, NativeIo},
-  memory::Gc,
-};
+use laythe_env::{memory::Gc, stdio::Stdio};
 use laythe_vm::compiler::{Compiler, Parser};
 use std::fs::File;
 use std::io::prelude::*;
@@ -36,9 +33,8 @@ fn compile_source(source: &str) {
   let hooks = GcHooks::new(&mut context);
   let module =
     hooks.manage(Module::from_path(&hooks, hooks.manage(PathBuf::from("./Benchmark.ly"))).unwrap());
-  let io = NativeIo::default();
-  let mut parser = Parser::new(io.stdio(), source);
-  let compiler = Compiler::new(module, io, &mut parser, &hooks);
+  let mut parser = Parser::new(Stdio::default(), source);
+  let compiler = Compiler::new(module, &mut parser, &hooks);
   compiler.compile().unwrap();
 }
 

--- a/laythe_vm/fixture/std_lib/builtin/iter/zip.ly
+++ b/laythe_vm/fixture/std_lib/builtin/iter/zip.ly
@@ -1,0 +1,19 @@
+let l1 = [1, 2, 3, 4];
+let l2 = ["cat", "dog", "parrot"];
+
+let zipped = l1.iter().zip(l2.iter());
+
+assertEq(zipped.current, nil);
+assertEq(zipped.next(), true);
+
+assertEq(zipped.current[0], 1);
+assertEq(zipped.current[1], "cat");
+assertEq(zipped.next(), true);
+
+assertEq(zipped.current[0], 2);
+assertEq(zipped.current[1], "dog");
+assertEq(zipped.next(), true);
+
+assertEq(zipped.current[0], 3);
+assertEq(zipped.current[1], "parrot");
+assertEq(zipped.next(), false);

--- a/laythe_vm/fixture/std_lib/builtin/list/index.ly
+++ b/laythe_vm/fixture/std_lib/builtin/list/index.ly
@@ -1,0 +1,5 @@
+let l = [1, 2, 3, 4, 5];
+
+assertEq(l.index(3), 2);
+assertEq(l.index(5), 4);
+assertEq(l.index(6), nil);

--- a/laythe_vm/fixture/std_lib/builtin/map/set.ly
+++ b/laythe_vm/fixture/std_lib/builtin/map/set.ly
@@ -1,0 +1,14 @@
+fn example() {}
+
+let map = {
+  1: "dude",
+  "cat": true,
+  "dog": true,
+  nil: true,
+  "rabbit": true,
+  example: example,
+};
+
+assertEq(map.set(1, "bro"), "dude");
+assertEq(map.set(false, 25), nil);
+assertEq(map.set(example, || true), example);

--- a/laythe_vm/fixture/std_lib/io/stdio/stdin/read.ly
+++ b/laythe_vm/fixture/std_lib/io/stdio/stdin/read.ly
@@ -1,0 +1,4 @@
+import Stdio from 'std/io/stdio';
+let stdin = Stdio.stdin;
+
+assertEq(stdin.read(), 'expected');

--- a/laythe_vm/fixture/std_lib/io/stdio/stdin/readline.ly
+++ b/laythe_vm/fixture/std_lib/io/stdio/stdin/readline.ly
@@ -1,0 +1,5 @@
+import Stdio from 'std/io/stdio';
+let stdin = Stdio.stdin;
+
+assertEq(stdin.readLine(), 'expected 1');
+assertEq(stdin.readLine(), 'expected 2');

--- a/laythe_vm/fixture/std_lib/io/stdio/stdout/write.ly
+++ b/laythe_vm/fixture/std_lib/io/stdio/stdout/write.ly
@@ -1,0 +1,6 @@
+import Stdio from 'std/io/stdio';
+let stdout = Stdio.stdout;
+
+stdout.write('expected 1');
+stdout.write(' expected 2');
+stdout.flush();

--- a/laythe_vm/fixture/std_lib/io/stdio/stdout/writeln.ly
+++ b/laythe_vm/fixture/std_lib/io/stdio/stdout/writeln.ly
@@ -1,0 +1,5 @@
+import Stdio from 'std/io/stdio';
+let stdout = Stdio.stdout;
+
+stdout.writeln('expected 1');
+stdout.writeln('expected 2');

--- a/laythe_vm/src/debug.rs
+++ b/laythe_vm/src/debug.rs
@@ -1,19 +1,21 @@
 use crate::call_frame::CallFrame;
 use laythe_core::chunk::{decode_u16, AlignedByteCode, Chunk, UpvalueIndex};
-use laythe_env::stdio::StdIo;
-use std::mem;
+use laythe_env::stdio::Stdio;
+use std::{io, io::Write, mem};
 
 /// Indicate where and how an exception was caught
-pub fn exception_catch<S: StdIo>(stdio: &S, frame: &CallFrame, idx: usize) {
-  stdio.println(&format!(
+pub fn exception_catch(stdout: &mut dyn Write, frame: &CallFrame, idx: usize) -> io::Result<()> {
+  writeln!(
+    stdout,
     "Exception popped {:0>4} frames caught by: {}",
     idx, frame.closure.fun.name
-  ));
+  )
 }
 
 /// Write a chunk to console
-pub fn disassemble_chunk<S: StdIo>(stdio: &S, code_chunk: &Chunk, name: &str) {
-  stdio.println(&format!("== {0} ==", name));
+pub fn disassemble_chunk(stdio: &mut Stdio, code_chunk: &Chunk, name: &str) -> io::Result<()> {
+  let stdout = stdio.stdout();
+  writeln!(stdout, "== {0} ==", name)?;
 
   let mut offset: usize = 0;
   let mut last_offset: usize = 0;
@@ -21,166 +23,192 @@ pub fn disassemble_chunk<S: StdIo>(stdio: &S, code_chunk: &Chunk, name: &str) {
   while offset < code_chunk.instructions.len() {
     let temp = disassemble_instruction(stdio, code_chunk, offset, last_offset);
     last_offset = offset;
-    offset = temp;
+    offset = temp?;
   }
+
+  Ok(())
 }
 
 /// Write an instruction to console
-pub fn disassemble_instruction<S: StdIo>(
-  stdio: &S,
+pub fn disassemble_instruction(
+  stdio: &mut Stdio,
   chunk: &Chunk,
   ip: usize,
   last_offset: usize,
-) -> usize {
-  stdio.print(&format!("{:0>4} ", ip));
+) -> io::Result<usize> {
+  let stdout = stdio.stdout();
+  write!(stdout, "{:0>4} ", ip)?;
 
   if ip > 0 && chunk.get_line(ip) == chunk.get_line(last_offset) {
-    stdio.print("   | ")
+    write!(stdout, "   | ")?;
   } else {
-    stdio.print(&format!("{:>4} ", chunk.get_line(ip)))
+    write!(stdout, "{:>4} ", chunk.get_line(ip))?;
   }
 
   let (instruction, offset) = AlignedByteCode::decode(&chunk.instructions, ip as usize);
   match instruction {
-    AlignedByteCode::Return => simple_instruction(stdio, "Return", offset),
-    AlignedByteCode::Print => simple_instruction(stdio, "Print", offset),
-    AlignedByteCode::Negate => simple_instruction(stdio, "Negate", offset),
-    AlignedByteCode::Add => simple_instruction(stdio, "Add", offset),
-    AlignedByteCode::Subtract => simple_instruction(stdio, "Subtract", offset),
-    AlignedByteCode::Multiply => simple_instruction(stdio, "Multiply", offset),
-    AlignedByteCode::Divide => simple_instruction(stdio, "Divide", offset),
-    AlignedByteCode::Not => simple_instruction(stdio, "Not", offset),
-    AlignedByteCode::Nil => simple_instruction(stdio, "Nil", offset),
-    AlignedByteCode::True => simple_instruction(stdio, "True", offset),
-    AlignedByteCode::False => simple_instruction(stdio, "False", offset),
-    AlignedByteCode::List => simple_instruction(stdio, "List", offset),
-    AlignedByteCode::ListInit(arg_count) => short_instruction(stdio, "ListInit", arg_count, offset),
-    AlignedByteCode::Map => simple_instruction(stdio, "Map", offset),
-    AlignedByteCode::MapInit(arg_count) => short_instruction(stdio, "MapInit", arg_count, offset),
+    AlignedByteCode::Return => simple_instruction(stdio.stdout(), "Return", offset),
+    AlignedByteCode::Print => simple_instruction(stdio.stdout(), "Print", offset),
+    AlignedByteCode::Negate => simple_instruction(stdio.stdout(), "Negate", offset),
+    AlignedByteCode::Add => simple_instruction(stdio.stdout(), "Add", offset),
+    AlignedByteCode::Subtract => simple_instruction(stdio.stdout(), "Subtract", offset),
+    AlignedByteCode::Multiply => simple_instruction(stdio.stdout(), "Multiply", offset),
+    AlignedByteCode::Divide => simple_instruction(stdio.stdout(), "Divide", offset),
+    AlignedByteCode::Not => simple_instruction(stdio.stdout(), "Not", offset),
+    AlignedByteCode::Nil => simple_instruction(stdio.stdout(), "Nil", offset),
+    AlignedByteCode::True => simple_instruction(stdio.stdout(), "True", offset),
+    AlignedByteCode::False => simple_instruction(stdio.stdout(), "False", offset),
+    AlignedByteCode::List => simple_instruction(stdio.stdout(), "List", offset),
+    AlignedByteCode::ListInit(arg_count) => {
+      short_instruction(stdio.stdout(), "ListInit", arg_count, offset)
+    }
+    AlignedByteCode::Map => simple_instruction(stdio.stdout(), "Map", offset),
+    AlignedByteCode::MapInit(arg_count) => {
+      short_instruction(stdio.stdout(), "MapInit", arg_count, offset)
+    }
     AlignedByteCode::IterNext(constant) => {
-      invoke_instruction(stdio, "IterNext", chunk, constant, 0, offset)
+      invoke_instruction(stdio.stdout(), "IterNext", chunk, constant, 0, offset)
     }
     AlignedByteCode::IterCurrent(constant) => {
-      constant_instruction(stdio, "IterCurrent", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "IterCurrent", chunk, constant, offset)
     }
-    AlignedByteCode::GetIndex => simple_instruction(stdio, "GetIndex", offset),
-    AlignedByteCode::SetIndex => simple_instruction(stdio, "SetIndex", offset),
-    AlignedByteCode::Drop => simple_instruction(stdio, "Drop", offset),
-    AlignedByteCode::Call(arg_count) => byte_instruction(stdio, "Call", arg_count, offset),
-    AlignedByteCode::Import(path) => constant_instruction(stdio, "Import", chunk, path, offset),
+    AlignedByteCode::GetIndex => simple_instruction(stdio.stdout(), "GetIndex", offset),
+    AlignedByteCode::SetIndex => simple_instruction(stdio.stdout(), "SetIndex", offset),
+    AlignedByteCode::Drop => simple_instruction(stdio.stdout(), "Drop", offset),
+    AlignedByteCode::Call(arg_count) => byte_instruction(stdio.stdout(), "Call", arg_count, offset),
+    AlignedByteCode::Import(path) => {
+      constant_instruction(stdio.stdout(), "Import", chunk, path, offset)
+    }
     AlignedByteCode::Export(constant) => {
-      constant_instruction(stdio, "Export", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "Export", chunk, constant, offset)
     }
     AlignedByteCode::Invoke((constant, arg_count)) => {
-      invoke_instruction(stdio, "Invoke", chunk, constant, arg_count, offset)
+      invoke_instruction(stdio.stdout(), "Invoke", chunk, constant, arg_count, offset)
     }
-    AlignedByteCode::SuperInvoke((constant, arg_count)) => {
-      invoke_instruction(stdio, "SuperInvoke", chunk, constant, arg_count, offset)
-    }
+    AlignedByteCode::SuperInvoke((constant, arg_count)) => invoke_instruction(
+      stdio.stdout(),
+      "SuperInvoke",
+      chunk,
+      constant,
+      arg_count,
+      offset,
+    ),
     AlignedByteCode::Class(constant) => {
-      constant_instruction(stdio, "Class", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "Class", chunk, constant, offset)
     }
     AlignedByteCode::GetSuper(constant) => {
-      constant_instruction(stdio, "GetSuper", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "GetSuper", chunk, constant, offset)
     }
-    AlignedByteCode::Inherit => simple_instruction(stdio, "Inherit", offset),
+    AlignedByteCode::Inherit => simple_instruction(stdio.stdout(), "Inherit", offset),
     AlignedByteCode::Closure(constant) => {
       closure_instruction(stdio, "Closure", chunk, constant, offset)
     }
     AlignedByteCode::Method(constant) => {
-      constant_instruction(stdio, "Method", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "Method", chunk, constant, offset)
     }
     AlignedByteCode::StaticMethod(constant) => {
-      constant_instruction(stdio, "StaticMethod", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "StaticMethod", chunk, constant, offset)
     }
-    AlignedByteCode::CloseUpvalue => simple_instruction(stdio, "CloseUpvalue", offset),
+    AlignedByteCode::CloseUpvalue => simple_instruction(stdio.stdout(), "CloseUpvalue", offset),
     AlignedByteCode::UpvalueIndex(_) => {
-      simple_instruction(stdio, "!=== UpValueIndex - Invalid ===!", offset)
+      simple_instruction(stdio.stdout(), "!=== UpValueIndex - Invalid ===!", offset)
     }
     AlignedByteCode::DefineGlobal(constant) => {
-      constant_instruction(stdio, "DefineGlobal", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "DefineGlobal", chunk, constant, offset)
     }
     AlignedByteCode::GetGlobal(constant) => {
-      constant_instruction(stdio, "GetGlobal", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "GetGlobal", chunk, constant, offset)
     }
     AlignedByteCode::SetGlobal(constant) => {
-      constant_instruction(stdio, "SetGlobal", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "SetGlobal", chunk, constant, offset)
     }
-    AlignedByteCode::GetLocal(slot) => byte_instruction(stdio, "GetLocal", slot, offset),
-    AlignedByteCode::SetLocal(slot) => byte_instruction(stdio, "SetLocal", slot, offset),
-    AlignedByteCode::GetUpvalue(slot) => byte_instruction(stdio, "GetUpvalue", slot, offset),
-    AlignedByteCode::SetUpvalue(slot) => byte_instruction(stdio, "SetUpvalue", slot, offset),
+    AlignedByteCode::GetLocal(slot) => byte_instruction(stdio.stdout(), "GetLocal", slot, offset),
+    AlignedByteCode::SetLocal(slot) => byte_instruction(stdio.stdout(), "SetLocal", slot, offset),
+    AlignedByteCode::GetUpvalue(slot) => {
+      byte_instruction(stdio.stdout(), "GetUpvalue", slot, offset)
+    }
+    AlignedByteCode::SetUpvalue(slot) => {
+      byte_instruction(stdio.stdout(), "SetUpvalue", slot, offset)
+    }
     AlignedByteCode::SetProperty(slot) => {
-      constant_instruction(stdio, "SetProperty", chunk, slot, offset)
+      constant_instruction(stdio.stdout(), "SetProperty", chunk, slot, offset)
     }
     AlignedByteCode::GetProperty(slot) => {
-      constant_instruction(stdio, "GetProperty", chunk, slot, offset)
+      constant_instruction(stdio.stdout(), "GetProperty", chunk, slot, offset)
     }
-    AlignedByteCode::Jump(jump) => jump_instruction(stdio, "Jump", 1, jump, offset),
-    AlignedByteCode::JumpIfFalse(jump) => jump_instruction(stdio, "JumpIfFalse", 1, jump, offset),
-    AlignedByteCode::Loop(jump) => jump_instruction(stdio, "Loop", -1, jump, offset),
-    AlignedByteCode::Equal => simple_instruction(stdio, "Equal", offset),
-    AlignedByteCode::Greater => simple_instruction(stdio, "Greater", offset),
-    AlignedByteCode::Less => simple_instruction(stdio, "Less", offset),
+    AlignedByteCode::Jump(jump) => jump_instruction(stdio.stdout(), "Jump", 1, jump, offset),
+    AlignedByteCode::JumpIfFalse(jump) => {
+      jump_instruction(stdio.stdout(), "JumpIfFalse", 1, jump, offset)
+    }
+    AlignedByteCode::Loop(jump) => jump_instruction(stdio.stdout(), "Loop", -1, jump, offset),
+    AlignedByteCode::Equal => simple_instruction(stdio.stdout(), "Equal", offset),
+    AlignedByteCode::Greater => simple_instruction(stdio.stdout(), "Greater", offset),
+    AlignedByteCode::Less => simple_instruction(stdio.stdout(), "Less", offset),
     AlignedByteCode::Constant(constant) => {
-      constant_instruction(stdio, "Constant", chunk, constant as u16, offset)
+      constant_instruction(stdio.stdout(), "Constant", chunk, constant as u16, offset)
     }
     AlignedByteCode::ConstantLong(constant) => {
-      constant_instruction(stdio, "ConstantLong", chunk, constant, offset)
+      constant_instruction(stdio.stdout(), "ConstantLong", chunk, constant, offset)
     }
   }
 }
 
 fn jump_instruction(
-  stdio: &impl StdIo,
+  stdout: &mut dyn Write,
   name: &str,
   sign: isize,
   jump: u16,
   offset: usize,
-) -> usize {
+) -> io::Result<usize> {
   let net_jump = sign * (jump as isize);
-  stdio.println(&format!(
+  writeln!(
+    stdout,
     "{:16} {:5} -> {}",
     name,
     offset - 3,
     (offset as isize) + net_jump
-  ));
-  offset
+  )?;
+  Ok(offset)
 }
 
 /// print a constant
 fn constant_instruction(
-  stdio: &impl StdIo,
+  stdout: &mut dyn Write,
   name: &str,
   chunk: &Chunk,
   constant: u16,
   offset: usize,
-) -> usize {
-  stdio.print(&format!("{:16} {:5} ", name, constant));
-  stdio.println(&format!("{}", &chunk.constants[constant as usize]));
-  offset
+) -> io::Result<usize> {
+  write!(stdout, "{:16} {:5} ", name, constant)?;
+  writeln!(stdout, "{}", &chunk.constants[constant as usize])?;
+  Ok(offset)
 }
 
 /// print a closure
 fn closure_instruction(
-  stdio: &impl StdIo,
+  stdio: &mut Stdio,
   name: &str,
   chunk: &Chunk,
   constant: u16,
   offset: usize,
-) -> usize {
-  stdio.print(&format!("{:16} {:5} ", name, constant));
-  stdio.println(&format!("{}", &chunk.constants[constant as usize]));
+) -> io::Result<usize> {
+  let stdout = stdio.stdout();
+
+  write!(stdout, "{:16} {:5} ", name, constant)?;
+  writeln!(stdout, "{}", &chunk.constants[constant as usize])?;
 
   let value = &chunk.constants[constant as usize];
   let upvalue_count = if value.is_fun() {
     value.to_fun().upvalue_count
   } else {
-    stdio.eprintln(&format!(
+    let stderr = stdio.stderr();
+
+    writeln!(
+      stderr,
       "!=== Compilation failure found {} instead of function ===!",
       value.value_type()
-    ));
-    0
+    )?;
+    panic!();
   };
 
   let mut current_offset = offset;
@@ -192,49 +220,61 @@ fn closure_instruction(
     };
 
     match upvalue_index {
-      UpvalueIndex::Local(local) => stdio.println(&format!(
+      UpvalueIndex::Local(local) => writeln!(
+        stdout,
         "{:0>4}      |                     local {}",
         current_offset, local
-      )),
-      UpvalueIndex::Upvalue(upvalue) => stdio.println(&format!(
+      ),
+      UpvalueIndex::Upvalue(upvalue) => writeln!(
+        stdout,
         "{:0>4}      |                     upvalue {}",
         current_offset, upvalue
-      )),
-    }
+      ),
+    }?;
 
     current_offset += 2;
   }
 
-  current_offset
+  Ok(current_offset)
 }
 
 fn invoke_instruction(
-  stdio: &impl StdIo,
+  stdout: &mut dyn Write,
   name: &str,
   chunk: &Chunk,
   constant: u16,
   arg_count: u8,
   offset: usize,
-) -> usize {
-  stdio.print(&format!("{:16} {:5} ({} args) ", name, arg_count, constant));
-  stdio.println(&format!("{}", &chunk.constants[constant as usize]));
-  offset
+) -> io::Result<usize> {
+  write!(stdout, "{:16} {:5} ({} args) ", name, arg_count, constant)?;
+  writeln!(stdout, "{}", &chunk.constants[constant as usize])?;
+  Ok(offset)
 }
 
 /// print a short instruction
-fn short_instruction(stdio: &impl StdIo, name: &str, slot: u16, offset: usize) -> usize {
-  stdio.println(&format!("{:16} {:5}", name, slot));
-  offset
+fn short_instruction(
+  stdout: &mut dyn Write,
+  name: &str,
+  slot: u16,
+  offset: usize,
+) -> io::Result<usize> {
+  writeln!(stdout, "{:16} {:5}", name, slot)?;
+  Ok(offset)
 }
 
 /// print a byte instruction
-fn byte_instruction(stdio: &impl StdIo, name: &str, slot: u8, offset: usize) -> usize {
-  stdio.println(&format!("{:16} {:5}", name, slot));
-  offset
+fn byte_instruction(
+  stdout: &mut dyn Write,
+  name: &str,
+  slot: u8,
+  offset: usize,
+) -> io::Result<usize> {
+  writeln!(stdout, "{:16} {:5}", name, slot)?;
+  Ok(offset)
 }
 
 /// print a simple instruction
-fn simple_instruction(stdio: &impl StdIo, name: &str, offset: usize) -> usize {
-  stdio.println(&format!("{:16}", name));
-  offset
+fn simple_instruction(stdout: &mut dyn Write, name: &str, offset: usize) -> io::Result<usize> {
+  writeln!(stdout, "{:16}", name)?;
+  Ok(offset)
 }

--- a/laythe_vm/tests/builtin.rs
+++ b/laythe_vm/tests/builtin.rs
@@ -68,6 +68,7 @@ fn iter() -> Result<(), std::io::Error> {
       "std_lib/builtin/iter/next.ly",
       "std_lib/builtin/iter/reduce.ly",
       "std_lib/builtin/iter/str.ly",
+      "std_lib/builtin/iter/zip.ly",
     ],
     ExecuteResult::Ok,
   )?;
@@ -107,13 +108,14 @@ fn list() -> Result<(), std::io::Error> {
 fn map() -> Result<(), std::io::Error> {
   test_files(
     &vec![
-      "std_lib/builtin/map/size.ly",
-      "std_lib/builtin/map/str.ly",
-      "std_lib/builtin/map/has.ly",
       "std_lib/builtin/map/get.ly",
-      "std_lib/builtin/map/remove.ly",
+      "std_lib/builtin/map/has.ly",
       "std_lib/builtin/map/insert.ly",
       "std_lib/builtin/map/iter.ly",
+      "std_lib/builtin/map/remove.ly",
+      "std_lib/builtin/map/set.ly",
+      "std_lib/builtin/map/size.ly",
+      "std_lib/builtin/map/str.ly",
     ],
     ExecuteResult::Ok,
   )?;

--- a/laythe_vm/tests/builtin.rs
+++ b/laythe_vm/tests/builtin.rs
@@ -1,11 +1,10 @@
-use laythe_env::io::NativeIo;
 use laythe_vm::vm::ExecuteResult;
 use support::assert_files_exit;
 
 mod support;
 
 fn test_files(paths: &[&str], result: ExecuteResult) -> Result<(), std::io::Error> {
-  assert_files_exit(paths, FILE_PATH, NativeIo(), result)
+  assert_files_exit(paths, FILE_PATH, result)
 }
 
 const FILE_PATH: &str = file!();
@@ -22,17 +21,11 @@ fn bool() -> Result<(), std::io::Error> {
 #[test]
 fn class() -> Result<(), std::io::Error> {
   test_files(
-    &vec![
-      "std_lib/builtin/class/superClass.ly",
-    ],
+    &vec!["std_lib/builtin/class/superClass.ly"],
     ExecuteResult::Ok,
   )?;
 
-  test_files(
-    &vec![
-    ],
-    ExecuteResult::RuntimeError,
-  )
+  test_files(&vec![], ExecuteResult::RuntimeError)
 }
 
 #[test]

--- a/laythe_vm/tests/builtin.rs
+++ b/laythe_vm/tests/builtin.rs
@@ -83,6 +83,7 @@ fn list() -> Result<(), std::io::Error> {
       "std_lib/builtin/list/collect.ly",
       "std_lib/builtin/list/has.ly",
       "std_lib/builtin/list/insert.ly",
+      "std_lib/builtin/list/index.ly",
       "std_lib/builtin/list/iter.ly",
       "std_lib/builtin/list/pop.ly",
       "std_lib/builtin/list/push.ly",

--- a/laythe_vm/tests/io.rs
+++ b/laythe_vm/tests/io.rs
@@ -1,0 +1,65 @@
+use laythe_vm::vm::ExecuteResult;
+use support::{assert_file_exit_and_stdio};
+
+mod support;
+
+fn test_file_with_stdout(
+  path: &str,
+  stdout: Vec<&str>,
+  result: ExecuteResult,
+) -> Result<(), std::io::Error> {
+  assert_file_exit_and_stdio(path, FILE_PATH, None, None, Some(stdout), None, result)
+}
+
+fn test_file_with_stdin(
+  path: &str,
+  stdin: String,
+  result: ExecuteResult,
+) -> Result<(), std::io::Error> {
+  assert_file_exit_and_stdio(path, FILE_PATH, Some(stdin), None, None, None, result)
+}
+
+fn test_file_with_stdin_lines(
+  path: &str,
+  lines: Vec<String>,
+  result: ExecuteResult,
+) -> Result<(), std::io::Error> {
+  assert_file_exit_and_stdio(path, FILE_PATH, None, Some(lines), None, None, result)
+}
+
+const FILE_PATH: &str = file!();
+
+#[test]
+fn stdio() -> Result<(), std::io::Error> {
+  test_file_with_stdout(
+    "std_lib/io/stdio/stdout/write.ly",
+    vec![
+      "expected 1 expected 2"
+    ],
+    ExecuteResult::Ok
+  )?;
+
+  test_file_with_stdout(
+    "std_lib/io/stdio/stdout/writeln.ly",
+    vec![
+      "expected 1",
+      "expected 2",
+    ],
+    ExecuteResult::Ok
+  )?;
+
+  test_file_with_stdin(
+    "std_lib/io/stdio/stdin/read.ly",
+    "expected".to_string(),
+    ExecuteResult::Ok
+  )?;
+
+  test_file_with_stdin_lines(
+    "std_lib/io/stdio/stdin/readline.ly",
+    vec![
+      "expected 1".to_string(),
+      "expected 2".to_string(),
+    ],
+    ExecuteResult::Ok
+  )
+}

--- a/laythe_vm/tests/language.rs
+++ b/laythe_vm/tests/language.rs
@@ -1,20 +1,19 @@
-use laythe_env::io::NativeIo;
 use laythe_vm::vm::{default_native_vm, ExecuteResult};
 use support::{assert_file_exit_and_stdio, assert_files_exit};
 
 mod support;
 
 fn test_file_exits(paths: &[&str], result: ExecuteResult) -> Result<(), std::io::Error> {
-  assert_files_exit(paths, FILE_PATH, NativeIo(), result)
+  assert_files_exit(paths, FILE_PATH, result)
 }
 
 fn test_file_with_stdio(
   path: &str,
   stdout: Option<Vec<&str>>,
-  errout: Option<Vec<&str>>,
+  stderr: Option<Vec<&str>>,
   result: ExecuteResult,
 ) -> Result<(), std::io::Error> {
-  assert_file_exit_and_stdio(path, FILE_PATH, stdout, errout, result)
+  assert_file_exit_and_stdio(path, FILE_PATH, None, None, stdout, stderr, result)
 }
 
 const FILE_PATH: &str = file!();

--- a/laythe_vm/tests/math.rs
+++ b/laythe_vm/tests/math.rs
@@ -1,11 +1,10 @@
-use laythe_env::io::NativeIo;
 use laythe_vm::vm::ExecuteResult;
 use support::assert_files_exit;
 
 mod support;
 
 fn test_files(paths: &[&str], result: ExecuteResult) -> Result<(), std::io::Error> {
-  assert_files_exit(paths, FILE_PATH, NativeIo(), result)
+  assert_files_exit(paths, FILE_PATH, result)
 }
 
 const FILE_PATH: &str = file!();

--- a/laythe_vm/tests/support/mod.rs
+++ b/laythe_vm/tests/support/mod.rs
@@ -1,12 +1,14 @@
-use laythe_env::{env::NativeEnvIo, fs::NativeFsIo, io::Io, stdio::StdIo};
+use laythe_env::{
+  io::{support::IoTest, Io},
+  stdio::support::StdioTestContainer,
+};
 use laythe_vm::vm::{ExecuteResult, Vm};
 use std::fs::File;
 use std::io::prelude::*;
-use std::{
-  cell::RefCell,
-  path::{Path, PathBuf},
-};
-use std::{io::Result, rc::Rc};
+use std::io::{Cursor, self};
+use std::path::{Path, PathBuf};
+use std::str;
+use std::fmt;
 
 pub fn fixture_path_inner(fixture_path: &str, test_file_path: &str) -> Option<PathBuf> {
   let test_path = Path::new(test_file_path);
@@ -18,34 +20,24 @@ pub fn fixture_path_inner(fixture_path: &str, test_file_path: &str) -> Option<Pa
     .and_then(|path| Some(path.join("fixture").join(fixture_path)))
 }
 
-pub fn assert_files_exit<I: Io + 'static>(
+pub fn assert_files_exit(
   paths: &[&str],
   test_file_path: &str,
-  io: I,
   result: ExecuteResult,
-) -> Result<()> {
+) -> io::Result<()> {
   for path in paths {
-    let mut vm = Vm::new(io.clone());
+    let mut stdio_container = StdioTestContainer::default();
+    let io_test = Box::new(IoTest::new(&mut stdio_container));
 
-    let test_path = fixture_path_inner(path, test_file_path).expect("No parent directory");
-    let debug_path = test_path.to_str().map(|s| s.to_string());
-
-    let mut file = match File::open(test_path.clone()) {
-      Ok(file) => file,
-      Err(err) => {
-        println!("Could not find {}", test_path.to_str().unwrap());
+    {
+      let io = Io::new(io_test);
+  
+      if let Err(err) = assert_files_exit_inner(path, test_file_path, io, result.clone()) {
+        eprintln!("{}", str::from_utf8(&*stdio_container.stdout).expect("Could not unwrap stdout"));
+        eprintln!("{}", str::from_utf8(&*stdio_container.stderr).expect("Could not unwrap stderr"));
         return Err(err);
       }
-    };
-    let mut source = String::new();
-    file.read_to_string(&mut source)?;
-
-    assert_eq!(
-      vm.run(test_path, &source),
-      result,
-      "Failing file {:?}",
-      debug_path
-    );
+    }
   }
 
   Ok(())
@@ -56,127 +48,132 @@ pub fn assert_files_exit<I: Io + 'static>(
 pub fn assert_file_exit_and_stdio(
   path: &str,
   file_path: &str,
+  stdin: Option<String>,
+  lines: Option<Vec<String>>,
   stdout: Option<Vec<&str>>,
-  errout: Option<Vec<&str>>,
+  stderr: Option<Vec<&str>>,
   result: ExecuteResult,
-) -> Result<()> {
-  let io = MockedConsoleIo::new(MockedStdIo::default());
+) -> io::Result<()> {
+  let mut stdio_container = StdioTestContainer {
+    stdout: Box::new(vec![]),
+    stderr: Box::new(vec![]),
+    stdin: Box::new(Cursor::new(Vec::from(
+      stdin.unwrap_or("".to_string()).as_bytes(),
+    ))),
+    lines: Box::new(lines.unwrap_or(vec![])),
+    line_index: Box::new(0),
+  };
+  let io_test = Box::new(IoTest::new(&mut stdio_container));
 
-  assert_files_exit(&[path], file_path, io.clone(), result)?;
+  {
+    let io = Io::new(io_test);
 
+    if let Err(err) = assert_files_exit_inner(path, file_path, io, result) {
+      stdio_container.log_stdio();
+      return Err(err);
+    }
+  }
+
+  // assert stdout matches if provided
   if let Some(stdout) = stdout {
-    io.stdio
-      .stdout
-      .borrow()
+    let stdout_result = str::from_utf8(&stdio_container.stdout).map(|s| s.to_string());
+
+    assert!(stdout_result.is_ok());
+    let stdout_string = stdout_result.unwrap();
+    let stdout_string = stdout_string.trim_end();
+
+    let stdout_lines: Vec<&str> = stdout_string.split("\n").collect();
+
+    stdout_lines
       .iter()
       .zip(stdout.iter())
       .for_each(|(actual, expected)| {
         assert_eq!(actual, expected);
       });
 
-    assert_eq!(
-      io.stdio.stdout.borrow().len(),
-      stdout.len(),
-      "Different standard out lines were collected than expected"
-    );
+
+    if let Err(err) = ly_assert_eq(
+      &stdout_lines.len(), 
+      &stdout.len(), 
+      None) {
+
+      stdio_container.log_stdio();
+      panic!(err.to_string())
+    }
   }
 
-  if let Some(errout) = errout {
-    io.stdio
-      .errout
-      .borrow()
+  // assert stderr matches if provided
+  if let Some(stderr) = stderr {
+    let stderr_result = str::from_utf8(&stdio_container.stderr).map(|s| s.to_string());
+
+    assert!(stderr_result.is_ok());
+    let stderr_string = stderr_result.unwrap();
+
+    let mut stderr_lines: Vec<&str> = stderr_string.split("\n").collect();
+    stderr_lines.pop();
+
+    stderr_lines
       .iter()
-      .zip(errout.iter())
+      .zip(stderr.iter())
       .for_each(|(actual, expected)| {
         assert_eq!(actual, expected);
       });
 
-    assert_eq!(
-      io.stdio.errout.borrow().len(),
-      errout.len(),
-      "Different error out lines were collected than expected"
-    );
+    if let Err(err) = ly_assert_eq(
+      &stderr_lines.len(), 
+      &stderr.len(), 
+      None) {
+
+      stdio_container.log_stdio();
+      panic!(err.to_string())
+    }
   }
 
   Ok(())
 }
-#[derive(Debug, Clone, Default)]
-pub struct MockedConsoleIo {
-  pub stdio: MockedStdIo,
-}
 
-impl MockedConsoleIo {
-  pub fn new(stdio: MockedStdIo) -> Self {
-    Self { stdio }
-  }
-}
+fn assert_files_exit_inner(
+  path: &str,
+  test_file_path: &str,
+  io: Io,
+  result: ExecuteResult,
+) -> io::Result<()> {
+  let mut vm = Vm::new(io.clone());
 
-impl Io for MockedConsoleIo {
-  type StdIo = MockedStdIo;
-  type FsIo = NativeFsIo;
-  type EnvIo = NativeEnvIo;
+  let test_path = fixture_path_inner(path, test_file_path).expect("No parent directory");
+  let debug_path = test_path.to_str().map(|s| s.to_string());
 
-  fn stdio(&self) -> Self::StdIo {
-    self.stdio.clone()
-  }
-
-  fn fsio(&self) -> Self::FsIo {
-    NativeFsIo()
-  }
-
-  fn envio(&self) -> Self::EnvIo {
-    NativeEnvIo()
-  }
-}
-
-#[derive(Clone, Debug)]
-pub struct MockedStdIo {
-  pub stdout: Rc<RefCell<Vec<String>>>,
-  pub errout: Rc<RefCell<Vec<String>>>,
-  pub read_lines: Rc<RefCell<Vec<String>>>,
-}
-
-impl Default for MockedStdIo {
-  fn default() -> Self {
-    Self {
-      stdout: Rc::new(RefCell::new(vec![])),
-      errout: Rc::new(RefCell::new(vec![])),
-      read_lines: Rc::new(RefCell::new(vec![])),
+  let mut file = match File::open(test_path.clone()) {
+    Ok(file) => file,
+    Err(err) => {
+      println!("Could not find {}", test_path.to_str().unwrap());
+      return Err(err);
     }
-  }
+  };
+  let mut source = String::new();
+  file.read_to_string(&mut source)?;
+
+  ly_assert_eq(
+    &vm.run(test_path, &source),
+    &result,
+    Some(format!(
+      "Failing file {:?}",
+      debug_path
+    ))
+  )?;
+
+  Ok(())
 }
 
-impl StdIo for MockedStdIo {
-  fn print(&self, message: &str) {
-    print!("{}", message);
+/// Assert equal returning a result so debug information has a chance to be captured and displayed
+fn ly_assert_eq<T: PartialEq + fmt::Debug>(expected: &T, received: &T, message: Option<String>) -> io::Result<()> {
+  if expected == received {
+    return Ok(())
+  }
 
-    match self.stdout.borrow_mut().last_mut() {
-      Some(line) => line.push_str(message),
-      None => self.stdout.borrow_mut().push(message.to_string()),
-    }
-  }
-  fn println(&self, message: &str) {
-    println!("{}", message);
-
-    self.stdout.borrow_mut().push(message.to_string());
-  }
-  fn eprint(&self, message: &str) {
-    eprint!("{}", message);
-
-    match self.errout.borrow_mut().last_mut() {
-      Some(line) => line.push_str(message),
-      None => self.errout.borrow_mut().push(message.to_string()),
-    }
-  }
-  fn eprintln(&self, message: &str) {
-    eprintln!("{}", message);
-
-    self.errout.borrow_mut().push(message.to_string());
-  }
-  fn flush(&self) -> Result<()> {
-    Ok(())
-  }
-  fn read_line(&self, _buffer: &mut String) -> Result<usize> {
-    Ok(0)
-  }
+  // should consider mapping io errors to something else
+  Err(io::Error::new(
+    io::ErrorKind::Other, 
+    message.unwrap_or(format!("Expected {:?} Received {:?}", expected, received))
+  ))
 }


### PR DESCRIPTION
## Summary
This PR makes two primary changes. 
* Removes the generic Io parameter instead opting for `dyn Traits`
* Expose more primitive traits for stdio instead of random methods. `stdout` and `stderr` now expose `Write` and `stdin` a `Read`. This makes testing and swapping implementations easier.

Overall I think this makes a possible wasm target much easier and now makes it possible to test stdio in a reasonable manner. We now have a IoTest which for stdio uses strings as Write instead of the console. to assert certain things were written to them.