### PR TITLE
make iterator current a method instead of property

### DIFF
--- a/laythe_core/src/iterator.rs
+++ b/laythe_core/src/iterator.rs
@@ -3,8 +3,7 @@ use crate::{
   value::{Value, VALUE_NIL},
   Call,
 };
-use laythe_env::managed::{DebugHeap, Manage, Managed, Trace};
-use smol_str::SmolStr;
+use laythe_env::managed::{DebugHeap, Manage, Trace};
 use std::mem;
 use std::{fmt, io::Write};
 
@@ -28,15 +27,6 @@ impl LyIterator {
       iterator,
       current: VALUE_NIL,
     }
-  }
-
-  /// Allow access the "current" field in the iterator
-  pub fn get_field(&self, name: &Managed<SmolStr>) -> Option<&Value> {
-    if &***name == "current" {
-      return Some(&self.current);
-    }
-
-    None
   }
 
   /// Get the name of this iterator

--- a/laythe_vm/fixture/language/iterator/assign_iter_keep_state.lay
+++ b/laythe_vm/fixture/language/iterator/assign_iter_keep_state.lay
@@ -8,5 +8,5 @@ let iter2 = iter1;
 iter2.next();
 iter2.next();
 
-assertEq(iter1.current, 4);
-assertEq(iter2.current, 4);
+assertEq(iter1.current(), 4);
+assertEq(iter2.current(), 4);

--- a/laythe_vm/fixture/language/iterator/cannot_set_current.lay
+++ b/laythe_vm/fixture/language/iterator/cannot_set_current.lay
@@ -1,3 +1,0 @@
-let list = [1, 2, 3];
-let iter = list.iter();
-iter.current = 4;

--- a/laythe_vm/fixture/std_lib/global/iter/chain.lay
+++ b/laythe_vm/fixture/std_lib/global/iter/chain.lay
@@ -3,26 +3,26 @@ let l2 = ["cat", "dog", "parrot"];
 
 let chained = l1.iter().chain(l2.iter());
 
-assertEq(chained.current, nil);
+assertEq(chained.current(), nil);
 assertEq(chained.next(), true);
 
-assertEq(chained.current, 1);
+assertEq(chained.current(), 1);
 assertEq(chained.next(), true);
 
-assertEq(chained.current, 2);
+assertEq(chained.current(), 2);
 assertEq(chained.next(), true);
 
-assertEq(chained.current, 3);
+assertEq(chained.current(), 3);
 assertEq(chained.next(), true);
 
-assertEq(chained.current, 4);
+assertEq(chained.current(), 4);
 assertEq(chained.next(), true);
 
-assertEq(chained.current, "cat");
+assertEq(chained.current(), "cat");
 assertEq(chained.next(), true);
 
-assertEq(chained.current, "dog");
+assertEq(chained.current(), "dog");
 assertEq(chained.next(), true);
 
-assertEq(chained.current, "parrot");
+assertEq(chained.current(), "parrot");
 assertEq(chained.next(), false);

--- a/laythe_vm/fixture/std_lib/global/iter/filter.lay
+++ b/laythe_vm/fixture/std_lib/global/iter/filter.lay
@@ -4,6 +4,6 @@ let iter = {
 }.iter().filter(|x| x[0] == "key");
 
 assertEq(iter.next(), true);
-assertEq(iter.current[1], 10);
+assertEq(iter.current()[1], 10);
 
 assertEq(iter.next(), false);

--- a/laythe_vm/fixture/std_lib/global/iter/map.lay
+++ b/laythe_vm/fixture/std_lib/global/iter/map.lay
@@ -1,15 +1,15 @@
 let iter = [1, 2, 3, 4].iter().map(|x| x / 2);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, 0.5);
+assertEq(iter.current(), 0.5);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, 1);
+assertEq(iter.current(), 1);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, 1.5);
+assertEq(iter.current(), 1.5);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, 2.0);
+assertEq(iter.current(), 2.0);
 
 assertEq(iter.next(), false);

--- a/laythe_vm/fixture/std_lib/global/iter/next.lay
+++ b/laythe_vm/fixture/std_lib/global/iter/next.lay
@@ -1,15 +1,15 @@
 let iter = [1, 2, 3, "false"].iter();
 
 assertEq(iter.next(), true);
-assertEq(iter.current, 1);
+assertEq(iter.current(), 1);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, 2);
+assertEq(iter.current(), 2);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, 3);
+assertEq(iter.current(), 3);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, "false");
+assertEq(iter.current(), "false");
 
 assertEq(iter.next(), false);

--- a/laythe_vm/fixture/std_lib/global/iter/zip.lay
+++ b/laythe_vm/fixture/std_lib/global/iter/zip.lay
@@ -3,17 +3,17 @@ let l2 = ["cat", "dog", "parrot"];
 
 let zipped = l1.iter().zip(l2.iter());
 
-assertEq(zipped.current, nil);
+assertEq(zipped.current(), nil);
 assertEq(zipped.next(), true);
 
-assertEq(zipped.current[0], 1);
-assertEq(zipped.current[1], "cat");
+assertEq(zipped.current()[0], 1);
+assertEq(zipped.current()[1], "cat");
 assertEq(zipped.next(), true);
 
-assertEq(zipped.current[0], 2);
-assertEq(zipped.current[1], "dog");
+assertEq(zipped.current()[0], 2);
+assertEq(zipped.current()[1], "dog");
 assertEq(zipped.next(), true);
 
-assertEq(zipped.current[0], 3);
-assertEq(zipped.current[1], "parrot");
+assertEq(zipped.current()[0], 3);
+assertEq(zipped.current()[1], "parrot");
 assertEq(zipped.next(), false);

--- a/laythe_vm/fixture/std_lib/global/list/iter.lay
+++ b/laythe_vm/fixture/std_lib/global/list/iter.lay
@@ -5,21 +5,21 @@ fn greeter(name) {
 let x = ["cat", "dog", greeter, false, [10]];
 let iter = x.iter();
 
-assertEq(iter.current, nil);
+assertEq(iter.current(), nil);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, "cat");
+assertEq(iter.current(), "cat");
 
 assertEq(iter.next(), true);
-assertEq(iter.current, "dog");
+assertEq(iter.current(), "dog");
 
 assertEq(iter.next(), true);
-assertEq(iter.current, greeter);
+assertEq(iter.current(), greeter);
 
 assertEq(iter.next(), true);
-assertEq(iter.current, false);
+assertEq(iter.current(), false);
 
 assertEq(iter.next(), true);
-assertEq(iter.current[0], 10);
+assertEq(iter.current()[0], 10);
 
 assertEq(iter.next(), false);

--- a/laythe_vm/fixture/std_lib/global/number/times.lay
+++ b/laythe_vm/fixture/std_lib/global/number/times.lay
@@ -2,5 +2,5 @@ let results = [0, 1, 2, 3, 4].iter();
 
 5.times().each(|i| {
   results.next();
-  assertEq(i, results.current);
+  assertEq(i, results.current());
 });

--- a/laythe_vm/fixture/std_lib/global/str/split.lay
+++ b/laythe_vm/fixture/std_lib/global/str/split.lay
@@ -1,12 +1,12 @@
 let b = "a b c".split(" ");
 
 assert(b.next());
-assertEq(b.current, "a");
+assertEq(b.current(), "a");
 
 assert(b.next());
-assertEq(b.current, "b");
+assertEq(b.current(), "b");
 
 assert(b.next());
-assertEq(b.current, "c");
+assertEq(b.current(), "c");
 
 assert(!b.next());

--- a/laythe_vm/tests/language.rs
+++ b/laythe_vm/tests/language.rs
@@ -563,10 +563,7 @@ fn iterator() -> Result<(), std::io::Error> {
 
   test_file_exits(&vec![], ExecuteResult::CompileError)?;
 
-  test_file_exits(
-    &vec!["language/iterator/cannot_set_current.lay"],
-    ExecuteResult::RuntimeError,
-  )
+  test_file_exits(&vec![], ExecuteResult::RuntimeError)
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Replace the `.current` property with the `.current()` method for iteration. This is for the eventual goal of eliminating `Value::Iter` and using a regular instance instead. This also appears to give a slight performance gain to property access as we can now assume the happy path of `is_instance` instead of having to run `kind()`