### PR TITLE
Remove specialized indexing instructions

### DIFF
--- a/laythe_core/src/managed/gc.rs
+++ b/laythe_core/src/managed/gc.rs
@@ -30,7 +30,7 @@ impl<T: 'static + Manage + ?Sized> Gc<T> {
 
   /// Return the underlying pointer as a usize. This is
   /// used by the nan boxing functionality
-  pub fn to_usize(&self) -> usize {
+  pub fn to_usize(self) -> usize {
     self.ptr.as_ptr() as *const () as usize
   }
 

--- a/laythe_core/src/managed/gc_obj.rs
+++ b/laythe_core/src/managed/gc_obj.rs
@@ -202,7 +202,7 @@ impl<T: 'static + Object> GcObj<T> {
   /// Return the underlying pointer as a usize. This is
   /// used by the nan boxing functionality
   #[inline]
-  pub fn to_usize(&self) -> usize {
+  pub fn to_usize(self) -> usize {
     unsafe { self.header_ptr() as *const () as usize }
   }
 }
@@ -393,82 +393,82 @@ impl GcObject {
   }
 
   #[inline]
-  pub fn to_str(&self) -> GcStr {
+  pub fn to_str(self) -> GcStr {
     unsafe { GcStr::from_alloc_ptr(self.ptr) }
   }
 
   #[inline]
-  pub fn to_class(&self) -> GcObj<Class> {
+  pub fn to_class(self) -> GcObj<Class> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Class>() },
     }
   }
 
   #[inline]
-  pub fn to_closure(&self) -> GcObj<Closure> {
+  pub fn to_closure(self) -> GcObj<Closure> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Closure>() },
     }
   }
 
   #[inline]
-  pub fn to_fun(&self) -> GcObj<Fun> {
+  pub fn to_fun(self) -> GcObj<Fun> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Fun>() },
     }
   }
 
   #[inline]
-  pub fn to_fiber(&self) -> GcObj<Fiber> {
+  pub fn to_fiber(self) -> GcObj<Fiber> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Fiber>() },
     }
   }
 
   #[inline]
-  pub fn to_instance(&self) -> GcObj<Instance> {
+  pub fn to_instance(self) -> GcObj<Instance> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Instance>() },
     }
   }
 
   #[inline]
-  pub fn to_enumerator(&self) -> GcObj<Enumerator> {
+  pub fn to_enumerator(self) -> GcObj<Enumerator> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Enumerator>() },
     }
   }
 
   #[inline]
-  pub fn to_list(&self) -> GcObj<List<Value>> {
+  pub fn to_list(self) -> GcObj<List<Value>> {
     GcObj {
       ptr: unsafe { self.data_ptr::<List<Value>>() },
     }
   }
 
   #[inline]
-  pub fn to_map(&self) -> GcObj<Map<Value, Value>> {
+  pub fn to_map(self) -> GcObj<Map<Value, Value>> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Map<Value, Value>>() },
     }
   }
 
   #[inline]
-  pub fn to_method(&self) -> GcObj<Method> {
+  pub fn to_method(self) -> GcObj<Method> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Method>() },
     }
   }
 
   #[inline]
-  pub fn to_native(&self) -> GcObj<Native> {
+  pub fn to_native(self) -> GcObj<Native> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Native>() },
     }
   }
 
   #[inline]
-  pub fn to_upvalue(&self) -> GcObj<Upvalue> {
+  pub fn to_upvalue(self) -> GcObj<Upvalue> {
     GcObj {
       ptr: unsafe { self.data_ptr::<Upvalue>() },
     }

--- a/laythe_core/src/managed/gc_str.rs
+++ b/laythe_core/src/managed/gc_str.rs
@@ -53,11 +53,11 @@ impl GcStr {
   /// let value = handle.value();
   /// assert!(value.to_usize() > 0);
   /// ```
-  pub fn to_usize(&self) -> usize {
+  pub fn to_usize(self) -> usize {
     self.0.as_alloc_ptr() as *const () as usize
   }
 
-  pub fn degrade(&self) -> GcObject {
+  pub fn degrade(self) -> GcObject {
     GcObject::new(self.0.ptr)
   }
 

--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -1,5 +1,5 @@
 use crate::{
-  constants::{INDEX_GET, INDEX_SET, INIT},
+  constants::INIT,
   managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Manage, Object, Trace},
 };
 use crate::{hooks::GcHooks, value::Value};
@@ -13,8 +13,6 @@ use super::ObjectKind;
 pub struct Class {
   name: GcStr,
   init: Option<Value>,
-  index_get: Option<Value>,
-  index_set: Option<Value>,
   methods: HashMap<GcStr, Value, FnvBuildHasher>,
   fields: HashMap<GcStr, u16, FnvBuildHasher>,
   meta_class: Option<GcObj<Class>>,
@@ -26,8 +24,6 @@ impl Class {
     let mut class = hooks.manage_obj(Self {
       name,
       init: None,
-      index_get: None,
-      index_set: None,
       methods: HashMap::default(),
       fields: HashMap::default(),
       meta_class: None,
@@ -46,8 +42,6 @@ impl Class {
     Self {
       name,
       init: None,
-      index_get: None,
-      index_set: None,
       methods: HashMap::default(),
       fields: HashMap::default(),
       meta_class: None,
@@ -68,16 +62,6 @@ impl Class {
   #[inline]
   pub fn init(&self) -> Option<Value> {
     self.init
-  }
-
-  #[inline]
-  pub fn index_get(&self) -> Option<Value> {
-    self.index_get
-  }
-
-  #[inline]
-  pub fn index_set(&self) -> Option<Value> {
-    self.index_set
   }
 
   pub fn meta_class(&self) -> &Option<GcObj<Class>> {
@@ -117,8 +101,6 @@ impl Class {
   pub fn add_method(&mut self, hooks: &GcHooks, name: GcStr, method: Value) -> Option<Value> {
     match &*name {
       INIT => self.init = Some(method),
-      INDEX_GET => self.index_get = Some(method),
-      INDEX_SET => self.index_set = Some(method),
       _ => (),
     }
 
@@ -185,8 +167,6 @@ impl Class {
     let mut meta_class = hooks.manage_obj(Self {
       name: hooks.manage_str(format!("{} metaClass", &*self.name)),
       init: None,
-      index_get: None,
-      index_set: None,
       methods: HashMap::default(),
       fields: HashMap::default(),
       meta_class: Some(class_class),

--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -99,9 +99,8 @@ impl Class {
   }
 
   pub fn add_method(&mut self, hooks: &GcHooks, name: GcStr, method: Value) -> Option<Value> {
-    match &*name {
-      INIT => self.init = Some(method),
-      _ => (),
+    if &*name == INIT {
+      self.init = Some(method)
     }
 
     hooks.grow(self, |class| class.methods.insert(name, method))

--- a/laythe_core/src/object/closure.rs
+++ b/laythe_core/src/object/closure.rs
@@ -38,7 +38,7 @@ impl Closure {
   /// assert_eq!(&*closure.fun().name(), "example");
   /// ```
   pub fn new(fun: GcObj<Fun>, upvalues: Box<[GcObj<Upvalue>]>) -> Self {
-    Closure { upvalues, fun }
+    Closure { fun, upvalues }
   }
 
   pub fn without_upvalues(fun: GcObj<Fun>) -> Self {

--- a/laythe_core/src/signature.rs
+++ b/laythe_core/src/signature.rs
@@ -84,7 +84,7 @@ impl ParameterBuilder {
   }
 
   /// Build a parameter from this builder
-  pub fn to_param(&self, hooks: &GcHooks) -> Parameter {
+  pub fn to_param(self, hooks: &GcHooks) -> Parameter {
     Parameter {
       name: hooks.manage_str(self.name),
       kind: self.kind,

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -386,16 +386,16 @@ mod unboxed {
         Self::Number(num) => {
           ValueKind::Number.hash(state);
           (*num as u64).hash(state);
-        },
+        }
         Self::Bool(b) => {
           ValueKind::Bool.hash(state);
           b.hash(state);
-        },
+        }
         Self::Nil => ValueKind::Nil.hash(state),
         Self::Obj(obj) => {
           ValueKind::Obj.hash(state);
           obj.hash(state);
-        },
+        }
       };
     }
   }
@@ -760,7 +760,8 @@ mod boxed {
       assert_eq!(mem::size_of::<Map<Value, Value>>(), 32);
       assert_eq!(mem::size_of::<Closure>(), 24);
       assert_eq!(mem::size_of::<Fun>(), 96);
-      assert_eq!(mem::size_of::<Class>(), 136);
+      assert_eq!(mem::size_of::<Fiber>(), 104);
+      assert_eq!(mem::size_of::<Class>(), 104);
       assert_eq!(mem::size_of::<Instance>(), 24);
       assert_eq!(mem::size_of::<Method>(), 16);
       assert_eq!(mem::size_of::<Enumerator>(), 24);

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -156,7 +156,7 @@ mod unboxed {
     /// assert_eq!(val1.to_num(), 20.0);
     /// ```
     #[inline]
-    pub fn to_num(&self) -> f64 {
+    pub fn to_num(self) -> f64 {
       match self {
         Value::Number(num) => *num,
         _ => panic!("Value is not number"),
@@ -173,7 +173,7 @@ mod unboxed {
     /// assert_eq!(b1.to_bool(), false);
     /// ```
     #[inline]
-    pub fn to_bool(&self) -> bool {
+    pub fn to_bool(self) -> bool {
       match self {
         Value::Bool(b1) => *b1,
         _ => panic!("Value is not boolean"),
@@ -197,7 +197,7 @@ mod unboxed {
     /// assert_eq!(&*value.to_obj().to_str(), "example")
     /// ```
     #[inline]
-    pub fn to_obj(&self) -> GcObject {
+    pub fn to_obj(self) -> GcObject {
       match self {
         Self::Obj(obj) => *obj,
         _ => panic!("Expected object."),
@@ -547,18 +547,18 @@ mod boxed {
     }
 
     #[inline]
-    pub fn to_bool(&self) -> bool {
-      *self == VALUE_TRUE
+    pub fn to_bool(self) -> bool {
+      self == VALUE_TRUE
     }
 
     #[inline]
-    pub fn to_num(&self) -> f64 {
+    pub fn to_num(self) -> f64 {
       let union = NumberUnion { bits: self.0 };
       unsafe { union.num }
     }
 
     #[inline]
-    pub fn to_obj(&self) -> GcObject {
+    pub fn to_obj(self) -> GcObject {
       let as_unsigned = self.0 & !TAG_OBJ;
       let ptr = unsafe { NonNull::new_unchecked(as_unsigned as usize as *mut u8) };
       GcObject::new(ptr)

--- a/laythe_lib/src/global/mod.rs
+++ b/laythe_lib/src/global/mod.rs
@@ -7,7 +7,7 @@ mod time;
 mod support;
 
 use crate::{StdResult, STD};
-use assert::add_assert_funs;
+use self::assert::add_assert_funs;
 use laythe_core::{hooks::GcHooks, managed::Gc, module::Package, utils::IdEmitter};
 use misc::add_misc_funs;
 use time::add_clock_funs;

--- a/laythe_lib/src/global/primitives/iter.rs
+++ b/laythe_lib/src/global/primitives/iter.rs
@@ -393,7 +393,7 @@ struct SkipIterator {
 
 impl SkipIterator {
   fn new(iter: GcObj<Enumerator>, skip_count: usize) -> Self {
-    Self { iter, skip_count }
+    Self { skip_count, iter }
   }
 }
 
@@ -622,7 +622,7 @@ impl LyNative for IterLen {
         }
 
         Call::Ok(val!(size as f64))
-      },
+      }
     }
   }
 }
@@ -1237,7 +1237,7 @@ mod test {
           let mut map_iter = r.to_obj().to_enumerator();
           assert_eq!(map_iter.next(&mut hooks).unwrap(), val!(true));
           assert_eq!(map_iter.current(), val!(5.0));
-        },
+        }
         _ => assert!(false),
       }
     }
@@ -1286,7 +1286,7 @@ mod test {
           assert_eq!(filter_iter.current(), val!(2.0));
           assert_eq!(filter_iter.next(&mut hooks).unwrap(), val!(true));
           assert_eq!(filter_iter.current(), val!(3.0));
-        },
+        }
         _ => assert!(false),
       }
     }
@@ -1337,7 +1337,7 @@ mod test {
         Call::Ok(r) => {
           assert!(r.is_num());
           assert_eq!(r.to_num(), 10.1);
-        },
+        }
         _ => assert!(false),
       }
     }
@@ -1371,7 +1371,7 @@ mod test {
         Call::Ok(r) => {
           assert!(r.is_num());
           assert_eq!(r.to_num(), 4.0);
-        },
+        }
         _ => assert!(false),
       }
     }

--- a/laythe_lib/src/global/primitives/list.rs
+++ b/laythe_lib/src/global/primitives/list.rs
@@ -422,7 +422,7 @@ impl LyNative for ListIndexSet {
     }
 
     list[index] = args[0];
-    Call::Ok(VALUE_NIL)
+    Call::Ok(args[0])
   }
 }
 
@@ -785,7 +785,7 @@ mod test {
       let result = list_index_set
         .call(&mut hooks, Some(val!(this)), values)
         .unwrap();
-      assert_eq!(result, VALUE_NIL);
+      assert_eq!(result, val!(false));
       assert_eq!(this[1], val!(false))
     }
   }

--- a/laythe_lib/src/global/primitives/map.rs
+++ b/laythe_lib/src/global/primitives/map.rs
@@ -286,7 +286,7 @@ impl LyNative for MapIndexSet {
     hooks.grow(&mut *this.unwrap().to_obj().to_map(), |map| {
       map.insert(key, args[0])
     });
-    Call::Ok(VALUE_NIL)
+    Call::Ok(args[0])
   }
 }
 
@@ -398,11 +398,11 @@ impl Enumerate for MapIterator {
       Some(next) => {
         self.current = val!(hooks.manage_obj(List::from(&[*next.0, *next.1] as &[Value])));
         Call::Ok(val!(true))
-      },
+      }
       None => {
         self.current = VALUE_NIL;
         Call::Ok(val!(false))
-      },
+      }
     }
   }
 
@@ -630,7 +630,7 @@ mod test {
       let result = map_set
         .call(&mut hooks, Some(val!(this)), &[val!(10.0), val!(true)])
         .unwrap();
-      assert!(result.is_nil());
+      assert_eq!(result, val!(10.0));
 
       assert_eq!(this.len(), 1);
       assert_eq!(*this.get(&val!(true)).unwrap(), val!(10.0));
@@ -638,7 +638,7 @@ mod test {
       let result = map_set
         .call(&mut hooks, Some(val!(this)), &[val!(false), val!(true)])
         .unwrap();
-      assert!(result.is_nil());
+      assert_eq!(result, val!(false));
 
       assert_eq!(this.len(), 1);
       assert_eq!(*this.get(&val!(true)).unwrap(), val!(false));

--- a/laythe_vm/src/byte_code.rs
+++ b/laythe_vm/src/byte_code.rs
@@ -64,12 +64,6 @@ pub enum AlignedByteCode {
   /// Get the current value from an iterator
   IterCurrent(u16),
 
-  /// Get from an index
-  GetIndex,
-
-  /// Set to an index
-  SetIndex,
-
   /// Drop a value
   Drop,
 
@@ -232,8 +226,6 @@ impl AlignedByteCode {
         AlignedByteCode::IterCurrent(decode_u16(&store[offset + 1..offset + 3])),
         offset + 3,
       ),
-      ByteCode::GetIndex => (AlignedByteCode::GetIndex, offset + 1),
-      ByteCode::SetIndex => (AlignedByteCode::SetIndex, offset + 1),
       ByteCode::Drop => (AlignedByteCode::Drop, offset + 1),
       ByteCode::DropN => (AlignedByteCode::DropN(store[offset + 1]), offset + 2),
       ByteCode::Dup => (AlignedByteCode::Dup, offset + 1),
@@ -360,8 +352,6 @@ impl AlignedByteCode {
       AlignedByteCode::Interpolate(cnt) => -(*cnt as i32) + 1,
       AlignedByteCode::IterNext(_) => 0,
       AlignedByteCode::IterCurrent(_) => 0,
-      AlignedByteCode::GetIndex => -1,
-      AlignedByteCode::SetIndex => -1,
       AlignedByteCode::Drop => -1,
       AlignedByteCode::DropN(cnt) => -(*cnt as i32),
       AlignedByteCode::Dup => 1,
@@ -424,8 +414,6 @@ impl Encode for AlignedByteCode {
       Self::Interpolate(slot) => op_short(code, ByteCode::Interpolate, slot),
       Self::IterNext(slot) => op_short(code, ByteCode::IterNext, slot),
       Self::IterCurrent(slot) => op_short(code, ByteCode::IterCurrent, slot),
-      Self::GetIndex => op(code, ByteCode::GetIndex),
-      Self::SetIndex => op(code, ByteCode::SetIndex),
       Self::Equal => op(code, ByteCode::Equal),
       Self::NotEqual => op(code, ByteCode::NotEqual),
       Self::Greater => op(code, ByteCode::Greater),
@@ -441,7 +429,7 @@ impl Encode for AlignedByteCode {
       Self::ImportSymbol((path, slot)) => {
         push_op_u16_tuple(code, ByteCode::ImportSymbol, path, slot);
         4
-      },
+      }
       Self::Export(slot) => op_short(code, ByteCode::Export, slot),
       Self::DefineGlobal(slot) => op_short(code, ByteCode::DefineGlobal, slot),
       Self::GetGlobal(slot) => op_short(code, ByteCode::GetGlobal, slot),
@@ -459,11 +447,11 @@ impl Encode for AlignedByteCode {
       Self::Invoke((slot1, slot2)) => {
         push_op_u16_u8_tuple(code, ByteCode::Invoke, slot1, slot2);
         4
-      },
+      }
       Self::SuperInvoke((slot1, slot2)) => {
         push_op_u16_u8_tuple(code, ByteCode::SuperInvoke, slot1, slot2);
         4
-      },
+      }
       Self::Closure(slot) => op_short(code, ByteCode::Closure, slot),
       Self::Method(slot) => op_short(code, ByteCode::Method, slot),
       Self::Field(slot) => op_short(code, ByteCode::Field, slot),
@@ -477,12 +465,12 @@ impl Encode for AlignedByteCode {
         let bytes = encoded.to_ne_bytes();
         code.extend_from_slice(&bytes);
         3
-      },
+      }
       Self::Slot(slot) => {
         let bytes = slot.to_ne_bytes();
         code.extend_from_slice(&bytes);
         5
-      },
+      }
     }
   }
 }
@@ -561,12 +549,6 @@ pub enum ByteCode {
 
   /// Get the current value from an iterator
   IterCurrent,
-
-  /// Get an index
-  GetIndex,
-
-  /// Set an index
-  SetIndex,
 
   /// Drop a value
   Drop,
@@ -775,8 +757,6 @@ mod test {
       (2, AlignedByteCode::SetUpvalue(56)),
       (2, AlignedByteCode::GetLocal(96)),
       (2, AlignedByteCode::SetLocal(149)),
-      (1, AlignedByteCode::GetIndex),
-      (1, AlignedByteCode::SetIndex),
       (3, AlignedByteCode::GetProperty(18273)),
       (3, AlignedByteCode::SetProperty(253)),
       (3, AlignedByteCode::JumpIfFalse(8941)),

--- a/laythe_vm/src/debug.rs
+++ b/laythe_vm/src/debug.rs
@@ -79,8 +79,6 @@ pub fn disassemble_instruction(
     AlignedByteCode::IterCurrent(constant) => {
       constant_instruction(stdio.stdout(), "IterCurrent", chunk, constant, offset)
     },
-    AlignedByteCode::GetIndex => simple_instruction(stdio.stdout(), "GetIndex", offset),
-    AlignedByteCode::SetIndex => simple_instruction(stdio.stdout(), "SetIndex", offset),
     AlignedByteCode::Drop => simple_instruction(stdio.stdout(), "Drop", offset),
     AlignedByteCode::DropN(count) => byte_instruction(stdio.stdout(), "DropN", count, offset),
     AlignedByteCode::Dup => simple_instruction(stdio.stdout(), "Dup", offset),

--- a/laythe_vm/src/debug.rs
+++ b/laythe_vm/src/debug.rs
@@ -68,33 +68,33 @@ pub fn disassemble_instruction(
     AlignedByteCode::False => simple_instruction(stdio.stdout(), "False", offset),
     AlignedByteCode::List(arg_count) => {
       short_instruction(stdio.stdout(), "List", arg_count, offset)
-    },
+    }
     AlignedByteCode::Map(arg_count) => short_instruction(stdio.stdout(), "Map", arg_count, offset),
     AlignedByteCode::Interpolate(arg_count) => {
       short_instruction(stdio.stdout(), "Interpolate", arg_count, offset)
-    },
+    }
     AlignedByteCode::IterNext(constant) => {
       invoke_instruction(stdio.stdout(), "IterNext", chunk, constant, 0, offset)
-    },
+    }
     AlignedByteCode::IterCurrent(constant) => {
       constant_instruction(stdio.stdout(), "IterCurrent", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::Drop => simple_instruction(stdio.stdout(), "Drop", offset),
     AlignedByteCode::DropN(count) => byte_instruction(stdio.stdout(), "DropN", count, offset),
     AlignedByteCode::Dup => simple_instruction(stdio.stdout(), "Dup", offset),
     AlignedByteCode::Call(arg_count) => byte_instruction(stdio.stdout(), "Call", arg_count, offset),
     AlignedByteCode::Import(path) => {
       constant_instruction(stdio.stdout(), "Import", chunk, path, offset)
-    },
+    }
     AlignedByteCode::ImportSymbol((path, slot)) => {
       constant_pair_instruction(stdio.stdout(), "ImportSymbol", chunk, (path, slot), offset)
-    },
+    }
     AlignedByteCode::Export(constant) => {
       constant_instruction(stdio.stdout(), "Export", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::Invoke((constant, arg_count)) => {
       invoke_instruction(stdio.stdout(), "Invoke", chunk, constant, arg_count, offset)
-    },
+    }
     AlignedByteCode::SuperInvoke((constant, arg_count)) => invoke_instruction(
       stdio.stdout(),
       "SuperInvoke",
@@ -105,57 +105,57 @@ pub fn disassemble_instruction(
     ),
     AlignedByteCode::Class(constant) => {
       constant_instruction(stdio.stdout(), "Class", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::Inherit => simple_instruction(stdio.stdout(), "Inherit", offset),
     AlignedByteCode::GetSuper(constant) => {
       constant_instruction(stdio.stdout(), "GetSuper", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::Closure(constant) => {
       closure_instruction(stdio, "Closure", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::Method(constant) => {
       constant_instruction(stdio.stdout(), "Method", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::Field(constant) => {
       constant_instruction(stdio.stdout(), "Field", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::StaticMethod(constant) => {
       constant_instruction(stdio.stdout(), "StaticMethod", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::CloseUpvalue => simple_instruction(stdio.stdout(), "CloseUpvalue", offset),
     AlignedByteCode::UpvalueIndex(_) => {
       simple_instruction(stdio.stdout(), "!=== UpValueIndex - Invalid ===!", offset)
-    },
+    }
     AlignedByteCode::Slot(_) => {
       simple_instruction(stdio.stdout(), "!=== Slot - Invalid ===!", offset)
-    },
+    }
     AlignedByteCode::DefineGlobal(constant) => {
       constant_instruction(stdio.stdout(), "DefineGlobal", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::GetGlobal(constant) => {
       constant_instruction(stdio.stdout(), "GetGlobal", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::SetGlobal(constant) => {
       constant_instruction(stdio.stdout(), "SetGlobal", chunk, constant, offset)
-    },
+    }
     AlignedByteCode::GetLocal(slot) => byte_instruction(stdio.stdout(), "GetLocal", slot, offset),
     AlignedByteCode::SetLocal(slot) => byte_instruction(stdio.stdout(), "SetLocal", slot, offset),
     AlignedByteCode::GetUpvalue(slot) => {
       byte_instruction(stdio.stdout(), "GetUpvalue", slot, offset)
-    },
+    }
     AlignedByteCode::SetUpvalue(slot) => {
       byte_instruction(stdio.stdout(), "SetUpvalue", slot, offset)
-    },
+    }
     AlignedByteCode::SetProperty(slot) => {
       constant_instruction_with_slot(stdio.stdout(), "SetProperty", chunk, slot, offset)
-    },
+    }
     AlignedByteCode::GetProperty(slot) => {
       constant_instruction_with_slot(stdio.stdout(), "GetProperty", chunk, slot, offset)
-    },
+    }
     AlignedByteCode::Jump(jump) => jump_instruction(stdio.stdout(), "Jump", 1, jump, offset),
     AlignedByteCode::JumpIfFalse(jump) => {
       jump_instruction(stdio.stdout(), "JumpIfFalse", 1, jump, offset)
-    },
+    }
     AlignedByteCode::Loop(jump) => jump_instruction(stdio.stdout(), "Loop", -1, jump, offset),
     AlignedByteCode::Equal => simple_instruction(stdio.stdout(), "Equal", offset),
     AlignedByteCode::NotEqual => simple_instruction(stdio.stdout(), "NotEqual", offset),
@@ -165,10 +165,10 @@ pub fn disassemble_instruction(
     AlignedByteCode::LessEqual => simple_instruction(stdio.stdout(), "LessEqual", offset),
     AlignedByteCode::Constant(constant) => {
       constant_instruction(stdio.stdout(), "Constant", chunk, constant as u16, offset)
-    },
+    }
     AlignedByteCode::ConstantLong(constant) => {
       constant_instruction(stdio.stdout(), "ConstantLong", chunk, constant, offset)
-    },
+    }
   }
 }
 
@@ -230,10 +230,10 @@ fn constant_instruction_with_slot(
   offset: usize,
 ) -> io::Result<usize> {
   write!(stdout, "{:13} {:5} ", name, constant)?;
-  write!(stdout, "{} ", &chunk.get_constant(constant as usize))?;
+  write!(stdout, "{}", &chunk.get_constant(constant as usize))?;
   writeln!(
     stdout,
-    "cache slot {}",
+    " cache slot {}",
     &decode_u32(&chunk.instructions()[offset..offset + 4])
   )?;
 

--- a/laythe_vm/src/vm.rs
+++ b/laythe_vm/src/vm.rs
@@ -217,7 +217,7 @@ impl Vm {
           self.pop_roots(2);
 
           self.interpret(main_module, &source, file_id);
-        },
+        }
         Err(error) => panic!("{}", error),
       }
     }
@@ -245,12 +245,12 @@ impl Vm {
         let main_module = self.main_module(module_path, main_id);
 
         self.interpret(main_module, &source, file_id)
-      },
+      }
       Err(err) => {
         writeln!(self.io.stdio().stderr(), "{}", &err.to_string())
           .expect("Unable to write to stderr");
         ExecuteResult::RuntimeError
-      },
+      }
     }
   }
 
@@ -270,7 +270,7 @@ impl Vm {
       Ok(fun) => {
         self.prepare(fun);
         self.execute(ExecuteMode::Normal)
-      },
+      }
       Err(errors) => {
         let mut stdio = self.io.stdio();
         let stderr_color = stdio.stderr_color();
@@ -279,7 +279,7 @@ impl Vm {
             .expect("Unable to write to stderr");
         }
         ExecuteResult::CompileError
-      },
+      }
     }
   }
 
@@ -412,7 +412,7 @@ impl Vm {
         let result = self.run_fun(val!(self.builtin.errors.import), &[error_message]);
 
         self.to_call_result(result)
-      },
+      }
     }
   }
 
@@ -452,8 +452,6 @@ impl Vm {
           ByteCode::Jump => self.op_jump(),
           ByteCode::Loop => self.op_loop(),
           ByteCode::DefineGlobal => self.op_define_global(),
-          ByteCode::GetIndex => self.op_get_index(),
-          ByteCode::SetIndex => self.op_set_index(),
           ByteCode::GetGlobal => self.op_get_global(),
           ByteCode::SetGlobal => self.op_set_global(),
           ByteCode::GetLocal => self.op_get_local(),
@@ -499,19 +497,19 @@ impl Vm {
                 return ExecuteResult::FunResult(self.fiber.peek(0));
               }
             }
-          },
+          }
           Signal::Ok => (),
           Signal::RuntimeError => match self.fiber.error() {
             Some(error) => {
               if let Some(execute_result) = self.stack_unwind(error) {
                 return execute_result;
               }
-            },
+            }
             None => self.internal_error("Runtime error was not set."),
           },
           Signal::Exit => {
             return ExecuteResult::Ok(self.exit_code);
-          },
+          }
         }
       }
     }
@@ -791,7 +789,7 @@ impl Vm {
               .inline_cache_mut()
               .set_invoke_cache(inline_slot, class, method);
             self.resolve_call(method, arg_count)
-          },
+          }
           None => self.runtime_error(
             self.builtin.errors.property,
             &format!(
@@ -801,7 +799,7 @@ impl Vm {
             ),
           ),
         }
-      },
+      }
     }
   }
 
@@ -838,7 +836,7 @@ impl Vm {
             .inline_cache_mut()
             .set_invoke_cache(inline_slot, super_class, method);
           self.resolve_call(method, arg_count)
-        },
+        }
         None => self.runtime_error(
           self.builtin.errors.property,
           &format!(
@@ -920,26 +918,6 @@ impl Vm {
     match current_module.insert_symbol(&GcHooks::new(self), name, global) {
       Ok(_) => Signal::Ok,
       Err(_) => Signal::Ok,
-    }
-  }
-
-  unsafe fn op_set_index(&mut self) -> Signal {
-    let receiver = self.fiber.peek(2);
-
-    let class = self.value_class(receiver);
-
-    match class.index_set() {
-      Some(index_set) => {
-        let value = self.fiber.peek(1);
-        let signal = self.resolve_call(index_set, 2);
-        self.fiber.drop();
-        self.fiber.push(value);
-        signal
-      },
-      None => self.runtime_error(
-        self.builtin.errors.method_not_found,
-        &format!("No method []= on class {}.", class.name()),
-      ),
     }
   }
 
@@ -1026,20 +1004,6 @@ impl Vm {
     Signal::Ok
   }
 
-  unsafe fn op_get_index(&mut self) -> Signal {
-    let receiver = self.fiber.peek(1);
-
-    let class = self.value_class(receiver);
-
-    match class.index_get() {
-      Some(index_get) => self.resolve_call(index_get, 1),
-      None => self.runtime_error(
-        self.builtin.errors.method_not_found,
-        &format!("No method [] on class {}.", class.name()),
-      ),
-    }
-  }
-
   unsafe fn op_get_global(&mut self) -> Signal {
     let store_index = self.read_short();
     let string = self.read_string(store_index);
@@ -1048,7 +1012,7 @@ impl Vm {
       Some(gbl) => {
         self.fiber.push(gbl);
         Signal::Ok
-      },
+      }
       None => self.runtime_error(
         self.builtin.errors.runtime,
         &format!("Undefined variable {}", string),
@@ -1136,12 +1100,12 @@ impl Vm {
         // generate a new import object
         let path = self.manage(List::from(path));
         self.manage(Import::new(*package, path))
-      },
+      }
       None => {
         // generate a new import object
         let path = self.manage(List::new());
         self.manage(Import::new(path_segments[0], path))
-      },
+      }
     };
 
     self.gc().push_root(import);
@@ -1151,7 +1115,7 @@ impl Vm {
         Ok(module) => {
           self.fiber.push(val!(module));
           Signal::Ok
-        },
+        }
         Err(err) => self.runtime_error(self.builtin.errors.runtime, &err.to_string()),
       },
       None => self.runtime_error(
@@ -1195,12 +1159,12 @@ impl Vm {
         // generate a new import object
         let path = self.manage(List::from(path));
         self.manage(Import::new(*package, path))
-      },
+      }
       None => {
         // generate a new import object
         let path = self.manage(List::new());
         self.manage(Import::new(path_segments[0], path))
-      },
+      }
     };
 
     self.gc().push_root(import);
@@ -1210,7 +1174,7 @@ impl Vm {
         Ok(module) => {
           self.fiber.push(val!(module));
           Signal::Ok
-        },
+        }
         Err(err) => self.runtime_error(self.builtin.errors.runtime, &err.to_string()),
       },
       None => self.runtime_error(
@@ -1505,7 +1469,7 @@ impl Vm {
       match class.meta_class() {
         Some(mut meta) => {
           meta.add_method(&GcHooks::new(self), name, method);
-        },
+        }
         None => self.internal_error(&format!("{} meta class not set.", class.name())),
       }
     } else {
@@ -1616,7 +1580,7 @@ impl Vm {
         } else {
           Signal::Ok
         }
-      },
+      }
     }
   }
 
@@ -1652,7 +1616,7 @@ impl Vm {
             assert_roots(native, roots_before, roots_current);
           }
           Signal::OkReturn
-        },
+        }
         Call::Err(error) => self.set_error(error),
         Call::Exit(code) => self.set_exit(code),
       },
@@ -1671,11 +1635,11 @@ impl Vm {
               assert_roots(native, roots_before, roots_current);
             }
             Signal::OkReturn
-          },
+          }
           Call::Err(error) => self.set_error(error),
           Call::Exit(code) => self.set_exit(code),
         }
-      },
+      }
     }
   }
 
@@ -1717,7 +1681,7 @@ impl Vm {
           self.current_fun = current_fun;
           self.load_ip();
           None
-        },
+        }
         None => Some(Signal::Exit),
       },
       None => self.internal_error("Compilation failure attempted to pop last frame"),
@@ -1837,7 +1801,7 @@ impl Vm {
             ),
           )),
         }
-      },
+      }
     }
   }
 
@@ -1854,7 +1818,7 @@ impl Vm {
         let bound = self.manage_obj(Method::new(self.fiber.peek(0), method));
         self.fiber.peek_set(0, val!(bound));
         Signal::Ok
-      },
+      }
       None => self.runtime_error(
         self.builtin.errors.runtime,
         &format!("Undefined property {}", name),
@@ -1943,10 +1907,10 @@ impl Vm {
       match &**upvalue {
         Upvalue::Open(index) => {
           write!(stdout, "[ stack {} ]", self.stack[*index])?;
-        },
+        }
         Upvalue::Closed(closed) => {
           write!(stdout, "[ heap {} ]", closed)?;
-        },
+        }
       }
     }
 
@@ -1960,7 +1924,7 @@ impl Vm {
       ExecuteResult::Ok(_) => self.internal_error("Accidental early exit in hook call"),
       ExecuteResult::CompileError => {
         self.internal_error("Compiler error should occur before code is executed.")
-      },
+      }
       ExecuteResult::RuntimeError => match self.fiber.error() {
         Some(error) => Call::Err(error),
         None => self.internal_error("Error not set on vm executor."),
@@ -1994,7 +1958,7 @@ impl Vm {
         } else {
           self.internal_error("Failed to construct error")
         })
-      },
+      }
       _ => self.internal_error("Failed to construct error"),
     }
   }
@@ -2020,11 +1984,11 @@ impl Vm {
         self.current_fun = frame.closure.fun();
         self.ip = frame.ip;
         None
-      },
+      }
       None => {
         self.print_error(error);
         Some(ExecuteResult::RuntimeError)
-      },
+      }
     }
   }
 


### PR DESCRIPTION
## Problem
With channels in progress it seemed likely I'd need a special instruction from the lhs of `a.b <- 10`. Specifically instead of just assigning we'd want to access b then attempt to enqueue a value. Because this seems likely a need to double every `SET*` instruction it would be good to eliminate instructions that aren't really needed.

## Solution
Remove the purpose built instructions `IndexGet` and `IndexSet` instead using the existing invoke machinery to call the indexing methods. Now indexing is effectively  equivalent to the following

```
let a = [1, 2, 3];
let b = ['cat', 'dog'];
let c = { 'some': 'example' };

a[1];
// a.[](1);

c['other'] = b[1] = 'thing';
// c.[]=(b.[]=('thing', 1), 'other')
```