### PR TITLE
Add user import support

### DIFF
--- a/laythe_core/src/managed/gc_str.rs
+++ b/laythe_core/src/managed/gc_str.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use std::{
   cmp::Ordering,
+  ffi::OsStr,
   fmt,
   hash::{Hash, Hasher},
   io::Write,
@@ -237,6 +238,12 @@ impl Clone for GcStr {
 impl AsRef<str> for GcStr {
   fn as_ref(&self) -> &str {
     self
+  }
+}
+
+impl AsRef<OsStr> for GcStr {
+  fn as_ref(&self) -> &OsStr {
+    OsStr::new(self)
   }
 }
 

--- a/laythe_env/src/fs.rs
+++ b/laythe_env/src/fs.rs
@@ -29,7 +29,7 @@ impl Fs {
   }
 
   /// Read a directory for files and sub directories
-  pub fn read_directory(&self, path: &Path) -> io::Result<SlDirEntry> {
+  pub fn read_directory(&self, path: &Path) -> io::Result<Vec<Box<dyn LyDirEntry>>> {
     self.fs.read_directory(path)
   }
 
@@ -44,11 +44,13 @@ impl Fs {
   }
 }
 
-pub struct SlDirEntry();
+pub trait LyDirEntry {
+  fn path(&self) -> PathBuf;
+}
 
 pub trait FsImpl: Send + Sync {
   fn read_to_string(&self, path: &Path) -> io::Result<String>;
-  fn read_directory(&self, path: &Path) -> io::Result<SlDirEntry>;
+  fn read_directory(&self, path: &Path) -> io::Result<Vec<Box<dyn LyDirEntry>>>;
   fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;
   fn relative_path(&self, base: &Path, import: &Path) -> io::Result<PathBuf>;
 }
@@ -68,8 +70,8 @@ impl FsImpl for FsMock {
   fn read_to_string(&self, _path: &Path) -> io::Result<String> {
     Ok("let x = 10;".to_string())
   }
-  fn read_directory(&self, _path: &Path) -> io::Result<SlDirEntry> {
-    Ok(SlDirEntry())
+  fn read_directory(&self, _path: &Path) -> io::Result<Vec<Box<dyn LyDirEntry>>> {
+    Ok(vec![])
   }
   fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
     Ok(path.to_path_buf())

--- a/laythe_vm/src/compiler/parser.rs
+++ b/laythe_vm/src/compiler/parser.rs
@@ -484,10 +484,11 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
       return self.error_current("Can only import from the module scope.");
     }
 
-    self.consume(
-      TokenKind::Identifier,
-      "Expected package name following import.",
-    )?;
+    match self.current.kind() {
+      TokenKind::Identifier | TokenKind::Self_ => self.advance(),
+      _ => self.error_current("Expected package name following import."),
+    }?;
+
     let mut path = self.vec();
     path.push(self.previous.clone());
 
@@ -2344,6 +2345,15 @@ mod test {
   fn import() {
     let example = r#"
       import std.time;
+    "#;
+
+    test(example);
+  }
+
+  #[test]
+  fn import_self() {
+    let example = r#"
+      import self.stuff;
     "#;
 
     test(example);


### PR DESCRIPTION
## Plan of Attack

We should probably try to do most of this outside of the vm as loading file into source doesn't have much to do with executing code
* Move essentially everything to do with import / export statements under the `laythe_vm/source`. 
  * We already have Vm file which manages loaded file. We can extend this to also managing loading new file
  * Not sure on name maybe just import?

When loading files right now we imagine the general structure as package which holds a single root module. That module then holds more modules that may represent a directory or a file. We may do something like python and have a __mod__.lay when we want to execute code for a "directory". For files we just want the file to be a directory.

* When importing a new module we probably want to do the following
  * Check is module is already loaded / cached
  * If not found recursively load modules
    * If child module is a directory just create an empty module object and proceed, putting any further recursions inside of it. Maybe we eventually include a __mod__.lay file if we want to run some code here.
    * If a file load and compile the contents, initialize the module
  * In cases where don't find a file we can just throw an exception

When we get to a file we want to "load" post compile we'll need to create a new fiber and put this module on it. As an example we could have these 3 files

```javascript
// main.lay
import self:cool:{beans};
print(beans);
```

```javascript
// cool.lay
import self:stuff:{dude};
export let beans = [dude];
```

```javascript
// stuff.lay
export let dude = "cool";
```

In this example initially we would run `main.lay`. 
* When the vm starts up it'll make it the main module compile it then start running it on it's own fiber
* It reaches the `import self:cool:{beans};` then tries to load the module and fails.
* The new import service in laythe will then resolve this file and load the string into memory and compile it
* Once the module is compiled we create a new fiber and place our new module onto it then schedule it to run next suspending the `main.lay` fiber
* `cool.lay` reaches `import self:stuff:{dude};` then tries to load the module and fails.
* The new import service in laythe will then resolve this file and load the string into memory and compile it
* Once the module is compile we create another new fiber and place our new module onto it then schedule it to run next suspending the `cool.lay` fiber
* We execute the `export let dude = "cool";` exporting our new `dude` symbol. 
* Once the module is "done" we then resume the `cool.lay` fiber
* In `cool.lay`