### PR TITLE
Update rust.yml remove on push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,6 @@
 name: Rust
 
 on:
-  push:
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
## Summary
Remove the effective copy of the ci steps. I'm not sure how limiting Github is on it's free actions, but at the minimum this clears up the checks information.