### PR TITLE
Move field keys onto class

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -100,8 +100,7 @@
         }
       },
       "args": [
-        "lox_interpreter/lox.ly",
-        "../../../craftinginterpreters/test/benchmark/binary_trees.lox"
+        "language/inheritance/set_fields_from_base_class.lay"
       ],
       "sourceLanguages": ["rust"],
       "cwd": "${workspaceFolder}/laythe_vm/fixture",

--- a/laythe_core/src/chunk.rs
+++ b/laythe_core/src/chunk.rs
@@ -129,6 +129,9 @@ pub enum AlignedByteCode {
   /// Create a method
   Method(u16),
 
+  /// Create a field
+  Field(u16),
+
   /// Create a static method
   StaticMethod(u16),
 
@@ -207,6 +210,7 @@ impl AlignedByteCode {
       }
       Self::Closure(slot) => push_op_u16(code, ByteCode::Closure, slot),
       Self::Method(slot) => push_op_u16(code, ByteCode::Method, slot),
+      Self::Field(slot) => push_op_u16(code, ByteCode::Field, slot),
       Self::StaticMethod(slot) => push_op_u16(code, ByteCode::StaticMethod, slot),
       Self::Class(slot) => push_op_u16(code, ByteCode::Class, slot),
       Self::GetSuper(slot) => push_op_u16(code, ByteCode::GetSuper, slot),
@@ -327,6 +331,10 @@ impl AlignedByteCode {
       ),
       ByteCode::Method => (
         AlignedByteCode::Method(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Field => (
+        AlignedByteCode::Field(decode_u16(&store[offset + 1..offset + 3])),
         offset + 3,
       ),
       ByteCode::StaticMethod => (
@@ -475,6 +483,9 @@ pub enum ByteCode {
 
   /// Create a method
   Method,
+
+  /// Create a field
+  Field,
 
   /// Create a static method
   StaticMethod,
@@ -764,6 +775,7 @@ mod test {
         (4, AlignedByteCode::SuperInvoke((2105, 15))),
         (3, AlignedByteCode::Closure(3638)),
         (3, AlignedByteCode::Method(188)),
+        (3, AlignedByteCode::Field(6634)),
         (3, AlignedByteCode::StaticMethod(4912)),
         (3, AlignedByteCode::Class(64136)),
         (3, AlignedByteCode::GetSuper(24)),

--- a/laythe_core/src/dynamic_map.rs
+++ b/laythe_core/src/dynamic_map.rs
@@ -48,6 +48,13 @@ impl<K: Ord + Hash, V> DynamicMap<K, V> {
     }
   }
 
+  pub fn len(&self) -> usize {
+    match self {
+      Self::Linear(linear) => linear.len(),
+      Self::Hash(hash) => hash.len(),
+    }
+  }
+
   pub fn capacity(&self) -> usize {
     match self {
       Self::Linear(linear) => linear.capacity(),

--- a/laythe_core/src/module.rs
+++ b/laythe_core/src/module.rs
@@ -77,7 +77,10 @@ impl Module {
         self.name()
       ))
     } else {
-      hooks.grow(self, |module| module.exports.insert(name));
+      hooks.grow(self, |module| {
+        module.exports.insert(name);
+      });
+      self.module_class.add_field(hooks, name);
       Ok(())
     }
   }
@@ -91,7 +94,6 @@ impl Module {
 
     self.exports.iter().for_each(|export| {
       import.set_field(
-        hooks,
         *export,
         *self
           .symbols

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -811,43 +811,6 @@ mod unboxed {
       }
     }
   }
-
-  #[cfg(test)]
-  mod test {
-    use super::*;
-    use laythe_env::managed::Allocation;
-    use std::ptr::NonNull;
-
-    fn example_each(string: Managed<SmolStr>) -> Vec<Value> {
-      vec![
-        Value::Bool(true),
-        Value::Nil,
-        Value::Number(10.0),
-        Value::String(string),
-      ]
-    }
-
-    #[test]
-    fn test_diff_type_no_equal() {
-      // let string = "example";
-      let mut string_alloc = Box::new(Allocation::new("data".to_string()));
-
-      // "blah".to_string().into_boxed_str();
-      let string_ptr = unsafe { NonNull::new_unchecked(&mut *string_alloc) };
-      let managed_string = Managed::from(string_ptr);
-
-      let examples = example_each(managed_string);
-      for i in 0..examples.len() {
-        for j in 0..examples.len() {
-          if i == j {
-            assert_eq!(examples[i] == examples[j], true);
-          } else {
-            assert_eq!(examples[i] == examples[j], false);
-          }
-        }
-      }
-    }
-  }
 }
 
 #[cfg(feature = "nan_boxing")]

--- a/laythe_lib/src/lib.rs
+++ b/laythe_lib/src/lib.rs
@@ -1,16 +1,16 @@
 #![deny(clippy::all)]
+mod env;
 pub mod global;
 mod io;
 mod math;
-mod env;
 mod support;
 
+use env::env_module;
 use global::add_global_module;
 use io::io_package;
 use laythe_core::{hooks::GcHooks, package::Package, LyResult};
 use laythe_env::managed::Managed;
 use math::math_module;
-use env::env_module;
 
 #[macro_export]
 macro_rules! native {
@@ -84,7 +84,7 @@ mod test {
     package.entities().for_each(|(_key, entity)| match entity {
       PackageEntity::Module(module) => {
         let import = module.import(hooks);
-        import.fields().for_each(|(_key, symbol)| {
+        import.fields().iter().for_each(|symbol| {
           let option = match symbol.kind() {
             ValueKind::Native => Some(symbol.to_native().meta().clone()),
             _ => None,

--- a/laythe_vm/fixture/language/class/bro.lay
+++ b/laythe_vm/fixture/language/class/bro.lay
@@ -1,0 +1,9 @@
+class Dude {
+  a;
+  b;
+  c;
+
+  init() {
+    self.bro = 10;
+  }
+}

--- a/laythe_vm/fixture/language/field/call_function_field.lay
+++ b/laythe_vm/fixture/language/field/call_function_field.lay
@@ -1,15 +1,16 @@
-class Foo {}
-
-fn bar(a, b) {
-  print("bar");
-  print(a);
-  print(b);
+class Foo {
+  init(bar) {
+    self.bar = bar;
+  }
 }
 
-let foo = Foo();
-foo.bar = bar;
+fn bar(a, b) {
+  return ["bar", a, b];
+}
 
-foo.bar(1, 2);
-// expect: bar
-// expect: 1
-// expect: 2
+let foo = Foo(bar);
+
+let result = foo.bar(1, 2);
+assertEq(result[0], "bar");
+assertEq(result[1], 1);
+assertEq(result[2], 2);

--- a/laythe_vm/fixture/language/field/many.lay
+++ b/laythe_vm/fixture/language/field/many.lay
@@ -1,4 +1,86 @@
-class Foo {}
+class Foo {
+  init() {
+    self.bilberry = nil;
+    self.lime = nil;
+    self.elderberry = nil;
+    self.raspberry = nil;
+    self.gooseberry = nil;
+    self.longan = nil;
+    self.mandarine = nil;
+    self.kiwifruit = nil;
+    self.orange = nil;
+    self.pomegranate = nil;
+    self.tomato = nil;
+    self.banana = nil;
+    self.juniper = nil;
+    self.damson = nil;
+    self.blackcurrant = nil;
+    self.peach = nil;
+    self.grape = nil;
+    self.mango = nil;
+    self.redcurrant = nil;
+    self.watermelon = nil;
+    self.plumcot = nil;
+    self.papaya = nil;
+    self.cloudberry = nil;
+    self.rambutan = nil;
+    self.salak = nil;
+    self.physalis = nil;
+    self.huckleberry = nil;
+    self.coconut = nil;
+    self.date = nil;
+    self.tamarind = nil;
+    self.lychee = nil;
+    self.raisin = nil;
+    self.apple = nil;
+    self.avocado = nil;
+    self.nectarine = nil;
+    self.pomelo = nil;
+    self.melon = nil;
+    self.currant = nil;
+    self.plum = nil;
+    self.persimmon = nil;
+    self.olive = nil;
+    self.cranberry = nil;
+    self.boysenberry = nil;
+    self.blackberry = nil;
+    self.passionfruit = nil;
+    self.mulberry = nil;
+    self.marionberry = nil;
+    self.plantain = nil;
+    self.lemon = nil;
+    self.yuzu = nil;
+    self.loquat = nil;
+    self.kumquat = nil;
+    self.salmonberry = nil;
+    self.tangerine = nil;
+    self.durian = nil;
+    self.pear = nil;
+    self.cantaloupe = nil;
+    self.quince = nil;
+    self.guava = nil;
+    self.strawberry = nil;
+    self.nance = nil;
+    self.apricot = nil;
+    self.jambul = nil;
+    self.grapefruit = nil;
+    self.clementine = nil;
+    self.jujube = nil;
+    self.cherry = nil;
+    self.feijoa = nil;
+    self.jackfruit = nil;
+    self.fig = nil;
+    self.cherimoya = nil;
+    self.pineapple = nil;
+    self.blueberry = nil;
+    self.jabuticaba = nil;
+    self.miracle = nil;
+    self.dragonfruit = nil;
+    self.satsuma = nil;
+    self.tamarillo = nil;
+    self.honeydew = nil;
+  }
+}
 
 let foo = Foo();
 fn setFields() {
@@ -86,85 +168,85 @@ fn setFields() {
 setFields();
 
 fn printFields() {
-  print(foo.apple); // expect: apple
-  print(foo.apricot); // expect: apricot
-  print(foo.avocado); // expect: avocado
-  print(foo.banana); // expect: banana
-  print(foo.bilberry); // expect: bilberry
-  print(foo.blackberry); // expect: blackberry
-  print(foo.blackcurrant); // expect: blackcurrant
-  print(foo.blueberry); // expect: blueberry
-  print(foo.boysenberry); // expect: boysenberry
-  print(foo.cantaloupe); // expect: cantaloupe
-  print(foo.cherimoya); // expect: cherimoya
-  print(foo.cherry); // expect: cherry
-  print(foo.clementine); // expect: clementine
-  print(foo.cloudberry); // expect: cloudberry
-  print(foo.coconut); // expect: coconut
-  print(foo.cranberry); // expect: cranberry
-  print(foo.currant); // expect: currant
-  print(foo.damson); // expect: damson
-  print(foo.date); // expect: date
-  print(foo.dragonfruit); // expect: dragonfruit
-  print(foo.durian); // expect: durian
-  print(foo.elderberry); // expect: elderberry
-  print(foo.feijoa); // expect: feijoa
-  print(foo.fig); // expect: fig
-  print(foo.gooseberry); // expect: gooseberry
-  print(foo.grape); // expect: grape
-  print(foo.grapefruit); // expect: grapefruit
-  print(foo.guava); // expect: guava
-  print(foo.honeydew); // expect: honeydew
-  print(foo.huckleberry); // expect: huckleberry
-  print(foo.jabuticaba); // expect: jabuticaba
-  print(foo.jackfruit); // expect: jackfruit
-  print(foo.jambul); // expect: jambul
-  print(foo.jujube); // expect: jujube
-  print(foo.juniper); // expect: juniper
-  print(foo.kiwifruit); // expect: kiwifruit
-  print(foo.kumquat); // expect: kumquat
-  print(foo.lemon); // expect: lemon
-  print(foo.lime); // expect: lime
-  print(foo.longan); // expect: longan
-  print(foo.loquat); // expect: loquat
-  print(foo.lychee); // expect: lychee
-  print(foo.mandarine); // expect: mandarine
-  print(foo.mango); // expect: mango
-  print(foo.marionberry); // expect: marionberry
-  print(foo.melon); // expect: melon
-  print(foo.miracle); // expect: miracle
-  print(foo.mulberry); // expect: mulberry
-  print(foo.nance); // expect: nance
-  print(foo.nectarine); // expect: nectarine
-  print(foo.olive); // expect: olive
-  print(foo.orange); // expect: orange
-  print(foo.papaya); // expect: papaya
-  print(foo.passionfruit); // expect: passionfruit
-  print(foo.peach); // expect: peach
-  print(foo.pear); // expect: pear
-  print(foo.persimmon); // expect: persimmon
-  print(foo.physalis); // expect: physalis
-  print(foo.pineapple); // expect: pineapple
-  print(foo.plantain); // expect: plantain
-  print(foo.plum); // expect: plum
-  print(foo.plumcot); // expect: plumcot
-  print(foo.pomegranate); // expect: pomegranate
-  print(foo.pomelo); // expect: pomelo
-  print(foo.quince); // expect: quince
-  print(foo.raisin); // expect: raisin
-  print(foo.rambutan); // expect: rambutan
-  print(foo.raspberry); // expect: raspberry
-  print(foo.redcurrant); // expect: redcurrant
-  print(foo.salak); // expect: salak
-  print(foo.salmonberry); // expect: salmonberry
-  print(foo.satsuma); // expect: satsuma
-  print(foo.strawberry); // expect: strawberry
-  print(foo.tamarillo); // expect: tamarillo
-  print(foo.tamarind); // expect: tamarind
-  print(foo.tangerine); // expect: tangerine
-  print(foo.tomato); // expect: tomato
-  print(foo.watermelon); // expect: watermelon
-  print(foo.yuzu); // expect: yuzu
+  assertEq(foo.apple, "apple"); // expect: apple
+  assertEq(foo.apricot, "apricot"); // expect: apricot
+  assertEq(foo.avocado, "avocado"); // expect: avocado
+  assertEq(foo.banana, "banana"); // expect: banana
+  assertEq(foo.bilberry, "bilberry"); // expect: bilberry
+  assertEq(foo.blackberry, "blackberry"); // expect: blackberry
+  assertEq(foo.blackcurrant, "blackcurrant"); // expect: blackcurrant
+  assertEq(foo.blueberry, "blueberry"); // expect: blueberry
+  assertEq(foo.boysenberry, "boysenberry"); // expect: boysenberry
+  assertEq(foo.cantaloupe, "cantaloupe"); // expect: cantaloupe
+  assertEq(foo.cherimoya, "cherimoya"); // expect: cherimoya
+  assertEq(foo.cherry, "cherry"); // expect: cherry
+  assertEq(foo.clementine, "clementine"); // expect: clementine
+  assertEq(foo.cloudberry, "cloudberry"); // expect: cloudberry
+  assertEq(foo.coconut, "coconut"); // expect: coconut
+  assertEq(foo.cranberry, "cranberry"); // expect: cranberry
+  assertEq(foo.currant, "currant"); // expect: currant
+  assertEq(foo.damson, "damson"); // expect: damson
+  assertEq(foo.date, "date"); // expect: date
+  assertEq(foo.dragonfruit, "dragonfruit"); // expect: dragonfruit
+  assertEq(foo.durian, "durian"); // expect: durian
+  assertEq(foo.elderberry, "elderberry"); // expect: elderberry
+  assertEq(foo.feijoa, "feijoa"); // expect: feijoa
+  assertEq(foo.fig, "fig"); // expect: fig
+  assertEq(foo.gooseberry, "gooseberry"); // expect: gooseberry
+  assertEq(foo.grape, "grape"); // expect: grape
+  assertEq(foo.grapefruit, "grapefruit"); // expect: grapefruit
+  assertEq(foo.guava, "guava"); // expect: guava
+  assertEq(foo.honeydew, "honeydew"); // expect: honeydew
+  assertEq(foo.huckleberry, "huckleberry"); // expect: huckleberry
+  assertEq(foo.jabuticaba, "jabuticaba"); // expect: jabuticaba
+  assertEq(foo.jackfruit, "jackfruit"); // expect: jackfruit
+  assertEq(foo.jambul, "jambul"); // expect: jambul
+  assertEq(foo.jujube, "jujube"); // expect: jujube
+  assertEq(foo.juniper, "juniper"); // expect: juniper
+  assertEq(foo.kiwifruit, "kiwifruit"); // expect: kiwifruit
+  assertEq(foo.kumquat, "kumquat"); // expect: kumquat
+  assertEq(foo.lemon, "lemon"); // expect: lemon
+  assertEq(foo.lime, "lime"); // expect: lime
+  assertEq(foo.longan, "longan"); // expect: longan
+  assertEq(foo.loquat, "loquat"); // expect: loquat
+  assertEq(foo.lychee, "lychee"); // expect: lychee
+  assertEq(foo.mandarine, "mandarine"); // expect: mandarine
+  assertEq(foo.mango, "mango"); // expect: mango
+  assertEq(foo.marionberry, "marionberry"); // expect: marionberry
+  assertEq(foo.melon, "melon"); // expect: melon
+  assertEq(foo.miracle, "miracle"); // expect: miracle
+  assertEq(foo.mulberry, "mulberry"); // expect: mulberry
+  assertEq(foo.nance, "nance"); // expect: nance
+  assertEq(foo.nectarine, "nectarine"); // expect: nectarine
+  assertEq(foo.olive, "olive"); // expect: olive
+  assertEq(foo.orange, "orange"); // expect: orange
+  assertEq(foo.papaya, "papaya"); // expect: papaya
+  assertEq(foo.passionfruit, "passionfruit"); // expect: passionfruit
+  assertEq(foo.peach, "peach"); // expect: peach
+  assertEq(foo.pear, "pear"); // expect: pear
+  assertEq(foo.persimmon, "persimmon"); // expect: persimmon
+  assertEq(foo.physalis, "physalis"); // expect: physalis
+  assertEq(foo.pineapple, "pineapple"); // expect: pineapple
+  assertEq(foo.plantain, "plantain"); // expect: plantain
+  assertEq(foo.plum, "plum"); // expect: plum
+  assertEq(foo.plumcot, "plumcot"); // expect: plumcot
+  assertEq(foo.pomegranate, "pomegranate"); // expect: pomegranate
+  assertEq(foo.pomelo, "pomelo"); // expect: pomelo
+  assertEq(foo.quince, "quince"); // expect: quince
+  assertEq(foo.raisin, "raisin"); // expect: raisin
+  assertEq(foo.rambutan, "rambutan"); // expect: rambutan
+  assertEq(foo.raspberry, "raspberry"); // expect: raspberry
+  assertEq(foo.redcurrant, "redcurrant"); // expect: redcurrant
+  assertEq(foo.salak, "salak"); // expect: salak
+  assertEq(foo.salmonberry, "salmonberry"); // expect: salmonberry
+  assertEq(foo.satsuma, "satsuma"); // expect: satsuma
+  assertEq(foo.strawberry, "strawberry"); // expect: strawberry
+  assertEq(foo.tamarillo, "tamarillo"); // expect: tamarillo
+  assertEq(foo.tamarind, "tamarind"); // expect: tamarind
+  assertEq(foo.tangerine, "tangerine"); // expect: tangerine
+  assertEq(foo.tomato, "tomato"); // expect: tomato
+  assertEq(foo.watermelon, "watermelon"); // expect: watermelon
+  assertEq(foo.yuzu, "yuzu"); // expect: yuzu
 }
 
 printFields();

--- a/laythe_vm/fixture/language/field/method_binds_self.lay
+++ b/laythe_vm/fixture/language/field/method_binds_self.lay
@@ -1,4 +1,9 @@
 class Foo {
+  init() {
+    self.name = nil;
+    self.slot = nil;
+  }
+
   sayName(a) {
     print(self.name);
     print(a);
@@ -12,8 +17,8 @@ let foo2 = Foo();
 foo2.name = "foo2";
 
 // Store the method reference on another object.
-foo2.f = foo1.sayName;
+foo2.slot = foo1.sayName;
 // Still retains original receiver.
-foo2.f(1);
+foo2.slot(1);
 // expect: foo1
 // expect: 1

--- a/laythe_vm/fixture/language/field/on_instance.lay
+++ b/laythe_vm/fixture/language/field/on_instance.lay
@@ -1,4 +1,9 @@
-class Foo {}
+class Foo {
+  init() {
+    self.bar = nil;
+    self.baz = nil;
+  }
+}
 
 let foo = Foo();
 

--- a/laythe_vm/fixture/language/inheritance/set_fields_from_base_class.lay
+++ b/laythe_vm/fixture/language/inheritance/set_fields_from_base_class.lay
@@ -1,4 +1,9 @@
 class Foo {
+  init() {
+    self.field1 = nil;
+    self.field2 = nil;
+  }
+
   foo(a, b) {
     self.field1 = a;
     self.field2 = b;

--- a/laythe_vm/src/debug.rs
+++ b/laythe_vm/src/debug.rs
@@ -106,6 +106,9 @@ pub fn disassemble_instruction(
     AlignedByteCode::Method(constant) => {
       constant_instruction(stdio.stdout(), "Method", chunk, constant, offset)
     }
+    AlignedByteCode::Field(constant) => {
+      constant_instruction(stdio.stdout(), "Field", chunk, constant, offset)
+    }
     AlignedByteCode::StaticMethod(constant) => {
       constant_instruction(stdio.stdout(), "StaticMethod", chunk, constant, offset)
     }

--- a/laythe_vm/tests/language.rs
+++ b/laythe_vm/tests/language.rs
@@ -266,7 +266,7 @@ fn field() -> Result<(), std::io::Error> {
       "language/field/call_function_field.lay",
       "language/field/get_and_set_method.lay",
       "language/field/many.lay",
-      "language/field/method_binds_this.lay",
+      "language/field/method_binds_self.lay",
       "language/field/method.lay",
       "language/field/on_instance.lay",
     ],


### PR DESCRIPTION
## Summary
Each `Instance` now holds it's fields a `Box<[Value]>` instead of a map. This reduces overall memory usage and in some cases provides a small speedup. This also leads to further opportunities to optimize as fields may be statically resolved and indexed into directly without a runtime lookup.