### PR TITLE
Add val! macro equal to Value::from

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -100,7 +100,7 @@
         }
       },
       "args": [
-        "benchmark/fluent.ly",
+        "std_lib/io/stdio/stdout/write.ly",
       ],
       "sourceLanguages": ["rust"],
       "cwd": "${workspaceFolder}/laythe_vm/fixture",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ default-members = [
   "laythe_macro",
   "laythe_env",
   "laythe_vm",
-  "laythe_wasm",
   "laythe",
 ]
 

--- a/laythe_core/src/chunk.rs
+++ b/laythe_core/src/chunk.rs
@@ -634,18 +634,19 @@ impl Chunk {
   ///
   /// # Examples
   /// ```
+  /// use laythe_core::val;
   /// use laythe_core::chunk::Chunk;
   /// use laythe_core::value::Value;
   ///
   /// let mut chunk = Chunk::default();
-  /// let index_1 = chunk.add_constant(Value::from(10.4));
-  /// let index_2 = chunk.add_constant(Value::from(5.2));
+  /// let index_1 = chunk.add_constant(val!(10.4));
+  /// let index_2 = chunk.add_constant(val!(5.2));
   ///
   /// assert_eq!(index_1, 0);
   /// assert_eq!(index_2, 1);
   ///
-  /// assert_eq!(chunk.constants[index_1], Value::from(10.4));
-  /// assert_eq!(chunk.constants[index_2], Value::from(5.2));
+  /// assert_eq!(chunk.constants[index_1], val!(10.4));
+  /// assert_eq!(chunk.constants[index_2], val!(5.2));
   /// ```
   pub fn add_constant(&mut self, value: Value) -> usize {
     self.constants.push(value);

--- a/laythe_core/src/module.rs
+++ b/laythe_core/src/module.rs
@@ -221,6 +221,7 @@ mod test {
   use crate::{
     hooks::{support::TestContext, GcHooks},
     object::Class,
+    val,
   };
 
   #[test]
@@ -274,7 +275,7 @@ mod test {
 
     let export_name = hooks.manage_str("exported".to_string());
 
-    module.insert_symbol(&hooks, export_name, Value::from(true));
+    module.insert_symbol(&hooks, export_name, val!(true));
     let result1 = module.export_symbol(&hooks, export_name);
     let result2 = module.export_symbol(&hooks, export_name);
 
@@ -298,13 +299,13 @@ mod test {
     );
 
     let export_name = hooks.manage_str("exported".to_string());
-    module.insert_symbol(&hooks, export_name, Value::from(true));
+    module.insert_symbol(&hooks, export_name, val!(true));
     assert!(module.export_symbol(&hooks, export_name).is_ok());
 
     let symbols = module.import(&hooks);
 
     if let Some(result) = symbols.get_field(&export_name) {
-      assert_eq!(*result, Value::from(true));
+      assert_eq!(*result, val!(true));
     } else {
       assert!(false);
     }
@@ -326,12 +327,12 @@ mod test {
     );
 
     let name = hooks.manage_str("exported".to_string());
-    module.insert_symbol(&hooks, name, Value::from(true));
+    module.insert_symbol(&hooks, name, val!(true));
 
     let symbol = module.get_symbol(name);
 
     if let Some(result) = symbol {
-      assert_eq!(*result, Value::from(true));
+      assert_eq!(*result, val!(true));
     } else {
       assert!(false);
     }

--- a/laythe_core/src/object.rs
+++ b/laythe_core/src/object.rs
@@ -157,18 +157,19 @@ impl Upvalue {
   ///
   /// # Examples
   /// ```
+  /// use laythe_core::val;
   /// use laythe_core::value::Value;
   /// use laythe_core::object::Upvalue;
   /// use std::rc::Rc;
   /// use std::ptr::NonNull;
   ///
-  /// let value = Value::from(10.0);
+  /// let value = val!(10.0);
   ///
   /// let mut upvalue = Upvalue::Open(NonNull::from(&value));
   /// upvalue.hoist();
   ///
   /// match upvalue {
-  ///   Upvalue::Closed(store) => assert_eq!(*store, Value::from(10.0)),
+  ///   Upvalue::Closed(store) => assert_eq!(*store, val!(10.0)),
   ///   Upvalue::Open(_) => assert!(false),
   /// };
   /// ```

--- a/laythe_core/src/package.rs
+++ b/laythe_core/src/package.rs
@@ -201,7 +201,7 @@ impl Manage for Package {
 
 #[cfg(test)]
 mod test {
-  use crate::object::Class;
+  use crate::{val, object::Class};
 
   #[test]
   fn new() {
@@ -283,7 +283,7 @@ mod test {
       .unwrap(),
     );
     let export_name = hooks.manage_str("exported".to_string());
-    module.insert_symbol(&hooks, export_name, Value::from(true));
+    module.insert_symbol(&hooks, export_name, val!(true));
     assert!(module.export_symbol(&hooks, export_name).is_ok());
 
     let mut package = Package::new(hooks.manage_str("my_package".to_string()));
@@ -300,7 +300,7 @@ mod test {
 
     if let Ok(result) = symbols1 {
       assert_eq!(result.len(), 1);
-      assert_eq!(*result.get_symbol(export_name).unwrap(), Value::from(true));
+      assert_eq!(*result.get_symbol(export_name).unwrap(), val!(true));
     }
   }
 }

--- a/laythe_core/src/signature.rs
+++ b/laythe_core/src/signature.rs
@@ -279,6 +279,7 @@ mod test {
 
   mod signature {
     use super::*;
+    use crate::val;
 
     const PARAMETERS_FIXED: [Parameter; 2] = [
       Parameter::new("index", ParameterKind::Number),
@@ -294,15 +295,15 @@ mod test {
         Err(SignatureError::LengthFixed(2))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(10.0), Value::from(true), Value::from(false)]),
+        fixed_signature.check(&[val!(10.0), val!(true), val!(false)]),
         Err(SignatureError::LengthFixed(2))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(true), Value::from(true)]),
+        fixed_signature.check(&[val!(true), val!(true)]),
         Err(SignatureError::TypeWrong(0))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(10.0), Value::from(true)]),
+        fixed_signature.check(&[val!(10.0), val!(true)]),
         Ok(())
       );
     }
@@ -321,20 +322,20 @@ mod test {
         Err(SignatureError::LengthVariadic(1))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(10.0), Value::from(10.0)]),
+        fixed_signature.check(&[val!(10.0), val!(10.0)]),
         Err(SignatureError::TypeWrong(0))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(true), Value::from(false)]),
+        fixed_signature.check(&[val!(true), val!(false)]),
         Err(SignatureError::TypeWrong(1))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(true), Value::from(10.0), Value::from(false)]),
+        fixed_signature.check(&[val!(true), val!(10.0), val!(false)]),
         Err(SignatureError::TypeWrong(2))
       );
-      assert_eq!(fixed_signature.check(&[Value::from(true)]), Ok(()));
+      assert_eq!(fixed_signature.check(&[val!(true)]), Ok(()));
       assert_eq!(
-        fixed_signature.check(&[Value::from(true), Value::from(10.0), Value::from(10.0)]),
+        fixed_signature.check(&[val!(true), val!(10.0), val!(10.0)]),
         Ok(())
       );
     }
@@ -353,20 +354,20 @@ mod test {
         Err(SignatureError::LengthDefaultLow(1))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(10.0), Value::from(10.0), Value::from(10.0)]),
+        fixed_signature.check(&[val!(10.0), val!(10.0), val!(10.0)]),
         Err(SignatureError::LengthDefaultHigh(2))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(10.0)]),
+        fixed_signature.check(&[val!(10.0)]),
         Err(SignatureError::TypeWrong(0))
       );
       assert_eq!(
-        fixed_signature.check(&[Value::from(false), Value::from(true)]),
+        fixed_signature.check(&[val!(false), val!(true)]),
         Err(SignatureError::TypeWrong(1))
       );
-      assert_eq!(fixed_signature.check(&[Value::from(true)]), Ok(()));
+      assert_eq!(fixed_signature.check(&[val!(true)]), Ok(()));
       assert_eq!(
-        fixed_signature.check(&[Value::from(true), Value::from(10.0)]),
+        fixed_signature.check(&[val!(true), val!(10.0)]),
         Ok(())
       );
     }

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -20,6 +20,13 @@ pub enum ValueKind {
   Upvalue,
 }
 
+#[macro_export]
+macro_rules! val {
+  ( $x:expr ) => {
+    Value::from($x)
+  };
+}
+
 #[cfg(not(feature = "nan_boxing"))]
 pub use self::unboxed::*;
 
@@ -881,7 +888,7 @@ mod unboxed {
 
 #[cfg(feature = "nan_boxing")]
 mod boxed {
-  use super::ValueKind;
+  use super::{Nil, ValueKind};
   use crate::{
     iterator::LyIterator,
     native::{NativeFun, NativeMethod},
@@ -1216,8 +1223,6 @@ mod boxed {
     }
   }
 
-  pub struct Nil();
-
   impl From<Nil> for Value {
     fn from(_: Nil) -> Self {
       VALUE_NIL
@@ -1505,8 +1510,8 @@ mod test {
 
   #[test]
   fn bool() {
-    let val_true = Value::from(true);
-    let val_false = Value::from(false);
+    let val_true = val!(true);
+    let val_false = val!(false);
 
     assert_type(val_true, ValueKind::Bool);
     assert_type(val_false, ValueKind::Bool);
@@ -1517,10 +1522,10 @@ mod test {
 
   #[test]
   fn num() {
-    let val_div_zero = Value::from(1.0 / 0.0);
-    let val_nan = Value::from(f64::NAN);
-    let val_neg_infinity = Value::from(f64::NEG_INFINITY);
-    let val_normal = Value::from(5.3);
+    let val_div_zero = val!(1.0 / 0.0);
+    let val_nan = val!(f64::NAN);
+    let val_neg_infinity = val!(f64::NEG_INFINITY);
+    let val_normal = val!(5.3);
 
     assert_type(val_div_zero, ValueKind::Number);
     assert_type(val_nan, ValueKind::Number);
@@ -1540,7 +1545,7 @@ mod test {
     let ptr = unsafe { NonNull::new_unchecked(&mut *alloc) };
 
     let managed = Managed::from(ptr);
-    let value = Value::from(managed);
+    let value = val!(managed);
     let managed2: Managed<String> = value.to_str();
 
     assert_type(value, ValueKind::String);
@@ -1556,7 +1561,7 @@ mod test {
     let ptr = unsafe { NonNull::new_unchecked(&mut *alloc) };
 
     let managed = Managed::from(ptr);
-    let value = Value::from(managed);
+    let value = val!(managed);
     let managed2 = value.to_list();
 
     assert_type(value, ValueKind::List);
@@ -1572,29 +1577,26 @@ mod test {
   fn map() {
     let mut map: Map<Value, Value> = Map::default();
     map.insert(VALUE_NIL, VALUE_TRUE);
-    map.insert(Value::from(10.0), VALUE_FALSE);
+    map.insert(val!(10.0), VALUE_FALSE);
 
     let mut alloc = Box::new(Allocation::new(map));
     let ptr = unsafe { NonNull::new_unchecked(&mut *alloc) };
 
     let managed = Managed::from(ptr);
-    let value = Value::from(managed);
+    let value = val!(managed);
     let managed2 = value.to_map();
 
     assert_type(value, ValueKind::Map);
 
     assert_eq!(managed.len(), managed2.len());
     assert_eq!(managed.get(&VALUE_NIL), managed2.get(&VALUE_NIL));
-    assert_eq!(
-      managed.get(&Value::from(10.0)),
-      managed2.get(&Value::from(10.0))
-    );
+    assert_eq!(managed.get(&val!(10.0)), managed2.get(&val!(10.0)));
   }
 
   #[test]
   fn fun() {
     let (_, managed) = test_fun();
-    let value = Value::from(managed);
+    let value = val!(managed);
     let managed2 = value.to_fun();
 
     assert_type(value, ValueKind::Fun);
@@ -1607,7 +1609,7 @@ mod test {
   fn closure() {
     let (_, managed) = test_closure();
 
-    let value = Value::from(managed);
+    let value = val!(managed);
     let managed2 = value.to_closure();
 
     assert_type(value, ValueKind::Closure);
@@ -1620,7 +1622,7 @@ mod test {
   fn class() {
     let (_, managed) = test_class();
 
-    let value = Value::from(managed);
+    let value = val!(managed);
     let managed2 = value.to_class();
 
     assert_type(value, ValueKind::Class);

--- a/laythe_lib/src/global/assert/assert.rs
+++ b/laythe_lib/src/global/assert/assert.rs
@@ -6,6 +6,7 @@ use laythe_core::{
   signature::{Arity, Parameter, ParameterKind},
   value::{Value, VALUE_NIL},
   CallResult, LyResult,
+  val,
 };
 use laythe_env::{
   managed::{Managed, Trace},
@@ -41,21 +42,21 @@ pub fn declare_assert_funs(hooks: &GcHooks, self_module: &mut Module) -> LyResul
     hooks,
     self_module,
     hooks.manage_str(ASSERT_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(Assert::new(str_name)) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(Assert::new(str_name)) as Box<dyn NativeFun>)),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(ASSERTEQ_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(AssertEq::new(str_name)) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(AssertEq::new(str_name)) as Box<dyn NativeFun>)),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(ASSERTNE_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(AssertNe::new(str_name)) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(AssertNe::new(str_name)) as Box<dyn NativeFun>)),
   )
 }
 
@@ -191,7 +192,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let assert = Assert::new(hooks.manage_str("str".to_string()));
-      let values = &[Value::from(true)];
+      let values = &[val!(true)];
 
       let result = match assert.call(&mut hooks, values) {
         Ok(res) => res,
@@ -229,7 +230,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
       let assert_eq = AssertEq::new(hooks.manage_str("str".to_string()));
 
-      let values = &[Value::from(10.5), Value::from(10.5)];
+      let values = &[val!(10.5), val!(10.5)];
 
       let result = match assert_eq.call(&mut hooks, values) {
         Ok(res) => res,
@@ -267,7 +268,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
       let assert_eq = AssertNe::new(hooks.manage_str("str".to_string()));
 
-      let values = &[Value::from(10.5), VALUE_NIL];
+      let values = &[val!(10.5), VALUE_NIL];
 
       let result = match assert_eq.call(&mut hooks, values) {
         Ok(res) => res,

--- a/laythe_lib/src/global/dependencies/module.rs
+++ b/laythe_lib/src/global/dependencies/module.rs
@@ -1,6 +1,6 @@
 use crate::support::export_and_insert;
 use laythe_core::{
-  hooks::GcHooks, module::Module, object::Class, package::Package, value::Value, LyResult,
+  val, hooks::GcHooks, module::Module, object::Class, package::Package, value::Value, LyResult,
 };
 
 pub const MODULE_CLASS_NAME: &str = "Module";
@@ -9,7 +9,7 @@ pub fn declare_module_class(hooks: &GcHooks, self_module: &mut Module) -> LyResu
   let name = hooks.manage_str(String::from(MODULE_CLASS_NAME));
   let class = hooks.manage(Class::bare(name));
 
-  export_and_insert(hooks, self_module, name, Value::from(class))
+  export_and_insert(hooks, self_module, name, val!(class))
 }
 
 pub fn define_module_class(_hooks: &GcHooks, _self_module: &Module, _: &Package) {}

--- a/laythe_lib/src/global/primitives/bool.rs
+++ b/laythe_lib/src/global/primitives/bool.rs
@@ -9,6 +9,7 @@ use laythe_core::{
   signature::Arity,
   value::{Value, VALUE_TRUE},
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -17,7 +18,7 @@ const BOOL_STR: NativeMeta = NativeMeta::new("str", Arity::Fixed(0), &[]);
 
 pub fn declare_bool_class(hooks: &GcHooks, module: &mut Module, package: &Package) -> LyResult<()> {
   let bool_class = default_class_inheritance(hooks, package, BOOL_CLASS_NAME)?;
-  export_and_insert(hooks, module, bool_class.name, Value::from(bool_class))
+  export_and_insert(hooks, module, bool_class.name, val!(bool_class))
 }
 
 pub fn define_bool_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -26,7 +27,7 @@ pub fn define_bool_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyRes
   bool_class.add_method(
     &hooks,
     hooks.manage_str(String::from(BOOL_STR.name)),
-    Value::from(to_dyn_method(hooks, BoolStr())),
+    val!(to_dyn_method(hooks, BoolStr())),
   );
 
   Ok(())
@@ -42,9 +43,9 @@ impl NativeMethod for BoolStr {
 
   fn call(&self, hooks: &mut Hooks, this: Value, _args: &[Value]) -> CallResult {
     if this == VALUE_TRUE {
-      Ok(Value::from(hooks.manage_str("true".to_string())))
+      Ok(val!(hooks.manage_str("true".to_string())))
     } else {
-      Ok(Value::from(hooks.manage_str("false".to_string())))
+      Ok(val!(hooks.manage_str("false".to_string())))
     }
   }
 }
@@ -71,8 +72,8 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let b_true = Value::from(true);
-      let b_false = Value::from(false);
+      let b_true = val!(true);
+      let b_false = val!(false);
 
       let result1 = bool_str.call(&mut hooks, b_true, &[]);
       let result2 = bool_str.call(&mut hooks, b_false, &[]);

--- a/laythe_lib/src/global/primitives/class.rs
+++ b/laythe_lib/src/global/primitives/class.rs
@@ -8,6 +8,7 @@ use laythe_core::{
   signature::Arity,
   value::{Value, VALUE_NIL},
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -19,7 +20,7 @@ pub fn declare_class_class(hooks: &GcHooks, module: &mut Module) -> LyResult<()>
   let name = hooks.manage_str(String::from(CLASS_CLASS_NAME));
   let class = hooks.manage(Class::bare(name));
 
-  export_and_insert(hooks, module, name, Value::from(class))
+  export_and_insert(hooks, module, name, val!(class))
 }
 
 pub fn define_class_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -28,7 +29,7 @@ pub fn define_class_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyRe
   class_class.add_method(
     &hooks,
     hooks.manage_str(String::from(CLASS_SUPER_CLASS.name)),
-    Value::from(to_dyn_method(hooks, ClassSuperClass())),
+    val!(to_dyn_method(hooks, ClassSuperClass())),
   );
 
   Ok(())
@@ -46,7 +47,7 @@ impl NativeMethod for ClassSuperClass {
     let super_class = this
       .to_class()
       .super_class()
-      .map(|super_class| Value::from(super_class))
+      .map(|super_class| val!(super_class))
       .unwrap_or(VALUE_NIL);
 
     Ok(super_class)
@@ -81,8 +82,8 @@ mod test {
 
       class.inherit(&hooks.to_gc(), super_class);
 
-      let class_value = Value::from(class);
-      let super_class_value = Value::from(super_class);
+      let class_value = val!(class);
+      let super_class_value = val!(super_class);
 
       let result1 = class_super_class.call(&mut hooks, class_value, &[]);
       let result2 = class_super_class.call(&mut hooks, super_class_value, &[]);

--- a/laythe_lib/src/global/primitives/iter.rs
+++ b/laythe_lib/src/global/primitives/iter.rs
@@ -12,6 +12,7 @@ use laythe_core::{
   utils::is_falsey,
   value::{Value, VALUE_NIL},
   CallResult, LyResult,
+  val,
 };
 use laythe_env::{
   managed::{Managed, Trace},
@@ -59,7 +60,7 @@ const ITER_INTO: NativeMeta = NativeMeta::new(
 
 pub fn declare_iter_class(hooks: &GcHooks, module: &mut Module, package: &Package) -> LyResult<()> {
   let class = default_class_inheritance(hooks, package, ITER_CLASS_NAME)?;
-  export_and_insert(hooks, module, class.name, Value::from(class))
+  export_and_insert(hooks, module, class.name, val!(class))
 }
 
 pub fn define_iter_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -68,55 +69,55 @@ pub fn define_iter_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyRes
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_STR.name)),
-    Value::from(to_dyn_method(hooks, IterStr())),
+    val!(to_dyn_method(hooks, IterStr())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_NEXT.name)),
-    Value::from(to_dyn_method(hooks, IterNext())),
+    val!(to_dyn_method(hooks, IterNext())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_ITER.name)),
-    Value::from(to_dyn_method(hooks, IterIter())),
+    val!(to_dyn_method(hooks, IterIter())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_MAP.name)),
-    Value::from(to_dyn_method(hooks, IterMap())),
+    val!(to_dyn_method(hooks, IterMap())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_FILTER.name)),
-    Value::from(to_dyn_method(hooks, IterFilter())),
+    val!(to_dyn_method(hooks, IterFilter())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_REDUCE.name)),
-    Value::from(to_dyn_method(hooks, IterReduce())),
+    val!(to_dyn_method(hooks, IterReduce())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_EACH.name)),
-    Value::from(to_dyn_method(hooks, IterEach())),
+    val!(to_dyn_method(hooks, IterEach())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_ZIP.name)),
-    Value::from(to_dyn_method(hooks, IterZip())),
+    val!(to_dyn_method(hooks, IterZip())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(ITER_INTO.name)),
-    Value::from(to_dyn_method(hooks, IterInto())),
+    val!(to_dyn_method(hooks, IterInto())),
   );
 
   Ok(())
@@ -131,8 +132,8 @@ impl NativeMethod for IterStr {
   }
 
   fn call(&self, hooks: &mut Hooks, this: Value, _args: &[Value]) -> CallResult {
-    Ok(Value::from(
-      hooks.manage_str(this.to_iter().name().to_string()),
+    Ok(val!(
+      hooks.manage_str(this.to_iter().name().to_string())
     ))
   }
 }
@@ -176,7 +177,7 @@ impl NativeMethod for IterMap {
     let iter = LyIterator::new(inner_iter);
     let iter = hooks.manage(iter);
 
-    Ok(Value::from(iter))
+    Ok(val!(iter))
   }
 }
 
@@ -208,11 +209,11 @@ impl LyIter for MapIterator {
 
   fn next(&mut self, hooks: &mut Hooks) -> CallResult {
     if is_falsey(self.iter.next(hooks)?) {
-      Ok(Value::from(false))
+      Ok(val!(false))
     } else {
       let current = self.iter.current();
       self.current = hooks.call(self.callable, &[current])?;
-      Ok(Value::from(true))
+      Ok(val!(true))
     }
   }
 
@@ -254,7 +255,7 @@ impl NativeMethod for IterFilter {
     let iter = LyIterator::new(inner_iter);
     let iter = hooks.manage(iter);
 
-    Ok(Value::from(iter))
+    Ok(val!(iter))
   }
 }
 
@@ -291,11 +292,11 @@ impl LyIter for FilterIterator {
 
       if !is_falsey(should_keep) {
         self.current = current;
-        return Ok(Value::from(true));
+        return Ok(val!(true));
       }
     }
 
-    Ok(Value::from(false))
+    Ok(val!(false))
   }
 
   fn size_hint(&self) -> Option<usize> {
@@ -385,7 +386,7 @@ impl NativeMethod for IterZip {
     let iter = LyIterator::new(inner_iter);
     let iter = hooks.manage(iter);
 
-    Ok(Value::from(iter))
+    Ok(val!(iter))
   }
 }
 
@@ -419,14 +420,14 @@ impl LyIter for ZipIterator {
     for iter in &mut self.iters {
       let next = iter.next(hooks)?;
       if is_falsey(next) {
-        return Ok(Value::from(false));
+        return Ok(val!(false));
       }
 
       results.push(iter.current());
     }
 
-    self.current = Value::from(results);
-    Ok(Value::from(true))
+    self.current = val!(results);
+    Ok(val!(true))
   }
 
   fn size_hint(&self) -> Option<usize> {
@@ -501,7 +502,7 @@ mod test {
       let iter = test_iter();
       let this = hooks.manage(LyIterator::new(iter));
 
-      let result = iter_str.call(&mut hooks, Value::from(this), &[]);
+      let result = iter_str.call(&mut hooks, val!(this), &[]);
       match result {
         Ok(r) => assert_eq!(&*r.to_str(), "Test Iterator"),
         Err(_) => assert!(false),
@@ -530,7 +531,7 @@ mod test {
       let iter = test_iter();
       let this = hooks.manage(LyIterator::new(iter));
 
-      let result = iter_next.call(&mut hooks, Value::from(this), &[]);
+      let result = iter_next.call(&mut hooks, val!(this), &[]);
       match result {
         Ok(r) => assert_eq!(r.to_bool(), true),
         Err(_) => assert!(false),
@@ -557,7 +558,7 @@ mod test {
 
       let iter = test_iter();
       let managed = hooks.manage(LyIterator::new(iter));
-      let this = Value::from(managed);
+      let this = val!(managed);
 
       let result = iter_iter.call(&mut hooks, this, &[]);
       match result {
@@ -587,14 +588,14 @@ mod test {
 
     #[test]
     fn call() {
-      let mut context = MockedContext::new(&[Value::from(5.0)]);
+      let mut context = MockedContext::new(&[val!(5.0)]);
       let mut hooks = Hooks::new(&mut context);
       let iter_map = IterMap();
 
       let iter = test_iter();
       let managed = hooks.manage(LyIterator::new(iter));
-      let this = Value::from(managed);
-      let fun = Value::from(hooks.manage(Closure::new(fun_from_hooks(
+      let this = val!(managed);
+      let fun = val!(hooks.manage(Closure::new(fun_from_hooks(
         &hooks.to_gc(),
         "example".to_string(),
         "module",
@@ -606,8 +607,8 @@ mod test {
       match result {
         Ok(r) => {
           let mut map_iter = r.to_iter();
-          assert_eq!(map_iter.next(&mut hooks).unwrap(), Value::from(true));
-          assert_eq!(map_iter.current(), Value::from(5.0));
+          assert_eq!(map_iter.next(&mut hooks).unwrap(), val!(true));
+          assert_eq!(map_iter.current(), val!(5.0));
         }
         Err(_) => assert!(false),
       }
@@ -634,14 +635,14 @@ mod test {
     #[test]
     fn call() {
       let mut context =
-        MockedContext::new(&[Value::from(false), Value::from(true), Value::from(true)]);
+        MockedContext::new(&[val!(false), val!(true), val!(true)]);
       let mut hooks = Hooks::new(&mut context);
       let iter_filter = IterFilter();
 
       let iter = test_iter();
       let managed = hooks.manage(LyIterator::new(iter));
-      let this = Value::from(managed);
-      let fun = Value::from(hooks.manage(Closure::new(fun_from_hooks(
+      let this = val!(managed);
+      let fun = val!(hooks.manage(Closure::new(fun_from_hooks(
         &hooks.to_gc(),
         "example".to_string(),
         "module",
@@ -653,10 +654,10 @@ mod test {
       match result {
         Ok(r) => {
           let mut filter_iter = r.to_iter();
-          assert_eq!(filter_iter.next(&mut hooks).unwrap(), Value::from(true));
-          assert_eq!(filter_iter.current(), Value::from(2.0));
-          assert_eq!(filter_iter.next(&mut hooks).unwrap(), Value::from(true));
-          assert_eq!(filter_iter.current(), Value::from(3.0));
+          assert_eq!(filter_iter.next(&mut hooks).unwrap(), val!(true));
+          assert_eq!(filter_iter.current(), val!(2.0));
+          assert_eq!(filter_iter.next(&mut hooks).unwrap(), val!(true));
+          assert_eq!(filter_iter.current(), val!(3.0));
         }
         Err(_) => assert!(false),
       }
@@ -687,19 +688,19 @@ mod test {
     #[test]
     fn call() {
       let mut context = MockedContext::new(&[
-        Value::from(false),
-        Value::from(false),
-        Value::from(false),
-        Value::from(false),
-        Value::from(10.1),
+        val!(false),
+        val!(false),
+        val!(false),
+        val!(false),
+        val!(10.1),
       ]);
       let mut hooks = Hooks::new(&mut context);
       let iter_reduce = IterReduce();
 
       let iter = test_iter();
       let managed = hooks.manage(LyIterator::new(iter));
-      let this = Value::from(managed);
-      let fun = Value::from(hooks.manage(Closure::new(fun_from_hooks(
+      let this = val!(managed);
+      let fun = val!(hooks.manage(Closure::new(fun_from_hooks(
         &hooks.to_gc(),
         "example".to_string(),
         "module",
@@ -707,7 +708,7 @@ mod test {
 
       fun.to_closure().fun.arity = Arity::Fixed(2);
 
-      let result = iter_reduce.call(&mut hooks, this, &[Value::from(0.0), fun]);
+      let result = iter_reduce.call(&mut hooks, this, &[val!(0.0), fun]);
       match result {
         Ok(r) => {
           assert!(r.is_num());
@@ -737,14 +738,14 @@ mod test {
 
     #[test]
     fn call() {
-      let mut context = MockedContext::new(&[Value::from(false); 5]);
+      let mut context = MockedContext::new(&[val!(false); 5]);
       let mut hooks = Hooks::new(&mut context);
       let iter_each = IterEach();
 
       let iter = test_iter();
       let managed = hooks.manage(LyIterator::new(iter));
-      let this = Value::from(managed);
-      let fun = Value::from(hooks.manage(Closure::new(fun_from_hooks(
+      let this = val!(managed);
+      let fun = val!(hooks.manage(Closure::new(fun_from_hooks(
         &hooks.to_gc(),
         "example".to_string(),
         "module",
@@ -779,17 +780,17 @@ mod test {
 
     #[test]
     fn call() {
-      let mut context = MockedContext::new(&[Value::from(1.0); 10]);
+      let mut context = MockedContext::new(&[val!(1.0); 10]);
       let mut hooks = Hooks::new(&mut context);
       let iter_zip = IterZip();
 
       let iter = test_iter();
       let managed = hooks.manage(LyIterator::new(iter));
-      let this = Value::from(managed);
+      let this = val!(managed);
 
       let iter2 = test_iter();
       let managed = hooks.manage(LyIterator::new(iter2));
-      let arg = Value::from(managed);
+      let arg = val!(managed);
 
       let result = iter_zip.call(&mut hooks, this, &[arg]);
       match result {
@@ -844,14 +845,14 @@ mod test {
 
     #[test]
     fn call() {
-      let mut context = MockedContext::new(&[Value::from(true); 5]);
+      let mut context = MockedContext::new(&[val!(true); 5]);
       let mut hooks = Hooks::new(&mut context);
       let iter_into = IterInto();
 
       let iter = test_iter();
       let managed = hooks.manage(LyIterator::new(iter));
-      let this = Value::from(managed);
-      let echo = Value::from(hooks.manage(Box::new(EchoFun()) as Box<dyn NativeFun>));
+      let this = val!(managed);
+      let echo = val!(hooks.manage(Box::new(EchoFun()) as Box<dyn NativeFun>));
 
       let result = iter_into.call(&mut hooks, this, &[echo]);
       match result {

--- a/laythe_lib/src/global/primitives/list.rs
+++ b/laythe_lib/src/global/primitives/list.rs
@@ -12,6 +12,7 @@ use laythe_core::{
   utils::is_falsey,
   value::{Value, VALUE_NIL},
   CallResult, LyResult,
+  val,
 };
 use laythe_env::{
   managed::{Managed, Trace},
@@ -63,7 +64,7 @@ const LIST_COLLECT: NativeMeta = NativeMeta::new(
 
 pub fn declare_list_class(hooks: &GcHooks, module: &mut Module, package: &Package) -> LyResult<()> {
   let class = default_class_inheritance(hooks, package, LIST_CLASS_NAME)?;
-  export_and_insert(hooks, module, class.name, Value::from(class))
+  export_and_insert(hooks, module, class.name, val!(class))
 }
 
 pub fn define_list_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -72,43 +73,43 @@ pub fn define_list_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyRes
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_SIZE.name)),
-    Value::from(to_dyn_method(hooks, ListSize())),
+    val!(to_dyn_method(hooks, ListSize())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_PUSH.name)),
-    Value::from(to_dyn_method(hooks, ListPush())),
+    val!(to_dyn_method(hooks, ListPush())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_POP.name)),
-    Value::from(to_dyn_method(hooks, ListPop())),
+    val!(to_dyn_method(hooks, ListPop())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_REMOVE.name)),
-    Value::from(to_dyn_method(hooks, ListRemove())),
+    val!(to_dyn_method(hooks, ListRemove())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_INDEX.name)),
-    Value::from(to_dyn_method(hooks, ListIndex())),
+    val!(to_dyn_method(hooks, ListIndex())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_INSERT.name)),
-    Value::from(to_dyn_method(hooks, ListInsert())),
+    val!(to_dyn_method(hooks, ListInsert())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_STR.name)),
-    Value::from(to_dyn_method(
+    val!(to_dyn_method(
       hooks,
       ListStr::new(hooks.manage_str(String::from(LIST_STR.name))),
     )),
@@ -117,25 +118,25 @@ pub fn define_list_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyRes
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_CLEAR.name)),
-    Value::from(to_dyn_method(hooks, ListClear())),
+    val!(to_dyn_method(hooks, ListClear())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_HAS.name)),
-    Value::from(to_dyn_method(hooks, ListHas())),
+    val!(to_dyn_method(hooks, ListHas())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(LIST_ITER.name)),
-    Value::from(to_dyn_method(hooks, ListIter())),
+    val!(to_dyn_method(hooks, ListIter())),
   );
 
   class.meta().expect("Meta class not set.").add_method(
     hooks,
     hooks.manage_str(String::from(LIST_COLLECT.name)),
-    Value::from(to_dyn_fun(hooks, ListCollect())),
+    val!(to_dyn_fun(hooks, ListCollect())),
   );
 
   Ok(())
@@ -197,7 +198,7 @@ impl NativeMethod for ListStr {
 
     // pop temporary roots and return joined string
     hooks.pop_roots(count);
-    Ok(Value::from(hooks.manage_str(formatted)))
+    Ok(val!(hooks.manage_str(formatted)))
   }
 }
 
@@ -210,7 +211,7 @@ impl NativeMethod for ListSize {
   }
 
   fn call(&self, _hooks: &mut Hooks, this: Value, _args: &[Value]) -> CallResult {
-    Ok(Value::from(this.to_list().len() as f64))
+    Ok(val!(this.to_list().len() as f64))
   }
 }
 
@@ -285,7 +286,7 @@ impl NativeMethod for ListIndex {
     let item = args[0];
     let index = this.to_list().iter().position(|x| *x == item);
 
-    Ok(index.map(|i| Value::from(i as f64)).unwrap_or(VALUE_NIL))
+    Ok(index.map(|i| val!(i as f64)).unwrap_or(VALUE_NIL))
   }
 }
 
@@ -341,7 +342,7 @@ impl NativeMethod for ListHas {
   }
 
   fn call(&self, _hooks: &mut Hooks, this: Value, args: &[Value]) -> CallResult {
-    Ok(Value::from(this.to_list().contains(&args[0])))
+    Ok(val!(this.to_list().contains(&args[0])))
   }
 }
 
@@ -358,7 +359,7 @@ impl NativeMethod for ListIter {
     let iter = LyIterator::new(inner_iter);
     let iter = hooks.manage(iter);
 
-    Ok(Value::from(iter))
+    Ok(val!(iter))
   }
 }
 
@@ -382,7 +383,7 @@ impl NativeFun for ListCollect {
       list.push(current);
     }
 
-    Ok(Value::from(hooks.manage(list)))
+    Ok(val!(hooks.manage(list)))
   }
 }
 
@@ -418,11 +419,11 @@ impl LyIter for ListIterator {
     match self.iter.next() {
       Some(value) => {
         self.current = *value;
-        Ok(Value::from(true))
+        Ok(val!(true))
       }
       None => {
         self.current = VALUE_NIL;
-        Ok(Value::from(false))
+        Ok(val!(false))
       }
     }
   }
@@ -470,9 +471,9 @@ mod test {
     fn call() {
       let gc = test_native_dependencies();
       let mut context = MockedContext::new(&[
-        Value::from(gc.manage_str("nil".to_string(), &NO_GC)),
-        Value::from(gc.manage_str("10".to_string(), &NO_GC)),
-        Value::from(gc.manage_str("[5]".to_string(), &NO_GC)),
+        val!(gc.manage_str("nil".to_string(), &NO_GC)),
+        val!(gc.manage_str("10".to_string(), &NO_GC)),
+        val!(gc.manage_str("[5]".to_string(), &NO_GC)),
       ]);
       let mut hooks = Hooks::new(&mut context);
       let list_str = ListStr::new(hooks.manage_str("str".to_string()));
@@ -481,12 +482,12 @@ mod test {
 
       let list = List::from(vec![
         VALUE_NIL,
-        Value::from(10.0),
-        Value::from(hooks.manage(List::from(vec![Value::from(5.0)]))),
+        val!(10.0),
+        val!(hooks.manage(List::from(vec![val!(5.0)]))),
       ]);
       let this = hooks.manage(list);
 
-      let result = list_str.call(&mut hooks, Value::from(this), values);
+      let result = list_str.call(&mut hooks, val!(this), values);
       match result {
         Ok(r) => assert_eq!(&*r.to_str(), "[nil, 10, [5]]"),
         Err(_) => assert!(false),
@@ -515,10 +516,10 @@ mod test {
 
       let values = &[];
 
-      let list = List::from(vec![VALUE_NIL, Value::from(10.0)]);
+      let list = List::from(vec![VALUE_NIL, val!(10.0)]);
       let this = hooks.manage(list);
 
-      let result = list_size.call(&mut hooks, Value::from(this), values);
+      let result = list_size.call(&mut hooks, val!(this), values);
       match result {
         Ok(r) => assert_eq!(r.to_num(), 2.0),
         Err(_) => assert!(false),
@@ -548,30 +549,30 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let list = List::from(vec![VALUE_NIL, Value::from(10.0)]);
+      let list = List::from(vec![VALUE_NIL, val!(10.0)]);
       let this = hooks.manage(list);
-      let list_value = Value::from(this);
+      let list_value = val!(this);
 
-      let result = list_push.call(&mut hooks, list_value, &[Value::from(false)]);
+      let result = list_push.call(&mut hooks, list_value, &[val!(false)]);
       match result {
         Ok(r) => {
           assert_eq!(r, VALUE_NIL);
           assert_eq!(list_value.to_list().len(), 3);
-          assert_eq!(list_value.to_list()[2], Value::from(false));
+          assert_eq!(list_value.to_list()[2], val!(false));
         }
         Err(_) => assert!(false),
       }
 
       let result = list_push.call(
         &mut hooks,
-        Value::from(this),
-        &[Value::from(10.3), VALUE_NIL],
+        val!(this),
+        &[val!(10.3), VALUE_NIL],
       );
       match result {
         Ok(r) => {
           assert_eq!(r, VALUE_NIL);
           assert_eq!(list_value.to_list().len(), 5);
-          assert_eq!(list_value.to_list()[3], Value::from(10.3));
+          assert_eq!(list_value.to_list()[3], val!(10.3));
           assert_eq!(list_value.to_list()[4], VALUE_NIL);
         }
         Err(_) => assert!(false),
@@ -597,9 +598,9 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let list = List::from(vec![Value::from(true)]);
+      let list = List::from(vec![val!(true)]);
       let this = hooks.manage(list);
-      let list_value = Value::from(this);
+      let list_value = val!(this);
 
       let result = list_pop.call(&mut hooks, list_value, &[]);
       match result {
@@ -643,11 +644,11 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let list = List::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
+      let list = List::from(&[VALUE_NIL, val!(10.0), val!(true)] as &[Value]);
       let this = hooks.manage(list);
-      let list_value = Value::from(this);
+      let list_value = val!(this);
 
-      let result = list_remove.call(&mut hooks, list_value, &[Value::from(1.0)]);
+      let result = list_remove.call(&mut hooks, list_value, &[val!(1.0)]);
       match result {
         Ok(r) => {
           assert_eq!(r.to_num(), 10.0);
@@ -656,13 +657,13 @@ mod test {
         Err(_) => assert!(false),
       }
 
-      let result = list_remove.call(&mut hooks, list_value, &[Value::from(-1.0)]);
+      let result = list_remove.call(&mut hooks, list_value, &[val!(-1.0)]);
       match result {
         Ok(_) => assert!(false),
         Err(_) => assert!(true),
       }
 
-      let result = list_remove.call(&mut hooks, list_value, &[Value::from(10.0)]);
+      let result = list_remove.call(&mut hooks, list_value, &[val!(10.0)]);
       match result {
         Ok(_) => assert!(false),
         Err(_) => assert!(true),
@@ -692,11 +693,11 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let list = List::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
+      let list = List::from(&[VALUE_NIL, val!(10.0), val!(true)] as &[Value]);
       let this = hooks.manage(list);
-      let list_value = Value::from(this);
+      let list_value = val!(this);
 
-      let result = list_index.call(&mut hooks, list_value, &[Value::from(10.0)]);
+      let result = list_index.call(&mut hooks, list_value, &[val!(10.0)]);
       match result {
         Ok(r) => {
           assert_eq!(r.to_num(), 1.0);
@@ -732,31 +733,31 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let list = List::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
+      let list = List::from(&[VALUE_NIL, val!(10.0), val!(true)] as &[Value]);
       let this = hooks.manage(list);
-      let list_value = Value::from(this);
+      let list_value = val!(this);
 
       let result = list_insert.call(
         &mut hooks,
         list_value,
-        &[Value::from(1.0), Value::from(false)],
+        &[val!(1.0), val!(false)],
       );
       match result {
         Ok(r) => {
           assert!(r.is_nil());
-          assert_eq!(this[1], Value::from(false));
+          assert_eq!(this[1], val!(false));
           assert_eq!(this.len(), 4);
         }
         Err(_) => assert!(false),
       }
 
-      let result = list_insert.call(&mut hooks, list_value, &[Value::from(-1.0)]);
+      let result = list_insert.call(&mut hooks, list_value, &[val!(-1.0)]);
       match result {
         Ok(_) => assert!(false),
         Err(_) => assert!(true),
       }
 
-      let result = list_insert.call(&mut hooks, list_value, &[Value::from(10.0)]);
+      let result = list_insert.call(&mut hooks, list_value, &[val!(10.0)]);
       match result {
         Ok(_) => assert!(false),
         Err(_) => assert!(true),
@@ -782,9 +783,9 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let list = List::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
+      let list = List::from(&[VALUE_NIL, val!(10.0), val!(true)] as &[Value]);
       let this = hooks.manage(list);
-      let list_value = Value::from(this);
+      let list_value = val!(this);
 
       let result = list_clear.call(&mut hooks, list_value, &[]);
       match result {
@@ -828,11 +829,11 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let list = List::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
+      let list = List::from(&[VALUE_NIL, val!(10.0), val!(true)] as &[Value]);
       let this = hooks.manage(list);
-      let list_value = Value::from(this);
+      let list_value = val!(this);
 
-      let result = list_has.call(&mut hooks, list_value, &[Value::from(10.0)]);
+      let result = list_has.call(&mut hooks, list_value, &[val!(10.0)]);
       match result {
         Ok(r) => {
           assert!(r.to_bool());
@@ -840,7 +841,7 @@ mod test {
         Err(_) => assert!(false),
       }
 
-      let result = list_has.call(&mut hooks, list_value, &[Value::from(false)]);
+      let result = list_has.call(&mut hooks, list_value, &[val!(false)]);
       match result {
         Ok(r) => {
           assert!(!r.to_bool());
@@ -868,16 +869,16 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
       let list_iter = ListIter();
 
-      let list = List::from(&[VALUE_NIL, Value::from(10.0), Value::from(true)] as &[Value]);
+      let list = List::from(&[VALUE_NIL, val!(10.0), val!(true)] as &[Value]);
       let this = hooks.manage(list);
-      let list_value = Value::from(this);
+      let list_value = val!(this);
 
       let result = list_iter.call(&mut hooks, list_value, &[]);
       match result {
         Ok(r) => {
           let mut iter = r.to_iter();
           assert_eq!(iter.current(), VALUE_NIL);
-          assert_eq!(iter.next(&mut hooks).unwrap(), Value::from(true));
+          assert_eq!(iter.next(&mut hooks).unwrap(), val!(true));
           assert_eq!(iter.current(), VALUE_NIL);
         }
         Err(_) => assert!(false),
@@ -908,7 +909,7 @@ mod test {
       let list_iter = ListCollect();
 
       let iter = test_iter();
-      let iter_value = Value::from(hooks.manage(LyIterator::new(iter)));
+      let iter_value = val!(hooks.manage(LyIterator::new(iter)));
 
       let result = list_iter.call(&mut hooks, &[iter_value]);
       match result {

--- a/laythe_lib/src/global/primitives/method.rs
+++ b/laythe_lib/src/global/primitives/method.rs
@@ -9,6 +9,7 @@ use laythe_core::{
   signature::{Arity, Parameter, ParameterKind},
   value::Value,
   CallResult, LyResult,
+  val,
 };
 use laythe_env::{
   managed::{Managed, Trace},
@@ -30,7 +31,7 @@ pub fn declare_method_class(
   package: &Package,
 ) -> LyResult<()> {
   let method_class = default_class_inheritance(hooks, package, METHOD_CLASS_NAME)?;
-  export_and_insert(hooks, module, method_class.name, Value::from(method_class))
+  export_and_insert(hooks, module, method_class.name, val!(method_class))
 }
 
 pub fn define_method_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -39,7 +40,7 @@ pub fn define_method_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyR
   class.add_method(
     hooks,
     hooks.manage_str(String::from(METHOD_NAME.name)),
-    Value::from(to_dyn_method(
+    val!(to_dyn_method(
       hooks,
       MethodName::new(hooks.manage_str(String::from(METHOD_NAME.name))),
     )),
@@ -48,7 +49,7 @@ pub fn define_method_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyR
   class.add_method(
     hooks,
     hooks.manage_str(String::from(METHOD_CALL.name)),
-    Value::from(to_dyn_method(hooks, MethodCall())),
+    val!(to_dyn_method(hooks, MethodCall())),
   );
 
   Ok(())
@@ -119,8 +120,8 @@ mod test {
     #[test]
     fn call() {
       let mut context = MockedContext::default();
-      let responses = &[Value::from(
-        context.gc.manage_str("example".to_string(), &NO_GC),
+      let responses = &[val!(
+        context.gc.manage_str("example".to_string(), &NO_GC)
       )];
       context.responses.extend_from_slice(responses);
 
@@ -131,9 +132,9 @@ mod test {
       let class = hooks.manage(Class::bare(hooks.manage_str("exampleClass".to_string())));
       let closure = hooks.manage(Closure::new(fun));
       let instance = hooks.manage(Instance::new(class));
-      let method = hooks.manage(Method::new(Value::from(instance), Value::from(closure)));
+      let method = hooks.manage(Method::new(val!(instance), val!(closure)));
 
-      let result1 = method_name.call(&mut hooks, Value::from(method), &[]);
+      let result1 = method_name.call(&mut hooks, val!(method), &[]);
 
       match result1 {
         Ok(r) => assert_eq!(&*r.to_str(), "example"),
@@ -162,16 +163,16 @@ mod test {
     #[test]
     fn call() {
       let method_call = MethodCall();
-      let mut context = MockedContext::new(&[Value::from(14.3)]);
+      let mut context = MockedContext::new(&[val!(14.3)]);
       let mut hooks = Hooks::new(&mut context);
 
       let fun = fun_from_hooks(&hooks.to_gc(), "example".to_string(), "module");
       let class = hooks.manage(Class::bare(hooks.manage_str("exampleClass".to_string())));
       let closure = hooks.manage(Closure::new(fun));
       let instance = hooks.manage(Instance::new(class));
-      let method = hooks.manage(Method::new(Value::from(instance), Value::from(closure)));
+      let method = hooks.manage(Method::new(val!(instance), val!(closure)));
 
-      let result1 = method_call.call(&mut hooks, Value::from(method), &[]);
+      let result1 = method_call.call(&mut hooks, val!(method), &[]);
 
       match result1 {
         Ok(r) => assert_eq!(r.to_num(), 14.3),

--- a/laythe_lib/src/global/primitives/native_fun.rs
+++ b/laythe_lib/src/global/primitives/native_fun.rs
@@ -9,6 +9,7 @@ use laythe_core::{
   signature::{Arity, Parameter, ParameterKind},
   value::Value,
   CallResult, LyResult,
+  val,
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -27,7 +28,7 @@ pub fn declare_native_fun_class(
   package: &Package,
 ) -> LyResult<()> {
   let class = default_class_inheritance(hooks, package, NATIVE_FUN_CLASS_NAME)?;
-  export_and_insert(hooks, module, class.name, Value::from(class))
+  export_and_insert(hooks, module, class.name, val!(class))
 }
 
 pub fn define_native_fun_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -36,13 +37,13 @@ pub fn define_native_fun_class(hooks: &GcHooks, module: &Module, _: &Package) ->
   class.add_method(
     hooks,
     hooks.manage_str(String::from(NATIVE_FUN_NAME.name)),
-    Value::from(to_dyn_method(hooks, NativeFunName())),
+    val!(to_dyn_method(hooks, NativeFunName())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(NATIVE_FUN_CALL.name)),
-    Value::from(to_dyn_method(hooks, NativeFunCall())),
+    val!(to_dyn_method(hooks, NativeFunCall())),
   );
 
   Ok(())
@@ -57,8 +58,8 @@ impl NativeMethod for NativeFunName {
   }
 
   fn call(&self, hooks: &mut Hooks, this: Value, _args: &[Value]) -> CallResult {
-    Ok(Value::from(
-      hooks.manage_str(String::from(this.to_native_fun().meta().name)),
+    Ok(val!(
+      hooks.manage_str(String::from(this.to_native_fun().meta().name))
     ))
   }
 }
@@ -101,7 +102,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let managed: Managed<Box<dyn NativeFun>> = hooks.manage(Box::new(TestNative()));
-      let result = native_fun_name.call(&mut hooks, Value::from(managed), &[]);
+      let result = native_fun_name.call(&mut hooks, val!(managed), &[]);
       match result {
         Ok(r) => assert_eq!(*r.to_str(), "test".to_string()),
         Err(_) => assert!(false),
@@ -133,7 +134,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let managed: Managed<Box<dyn NativeFun>> = hooks.manage(Box::new(TestNative()));
-      let result = native_fun_call.call(&mut hooks, Value::from(managed), &[]);
+      let result = native_fun_call.call(&mut hooks, val!(managed), &[]);
       match result {
         Ok(r) => assert!(r.is_nil()),
         Err(_) => assert!(false),

--- a/laythe_lib/src/global/primitives/native_method.rs
+++ b/laythe_lib/src/global/primitives/native_method.rs
@@ -9,6 +9,7 @@ use laythe_core::{
   signature::{Arity, Parameter, ParameterKind},
   value::Value,
   CallResult, LyResult,
+  val,
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -27,7 +28,7 @@ pub fn declare_native_method_class(
   package: &Package,
 ) -> LyResult<()> {
   let class = default_class_inheritance(hooks, package, NATIVE_METHOD_CLASS_NAME)?;
-  export_and_insert(hooks, module, class.name, Value::from(class))
+  export_and_insert(hooks, module, class.name, val!(class))
 }
 
 pub fn define_native_method_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -36,13 +37,13 @@ pub fn define_native_method_class(hooks: &GcHooks, module: &Module, _: &Package)
   class.add_method(
     hooks,
     hooks.manage_str(String::from(NATIVE_METHOD_NAME.name)),
-    Value::from(to_dyn_method(hooks, NativeMethodName())),
+    val!(to_dyn_method(hooks, NativeMethodName())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(NATIVE_METHOD_CALL.name)),
-    Value::from(to_dyn_method(hooks, NativeMethodCall())),
+    val!(to_dyn_method(hooks, NativeMethodCall())),
   );
 
   Ok(())
@@ -57,7 +58,7 @@ impl NativeMethod for NativeMethodName {
   }
 
   fn call(&self, hooks: &mut Hooks, this: Value, _args: &[Value]) -> CallResult {
-    Ok(Value::from(hooks.manage_str(String::from(
+    Ok(val!(hooks.manage_str(String::from(
       this.to_native_method().meta().name,
     ))))
   }
@@ -100,7 +101,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let managed: Managed<Box<dyn NativeMethod>> = hooks.manage(Box::new(NativeMethodName()));
-      let result = native_method_name.call(&mut hooks, Value::from(managed), &[]);
+      let result = native_method_name.call(&mut hooks, val!(managed), &[]);
       match result {
         Ok(r) => assert_eq!(*r.to_str(), "name".to_string()),
         Err(_) => assert!(false),
@@ -132,7 +133,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let managed: Managed<Box<dyn NativeFun>> = hooks.manage(Box::new(TestNative()));
-      let result = native_fun_call.call(&mut hooks, Value::from(managed), &[]);
+      let result = native_fun_call.call(&mut hooks, val!(managed), &[]);
       match result {
         Ok(r) => assert!(r.is_nil()),
         Err(_) => assert!(false),

--- a/laythe_lib/src/global/primitives/nil.rs
+++ b/laythe_lib/src/global/primitives/nil.rs
@@ -9,6 +9,7 @@ use laythe_core::{
   signature::Arity,
   value::Value,
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -17,7 +18,7 @@ const NIL_STR: NativeMeta = NativeMeta::new("str", Arity::Fixed(0), &[]);
 
 pub fn declare_nil_class(hooks: &GcHooks, module: &mut Module, package: &Package) -> LyResult<()> {
   let class = default_class_inheritance(hooks, package, NIL_CLASS_NAME)?;
-  export_and_insert(hooks, module, class.name, Value::from(class))
+  export_and_insert(hooks, module, class.name, val!(class))
 }
 
 pub fn define_nil_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -26,7 +27,7 @@ pub fn define_nil_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResu
   class.add_method(
     hooks,
     hooks.manage_str(String::from(NIL_STR.name)),
-    Value::from(to_dyn_method(hooks, NilStr::new())),
+    val!(to_dyn_method(hooks, NilStr::new())),
   );
 
   Ok(())
@@ -49,7 +50,7 @@ impl NativeMethod for NilStr {
   }
 
   fn call(&self, hooks: &mut Hooks, _this: Value, _args: &[Value]) -> CallResult {
-    Ok(Value::from(hooks.manage_str("nil".to_string())))
+    Ok(val!(hooks.manage_str("nil".to_string())))
   }
 }
 

--- a/laythe_lib/src/global/primitives/object.rs
+++ b/laythe_lib/src/global/primitives/object.rs
@@ -8,6 +8,7 @@ use laythe_core::{
   signature::{Arity, Parameter, ParameterKind},
   value::Value,
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -23,7 +24,7 @@ pub fn declare_object_class(hooks: &GcHooks, self_module: &mut Module) -> LyResu
   let name = hooks.manage_str(String::from(OBJECT_CLASS_NAME));
   let class = hooks.manage(Class::bare(name));
 
-  export_and_insert(hooks, self_module, name, Value::from(class))
+  export_and_insert(hooks, self_module, name, val!(class))
 }
 
 pub fn define_object_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -32,7 +33,7 @@ pub fn define_object_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyR
   class.add_method(
     &hooks,
     hooks.manage_str(String::from(OBJECT_EQUALS.name)),
-    Value::from(to_dyn_method(hooks, ObjectEquals())),
+    val!(to_dyn_method(hooks, ObjectEquals())),
   );
 
   Ok(())
@@ -47,7 +48,7 @@ impl NativeMethod for ObjectEquals {
   }
 
   fn call(&self, _hooks: &mut Hooks, this: Value, args: &[Value]) -> CallResult {
-    Ok(Value::from(this == args[0]))
+    Ok(val!(this == args[0]))
   }
 }
 
@@ -77,9 +78,9 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let ten_1 = Value::from(10.0);
-      let b_false = Value::from(false);
-      let ten_2 = Value::from(10.0);
+      let ten_1 = val!(10.0);
+      let b_false = val!(false);
+      let ten_2 = val!(10.0);
 
       let result1 = bool_str.call(&mut hooks, ten_1, &[ten_2]);
       let result2 = bool_str.call(&mut hooks, ten_2, &[b_false]);

--- a/laythe_lib/src/global/primitives/string.rs
+++ b/laythe_lib/src/global/primitives/string.rs
@@ -9,6 +9,7 @@ use laythe_core::{
   signature::{Arity, Parameter, ParameterKind},
   value::Value,
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -26,7 +27,7 @@ pub fn declare_string_class(
   package: &Package,
 ) -> LyResult<()> {
   let class = default_class_inheritance(hooks, package, STRING_CLASS_NAME)?;
-  export_and_insert(hooks, module, class.name, Value::from(class))
+  export_and_insert(hooks, module, class.name, val!(class))
 }
 
 pub fn define_string_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<()> {
@@ -35,13 +36,13 @@ pub fn define_string_class(hooks: &GcHooks, module: &Module, _: &Package) -> LyR
   class.add_method(
     hooks,
     hooks.manage_str(String::from(STRING_STR.name)),
-    Value::from(to_dyn_method(hooks, StringStr())),
+    val!(to_dyn_method(hooks, StringStr())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(STRING_HAS.name)),
-    Value::from(to_dyn_method(hooks, StringHas())),
+    val!(to_dyn_method(hooks, StringHas())),
   );
 
   Ok(())
@@ -70,7 +71,7 @@ impl NativeMethod for StringHas {
 
   fn call(&self, _vhooks: &mut Hooks, this: Value, args: &[Value]) -> CallResult {
     let str = this.to_str();
-    Ok(Value::from(str.contains(&*args[0].to_str())))
+    Ok(val!(str.contains(&*args[0].to_str())))
   }
 }
 
@@ -96,7 +97,7 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let this = Value::from(hooks.manage_str("test".to_string()));
+      let this = val!(hooks.manage_str("test".to_string()));
       let result = string_str.call(&mut hooks, this, &[]);
       match result {
         Ok(r) => assert_eq!(*r.to_str(), "test".to_string()),
@@ -123,9 +124,9 @@ mod test {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
-      let this = Value::from(hooks.manage_str("some string".to_string()));
-      let contained = Value::from(hooks.manage_str("ome".to_string()));
-      let not_contained = Value::from(hooks.manage_str("other".to_string()));
+      let this = val!(hooks.manage_str("some string".to_string()));
+      let contained = val!(hooks.manage_str("ome".to_string()));
+      let not_contained = val!(hooks.manage_str("other".to_string()));
 
       let result = string_str.call(&mut hooks, this, &[contained]);
       match result {

--- a/laythe_lib/src/global/time/clock.rs
+++ b/laythe_lib/src/global/time/clock.rs
@@ -6,6 +6,7 @@ use laythe_core::{
   signature::Arity,
   value::Value,
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -16,7 +17,7 @@ pub fn declare_clock_funs(hooks: &GcHooks, module: &mut Module) -> LyResult<()> 
     hooks,
     module,
     hooks.manage_str(CLOCK_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(Clock()) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(Clock()) as Box<dyn NativeFun>)),
   )
 }
 
@@ -33,7 +34,7 @@ impl NativeFun for Clock {
     let time = io.time();
 
     match time.elapsed() {
-      Ok(elapsed) => Ok(Value::from((elapsed.as_micros() as f64) / 1000000.0)),
+      Ok(elapsed) => Ok(val!((elapsed.as_micros() as f64) / 1000000.0)),
       Err(e) => hooks.error(format!("clock failed {}", e)),
     }
   }

--- a/laythe_lib/src/io/stdio/stdin.rs
+++ b/laythe_lib/src/io/stdio/stdin.rs
@@ -10,6 +10,7 @@ use laythe_core::{
   signature::Arity,
   value::Value,
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -27,7 +28,7 @@ pub fn declare_stdin(hooks: &GcHooks, module: &mut Module, std: &Package) -> LyR
     hooks,
     module,
     hooks.manage_str(STDIN_INSTANCE_NAME.to_string()),
-    Value::from(instance),
+    val!(instance),
   )
 }
 
@@ -38,13 +39,13 @@ pub fn define_stdin(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<(
   class.add_method(
     hooks,
     hooks.manage_str(String::from(STDIN_READ.name)),
-    Value::from(to_dyn_method(hooks, StdinRead())),
+    val!(to_dyn_method(hooks, StdinRead())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(STDIN_READ_LINE.name)),
-    Value::from(to_dyn_method(hooks, StdinReadLine())),
+    val!(to_dyn_method(hooks, StdinReadLine())),
   );
 
   Ok(())
@@ -65,7 +66,7 @@ impl NativeMethod for StdinRead {
 
     let mut buf = String::new();
     match stdin.read_to_string(&mut buf) {
-      Ok(_) => Ok(Value::from(hooks.manage_str(buf))),
+      Ok(_) => Ok(val!(hooks.manage_str(buf))),
       Err(err) => Err(hooks.make_error(err.to_string())),
     }
   }
@@ -90,7 +91,7 @@ impl NativeMethod for StdinReadLine {
         if buf.ends_with('\n') {
           buf.pop();
         }
-        Ok(Value::from(hooks.manage_str(buf)))
+        Ok(val!(hooks.manage_str(buf)))
       }
       Err(err) => Err(hooks.make_error(err.to_string())),
     }

--- a/laythe_lib/src/io/stdio/stdout.rs
+++ b/laythe_lib/src/io/stdio/stdout.rs
@@ -10,6 +10,7 @@ use laythe_core::{
   signature::{Arity, Parameter, ParameterKind},
   value::{Value, VALUE_NIL},
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -38,7 +39,7 @@ pub fn declare_stdout(hooks: &GcHooks, module: &mut Module, std: &Package) -> Ly
     hooks,
     module,
     hooks.manage_str(STDOUT_INSTANCE_NAME.to_string()),
-    Value::from(instance),
+    val!(instance),
   )
 }
 
@@ -49,19 +50,19 @@ pub fn define_stdout(hooks: &GcHooks, module: &Module, _: &Package) -> LyResult<
   class.add_method(
     hooks,
     hooks.manage_str(String::from(STDOUT_WRITE.name)),
-    Value::from(to_dyn_method(hooks, StdoutWrite())),
+    val!(to_dyn_method(hooks, StdoutWrite())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(STDOUT_WRITELN.name)),
-    Value::from(to_dyn_method(hooks, StdoutWriteln())),
+    val!(to_dyn_method(hooks, StdoutWriteln())),
   );
 
   class.add_method(
     hooks,
     hooks.manage_str(String::from(STDOUT_FLUSH.name)),
-    Value::from(to_dyn_method(hooks, StdoutFlush())),
+    val!(to_dyn_method(hooks, StdoutFlush())),
   );
 
   Ok(())
@@ -156,7 +157,7 @@ mod test {
       let mut context = MockedContext::new_with_io(&stdio_container);
       let mut hooks = Hooks::new(&mut context);
 
-      let string = Value::from(hooks.manage_str("some string".to_string()));
+      let string = val!(hooks.manage_str("some string".to_string()));
       let result = stdout_write.call(&mut hooks, VALUE_NIL, &[string]);
 
       assert!(result.is_ok());
@@ -194,7 +195,7 @@ mod test {
       let mut context = MockedContext::new_with_io(&stdio_container);
       let mut hooks = Hooks::new(&mut context);
 
-      let string = Value::from(hooks.manage_str("some string".to_string()));
+      let string = val!(hooks.manage_str("some string".to_string()));
       let result = stdout_write.call(&mut hooks, VALUE_NIL, &[string]);
 
       assert!(result.is_ok());

--- a/laythe_lib/src/math/utils.rs
+++ b/laythe_lib/src/math/utils.rs
@@ -6,6 +6,7 @@ use laythe_core::{
   signature::{Arity, Parameter, ParameterKind},
   value::Value,
   CallResult, LyResult,
+  val
 };
 use laythe_env::{managed::Trace, stdio::Stdio};
 
@@ -47,56 +48,56 @@ pub fn declare_math_module(hooks: &GcHooks, self_module: &mut Module) -> LyResul
     hooks,
     self_module,
     hooks.manage_str(PI.to_string()),
-    Value::from(std::f64::consts::PI),
+    val!(std::f64::consts::PI),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(E.to_string()),
-    Value::from(std::f64::consts::E),
+    val!(std::f64::consts::E),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(SIN_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(Sin()) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(Sin()) as Box<dyn NativeFun>)),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(COS_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(Cos()) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(Cos()) as Box<dyn NativeFun>)),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(LN_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(Ln()) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(Ln()) as Box<dyn NativeFun>)),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(ABS_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(Abs()) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(Abs()) as Box<dyn NativeFun>)),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(REM_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(Rem()) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(Rem()) as Box<dyn NativeFun>)),
   )?;
 
   export_and_insert(
     hooks,
     self_module,
     hooks.manage_str(RAND_META.name.to_string()),
-    Value::from(hooks.manage(Box::new(Rand()) as Box<dyn NativeFun>)),
+    val!(hooks.manage(Box::new(Rand()) as Box<dyn NativeFun>)),
   )
 }
 
@@ -114,13 +115,13 @@ impl NativeFun for Sin {
 
   #[cfg(not(feature = "wasm"))]
   fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> CallResult {
-    Ok(Value::from(args[0].to_num().sin()))
+    Ok(val!(args[0].to_num().sin()))
   }
 
   #[cfg(feature = "wasm")]
   fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> CallResult {
     use js_sys::Math::sin;
-    Ok(Value::from(sin(args[0].to_num())))
+    Ok(val!(sin(args[0].to_num())))
   }
 }
 
@@ -134,13 +135,13 @@ impl NativeFun for Cos {
 
   #[cfg(not(feature = "wasm"))]
   fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> CallResult {
-    Ok(Value::from(args[0].to_num().cos()))
+    Ok(val!(args[0].to_num().cos()))
   }
 
   #[cfg(feature = "wasm")]
   fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> CallResult {
     use js_sys::Math::cos;
-    Ok(Value::from(cos(args[0].to_num())))
+    Ok(val!(cos(args[0].to_num())))
   }
 }
 
@@ -153,7 +154,7 @@ impl NativeFun for Ln {
   }
 
   fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> CallResult {
-    Ok(Value::from(args[0].to_num().ln()))
+    Ok(val!(args[0].to_num().ln()))
   }
 }
 
@@ -166,7 +167,7 @@ impl NativeFun for Abs {
   }
 
   fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> CallResult {
-    Ok(Value::from(args[0].to_num().abs()))
+    Ok(val!(args[0].to_num().abs()))
   }
 }
 
@@ -179,7 +180,7 @@ impl NativeFun for Rem {
   }
 
   fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> CallResult {
-    Ok(Value::from(args[0].to_num() % args[1].to_num()))
+    Ok(val!(args[0].to_num() % args[1].to_num()))
   }
 }
 
@@ -196,13 +197,13 @@ impl NativeFun for Rand {
     use rand::Rng;
     let mut rng = rand::thread_rng();
     let val: f64 = rng.gen_range(0.0, 1.0);
-    Ok(Value::from(val))
+    Ok(val!(val))
   }
 
   #[cfg(feature = "wasm")]
   fn call(&self, _hooks: &mut Hooks, _args: &[Value]) -> CallResult {
     use js_sys::Math::random;
-    Ok(Value::from(random()))
+    Ok(val!(random()))
   }
 }
 
@@ -233,12 +234,12 @@ mod test {
 
       let abs = Abs();
 
-      match abs.call(&mut hooks, &[Value::from(-2.0)]) {
+      match abs.call(&mut hooks, &[val!(-2.0)]) {
         Ok(res) => assert_eq!(res.to_num(), 2.0),
         Err(_) => panic!(),
       };
 
-      match abs.call(&mut hooks, &[Value::from(2.0)]) {
+      match abs.call(&mut hooks, &[val!(2.0)]) {
         Ok(res) => assert_eq!(res.to_num(), 2.0),
         Err(_) => panic!(),
       };
@@ -270,21 +271,21 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let rem = Rem();
-      let values = &[Value::from(3.0), Value::from(2.0)];
+      let values = &[val!(3.0), val!(2.0)];
 
       match rem.call(&mut hooks, values) {
         Ok(res) => assert_eq!(res.to_num(), 1.0),
         Err(_) => panic!(),
       };
 
-      let values = &[Value::from(-3.0), Value::from(2.0)];
+      let values = &[val!(-3.0), val!(2.0)];
 
       match rem.call(&mut hooks, values) {
         Ok(res) => assert_eq!(res.to_num(), -1.0),
         Err(_) => panic!(),
       };
 
-      let values = &[Value::from(3.0), Value::from(-2.0)];
+      let values = &[val!(3.0), val!(-2.0)];
 
       match rem.call(&mut hooks, values) {
         Ok(res) => assert_eq!(res.to_num(), 1.0),
@@ -314,7 +315,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let sin = Sin();
-      let values = &[Value::from(std::f64::consts::PI)];
+      let values = &[val!(std::f64::consts::PI)];
 
       match sin.call(&mut hooks, values) {
         Ok(res) => assert!(res.to_num().abs() < 0.0000001),
@@ -344,7 +345,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let cos = Cos();
-      let values = &[Value::from(std::f64::consts::FRAC_PI_2)];
+      let values = &[val!(std::f64::consts::FRAC_PI_2)];
 
       match cos.call(&mut hooks, values) {
         Ok(res) => assert!(res.to_num().abs() < 0.0000001),
@@ -374,7 +375,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
 
       let ln = Ln();
-      let values = &[Value::from(std::f64::consts::E)];
+      let values = &[val!(std::f64::consts::E)];
 
       match ln.call(&mut hooks, values) {
         Ok(res) => assert!((res.to_num() - 1.0).abs() < 0.0000001),

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -121,7 +121,7 @@ mod test {
     object::Fun,
     signature::Arity,
     value::{Value, ValueKind},
-    CallResult, LyError,
+    CallResult, LyError, val,
   };
   use laythe_env::{
     io::Io,
@@ -350,16 +350,16 @@ mod test {
     }
 
     fn current(&self) -> Value {
-      Value::from(self.current as f64)
+      val!(self.current as f64)
     }
 
     fn next(&mut self, _hooks: &mut Hooks) -> CallResult {
       if self.current > 4 {
-        return Ok(Value::from(false));
+        return Ok(val!(false));
       }
 
       self.current += 1;
-      Ok(Value::from(true))
+      Ok(val!(true))
     }
 
     fn size_hint(&self) -> Option<usize> {

--- a/laythe_vm/src/compiler.rs
+++ b/laythe_vm/src/compiler.rs
@@ -9,7 +9,7 @@ use laythe_core::{
   object::{Fun, FunKind},
   object::{Map, TryBlock},
   signature::Arity,
-  value::Value,
+  value::Value, val
 };
 use laythe_env::{
   managed::{Manage, Managed, Trace},
@@ -524,7 +524,7 @@ impl<'a, 's> Compiler<'a, 's> {
     fun_compiler.end_compiler();
     let upvalue_count = fun_compiler.fun.upvalue_count;
 
-    let index = self.make_constant(Value::from(fun_compiler.fun));
+    let index = self.make_constant(val!(fun_compiler.fun));
     self.emit_byte(AlignedByteCode::Closure(index));
 
     // emit upvalue index instructions
@@ -807,7 +807,7 @@ impl<'a, 's> Compiler<'a, 's> {
       .parser
       .consume(TokenKind::String, "Expected path string after 'from'.");
     let string = self.hooks.manage_str(copy_string(&self.parser.previous));
-    let value = Value::from(string);
+    let value = val!(string);
     let path = self.make_constant(value);
     self
       .parser
@@ -1043,7 +1043,7 @@ impl<'a, 's> Compiler<'a, 's> {
     let upvalue_count = fun_compiler.fun.upvalue_count;
     // let boxed_fun = Box::new(fun_compiler.fun);
 
-    let index = self.make_constant(Value::from(fun_compiler.fun));
+    let index = self.make_constant(val!(fun_compiler.fun));
     self.emit_byte(AlignedByteCode::Closure(index));
 
     // emit upvalue index instructions
@@ -1099,13 +1099,13 @@ impl<'a, 's> Compiler<'a, 's> {
 
   /// Compile a number literal
   fn number(&mut self) {
-    let value = Value::from(
+    let value = val!(
       self
         .parser
         .previous
         .lexeme
         .parse::<f64>()
-        .expect("Unable to parse float"),
+        .expect("Unable to parse float")
     );
     self.emit_constant(value);
   }
@@ -1118,7 +1118,7 @@ impl<'a, 's> Compiler<'a, 's> {
   /// Compile a string literal
   fn string(&mut self) {
     let string = self.hooks.manage_str(copy_string(&self.parser.previous));
-    let value = Value::from(string);
+    let value = val!(string);
     self.emit_constant(value)
   }
 
@@ -1390,7 +1390,7 @@ impl<'a, 's> Compiler<'a, 's> {
   /// Generate a constant from the provided identifier token
   fn identifer_constant(&mut self, name: Token) -> u16 {
     let identifer = self.hooks.manage_str(name.lexeme);
-    self.make_constant(Value::from(identifer))
+    self.make_constant(val!(identifer))
   }
 
   fn add_local(&mut self, name: Token) {


### PR DESCRIPTION
## Problem
As I continue to work on this project there is ever increasing boiler plate, more complex struct ect.

In order to combat this I've tackled the lowest hanging fruit and implemented a `val!`macro that is simply a shorthand for `Value::from`. I think it would be good to continue down this path of adding macros to make testing and implementing features easy.