### PR TITLE
Fix regressions

### DIFF
--- a/laythe_core/src/captures.rs
+++ b/laythe_core/src/captures.rs
@@ -8,7 +8,7 @@ use crate::{
   value::Value,
 };
 
-#[derive(PartialEq, Debug, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy)]
 pub struct Captures(Tuple);
 
 impl Captures {
@@ -67,5 +67,11 @@ impl Manage for Captures {
 
   fn as_debug(&self) -> &dyn DebugHeap {
     self
+  }
+}
+
+impl fmt::Debug for Captures {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    self.fmt_heap(f, 2)
   }
 }

--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -36,15 +36,19 @@ impl fmt::Display for FunKind {
 #[derive(Clone)]
 pub struct TryBlock {
   /// Start of the try block
-  start: u16,
+  start: usize,
 
   /// End of the try block
-  end: u16,
+  end: usize,
+
+  /// How many slots were used at the beginning of this
+  /// try catch
+  slots: usize
 }
 
 impl TryBlock {
-  pub fn new(start: u16, end: u16) -> Self {
-    TryBlock { start, end }
+  pub fn new(start: usize, end: usize, slots: usize) -> Self {
+    TryBlock { start, end, slots }
   }
 }
 
@@ -252,9 +256,9 @@ impl Fun {
     self.max_slot as usize
   }
 
-  pub fn has_catch_jump(&self, ip: u16) -> Option<u16> {
-    let mut min_range = std::u16::MAX;
-    let mut jump = None;
+  pub fn has_catch_jump(&self, ip: usize) -> Option<(usize, usize)> {
+    let mut min_range = std::usize::MAX;
+    let mut catch = None;
 
     for try_block in self.try_blocks.iter() {
       if ip >= try_block.start && ip < try_block.end {
@@ -262,12 +266,12 @@ impl Fun {
 
         if len < min_range {
           min_range = len;
-          jump = Some(try_block.end);
+          catch = Some((try_block.end, try_block.slots));
         }
       }
     }
 
-    jump
+    catch
   }
 }
 

--- a/laythe_core/src/object/mod.rs
+++ b/laythe_core/src/object/mod.rs
@@ -15,7 +15,7 @@ pub use channel::{Channel, CloseResult, ReceiveResult, SendResult};
 pub use class::Class;
 pub use closure::Closure;
 pub use enumerator::{Enumerate, Enumerator};
-pub use fiber::{Fiber, FiberResult, FiberState};
+pub use fiber::{Fiber, FiberResult, FiberState, UnwindResult};
 pub use fun::{Fun, FunBuilder, FunKind, TryBlock};
 pub use instance::Instance;
 pub use list::List;

--- a/laythe_vm/fixture/language/regression/catch_laythe_stack_overflow.lay
+++ b/laythe_vm/fixture/language/regression/catch_laythe_stack_overflow.lay
@@ -1,0 +1,13 @@
+for i in 1000.times() {
+  try {
+    let x;
+    let y;
+    let z;
+
+    [][1];
+  } catch {
+
+  }
+}
+
+assert(true)

--- a/laythe_vm/fixture/language/regression/native_stack_overvflow.lay
+++ b/laythe_vm/fixture/language/regression/native_stack_overvflow.lay
@@ -1,0 +1,7 @@
+for i in 100000.times() {
+  try {
+    [1].iter().map(|x| [][x]).list();
+  } catch {
+
+  }
+}

--- a/laythe_vm/src/vm.rs
+++ b/laythe_vm/src/vm.rs
@@ -2274,7 +2274,7 @@ impl Vm {
   }
 
   /// Search for a catch block up the stack, printing the error if no catch is found
-  fn stack_unwind(&mut self, error: GcObj<Instance>) -> Option<ExecuteResult> {
+  unsafe fn stack_unwind(&mut self, error: GcObj<Instance>) -> Option<ExecuteResult> {
     self.store_ip();
 
     match self.fiber.stack_unwind() {

--- a/laythe_vm/src/vm.rs
+++ b/laythe_vm/src/vm.rs
@@ -18,7 +18,7 @@ use laythe_core::{
   module::{Import, Module, Package},
   object::{
     Channel, Class, Closure, Fiber, Fun, Instance, List, LyBox, Map, Method, Native, NativeMeta,
-    ObjectKind, ReceiveResult, SendResult,
+    ObjectKind, ReceiveResult, SendResult, UnwindResult,
   },
   signature::{ArityError, Environment, ParameterKind, SignatureError},
   to_obj_kind,
@@ -66,6 +66,7 @@ pub enum ExecuteResult {
   CompileError,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ExecuteMode {
   Normal,
   CallFunction(usize),
@@ -561,7 +562,7 @@ impl Vm {
           },
           Signal::RuntimeError => match self.fiber.error() {
             Some(error) => {
-              if let Some(execute_result) = self.stack_unwind(error) {
+              if let Some(execute_result) = self.stack_unwind(error, mode) {
                 return execute_result;
               }
             }
@@ -2274,19 +2275,29 @@ impl Vm {
   }
 
   /// Search for a catch block up the stack, printing the error if no catch is found
-  unsafe fn stack_unwind(&mut self, error: GcObj<Instance>) -> Option<ExecuteResult> {
+  unsafe fn stack_unwind(
+    &mut self,
+    error: GcObj<Instance>,
+    mode: ExecuteMode,
+  ) -> Option<ExecuteResult> {
     self.store_ip();
 
-    match self.fiber.stack_unwind() {
-      Some(frame) => {
+    let bottom_frame = match mode {
+      ExecuteMode::Normal => 0,
+      ExecuteMode::CallFunction(depth) => depth,
+    };
+
+    match self.fiber.stack_unwind(bottom_frame) {
+      UnwindResult::Handled(frame) => {
         self.current_fun = frame.fun();
         self.ip = frame.ip();
         None
       }
-      None => {
+      UnwindResult::Unhandled => {
         self.print_error(error);
         Some(ExecuteResult::RuntimeError)
       }
+      UnwindResult::UnwindStopped => Some(ExecuteResult::RuntimeError),
     }
   }
 


### PR DESCRIPTION
## Summary
This PR fixes two regressions / bugs in the Vm.

1. A bug where we could overflow the native stack by never returns through a higher order function
2. A bug where we could endlessly fill up the VM stack by not reseting the stack after a catch fixes #12 