### PR TITLE
Simplify gc traits

### DIFF
--- a/laythe_core/src/captures.rs
+++ b/laythe_core/src/captures.rs
@@ -1,8 +1,8 @@
-use std::{fmt, mem};
+use std::fmt;
 
 use crate::{
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, GcObj, Manage, Trace, Tuple},
+  managed::{DebugHeap, DebugWrap, GcObj, Trace, Tuple},
   object::LyBox,
   val,
   value::Value,
@@ -57,16 +57,6 @@ impl DebugHeap for Captures {
     f.debug_struct("Captures")
       .field("0", &DebugWrap(&&*self.0, depth))
       .finish()
-  }
-}
-
-impl Manage for Captures {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>() + mem::size_of::<Value>() * self.len()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/captures.rs
+++ b/laythe_core/src/captures.rs
@@ -54,8 +54,8 @@ impl Trace for Captures {
 
 impl DebugHeap for Captures {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
-    f.debug_struct("Captures")
-      .field("0", &DebugWrap(&&*self.0, depth))
+    f.debug_tuple("Captures")
+      .field(&DebugWrap(&&*self.0, depth))
       .finish()
   }
 }

--- a/laythe_core/src/hooks.rs
+++ b/laythe_core/src/hooks.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-  managed::{Gc, GcObj, GcStr, Manage, Object, Trace, TraceRoot, Tuple},
+  managed::{Allocate, GcObj, GcStr, Object, Trace, TraceRoot, Tuple},
   memory::Allocator,
   value::{Value, VALUE_NIL},
   Call,
@@ -75,7 +75,7 @@ impl<'a> Hooks<'a> {
   }
 
   /// Request an object be managed by this allocator
-  pub fn manage<T: 'static + Manage>(&self, data: T) -> Gc<T> {
+  pub fn manage<R: 'static + Trace + Copy, T: 'static + Allocate<R>>(&self, data: T) -> R {
     self.as_gc().manage(data)
   }
 
@@ -138,7 +138,7 @@ impl<'a> GcHooks<'a> {
 
   /// Request an object be managed by this allocator
   #[inline]
-  pub fn manage<T: 'static + Manage>(&self, data: T) -> Gc<T> {
+  pub fn manage<R: 'static + Trace + Copy, T: 'static + Allocate<R>>(&self, data: T) -> R {
     self.context.gc().manage(data, self.context)
   }
 

--- a/laythe_core/src/hooks.rs
+++ b/laythe_core/src/hooks.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-  managed::{Allocate, GcObj, GcStr, Object, Trace, TraceRoot, Tuple},
+  managed::{Allocate, DebugHeapRef, GcObj, GcStr, Object, Trace, TraceRoot, Tuple},
   memory::Allocator,
   value::{Value, VALUE_NIL},
   Call,
@@ -75,12 +75,16 @@ impl<'a> Hooks<'a> {
   }
 
   /// Request an object be managed by this allocator
-  pub fn manage<R: 'static + Trace + Copy, T: 'static + Allocate<R>>(&self, data: T) -> R {
+  pub fn manage<R, T>(&self, data: T) -> R
+  where
+    R: 'static + Trace + Copy + DebugHeapRef,
+    T: Allocate<R>,
+  {
     self.as_gc().manage(data)
   }
 
   /// Request a string be managed by this allocator
-  pub fn manage_obj<T: 'static + Object>(&self, obj: T) -> GcObj<T> {
+  pub fn manage_obj<T: Object>(&self, obj: T) -> GcObj<T> {
     self.as_gc().manage_obj(obj)
   }
 
@@ -138,13 +142,17 @@ impl<'a> GcHooks<'a> {
 
   /// Request an object be managed by this allocator
   #[inline]
-  pub fn manage<R: 'static + Trace + Copy, T: 'static + Allocate<R>>(&self, data: T) -> R {
+  pub fn manage<R, T>(&self, data: T) -> R
+  where
+    R: 'static + Trace + Copy + DebugHeapRef,
+    T: Allocate<R>,
+  {
     self.context.gc().manage(data, self.context)
   }
 
   /// Request a string be managed by this allocator
   #[inline]
-  pub fn manage_obj<T: 'static + Object>(&self, obj: T) -> GcObj<T> {
+  pub fn manage_obj<T: Object>(&self, obj: T) -> GcObj<T> {
     self.context.gc().manage_obj(obj, self.context)
   }
 
@@ -232,7 +240,10 @@ pub trait GcContext: TraceRoot {
 #[derive(Default)]
 pub struct NoContext {
   /// A reference to a gc just to allocate
-  pub gc: RefCell<Allocator>,
+  gc: RefCell<Allocator>,
+
+  // can we collect from this context
+  can_collect: bool,
 }
 
 impl NoContext {
@@ -240,7 +251,19 @@ impl NoContext {
   pub fn new(gc: Allocator) -> Self {
     Self {
       gc: RefCell::new(gc),
+      can_collect: false,
     }
+  }
+
+  pub fn with_collection(gc: Allocator) -> Self {
+    Self {
+      gc: RefCell::new(gc),
+      can_collect: true,
+    }
+  }
+
+  pub fn replace_gc(&self, gc: Allocator) -> Allocator {
+    self.gc.replace(gc)
   }
 
   pub fn done(self) -> Allocator {
@@ -254,7 +277,7 @@ impl TraceRoot for NoContext {
   fn trace_debug(&self, _stdout: &mut dyn Write) {}
 
   fn can_collect(&self) -> bool {
-    false
+    self.can_collect
   }
 }
 

--- a/laythe_core/src/lib.rs
+++ b/laythe_core/src/lib.rs
@@ -29,3 +29,24 @@ use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
 use managed::GcObj;
 use object::Instance;
+
+#[macro_export]
+macro_rules! impl_trace {
+  ( $x:ty ) => {
+    impl Trace for $x {
+      fn trace(&self) {}
+      fn trace_debug(&self, _log: &mut dyn std::io::Write) {}
+    }
+  };
+}
+
+#[macro_export]
+macro_rules! impl_debug_heap {
+  ( $x:ty ) => {
+    impl DebugHeap for $x {
+      fn fmt_heap(&self, f: &mut std::fmt::Formatter, _depth: usize) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?}", self))
+      }
+    }
+  };
+}

--- a/laythe_core/src/managed/allocation.rs
+++ b/laythe_core/src/managed/allocation.rs
@@ -1,6 +1,6 @@
 use std::{
-  fmt, mem,
-  sync::atomic::{AtomicBool, Ordering},
+  fmt,
+  sync::atomic::{AtomicBool, Ordering}, mem,
 };
 
 use super::{

--- a/laythe_core/src/managed/allocation.rs
+++ b/laythe_core/src/managed/allocation.rs
@@ -28,25 +28,12 @@ impl<T: 'static> Allocation<T> {
   }
 }
 
-impl<T: 'static + DebugHeap> Allocation<T> {
-  /// What is the size of this allocation in bytes
-  #[inline]
-  pub fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  /// Get a trait object is can be logged for the heap
-  pub fn as_debug(&self) -> &dyn DebugHeap {
-    &self.data
-  }
-}
-
 impl<T> Mark for Allocation<T> {
   /// Mark this allocation as visited, returning
   /// the existing marked status
   #[inline]
   fn mark(&self) -> bool {
-    self.header.marked()
+    self.header.mark()
   }
 }
 
@@ -66,16 +53,20 @@ impl<T> Unmark for Allocation<T> {
 
 impl<T: 'static + DebugHeap> Manage for Allocation<T> {
   fn size(&self) -> usize {
-    mem::size_of::<T>()
+    mem::size_of::<Self>()
   }
 
   fn as_debug(&self) -> &dyn DebugHeap {
-    &self.data
+    self
+  }
+
+  fn loc(&self) -> *const u8 {
+    (self as *const Allocation<T>) as *const u8
   }
 }
 
 impl<T: 'static + DebugHeap> DebugHeap for Allocation<T> {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
-    self.data.fmt_heap(f, depth)
+    self.data.fmt_heap(f, depth.saturating_sub(1))
   }
 }

--- a/laythe_core/src/managed/gc.rs
+++ b/laythe_core/src/managed/gc.rs
@@ -89,7 +89,7 @@ impl<T: 'static + Trace + DebugHeap> Trace for Gc<T> {
 impl<T: 'static + DebugHeap> DebugHeap for Gc<T> {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
     if depth == 0 {
-      f.write_fmt(format_args!("{:p}", &self.ptr))
+      f.write_fmt(format_args!("{:p}", self.ptr))
     } else {
       f.write_fmt(format_args!(
         "{:?}",

--- a/laythe_core/src/managed/gc_array.rs
+++ b/laythe_core/src/managed/gc_array.rs
@@ -173,6 +173,7 @@ impl<T, H: Marked> Marked for GcArray<T, H> {
 }
 
 impl<T: Trace + DebugHeap, H: Send + Mark> Trace for GcArray<T, H> {
+  #[inline]
   fn trace(&self) {
     if self.mark() {
       return;
@@ -181,6 +182,7 @@ impl<T: Trace + DebugHeap, H: Send + Mark> Trace for GcArray<T, H> {
     self.iter().for_each(|i| i.trace());
   }
 
+  #[inline]
   fn trace_debug(&self, log: &mut dyn std::io::Write) {
     if self.mark() {
       return;
@@ -202,7 +204,7 @@ impl<T: Trace + DebugHeap, H: Send + Mark> Trace for GcArray<T, H> {
 impl<T: DebugHeap, H> DebugHeap for GcArray<T, H> {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
     if depth == 0 {
-      f.write_fmt(format_args!("{:p}", &self.ptr))
+      f.write_fmt(format_args!("{:p}", self.ptr))
     } else {
       f.debug_list()
         .entries(self.iter().map(|x| DebugWrap(x, depth.saturating_sub(1))))
@@ -229,6 +231,7 @@ impl<T, H> Clone for GcArray<T, H> {
 impl<T, H> Deref for GcArray<T, H> {
   type Target = [T];
 
+  #[inline]
   fn deref(&self) -> &Self::Target {
     let data = self.data();
     let len = self.len();
@@ -237,6 +240,7 @@ impl<T, H> Deref for GcArray<T, H> {
 }
 
 impl<T, H> DerefMut for GcArray<T, H> {
+  #[inline]
   fn deref_mut(&mut self) -> &mut Self::Target {
     let data = self.data();
     let len = self.len();

--- a/laythe_core/src/managed/gc_array.rs
+++ b/laythe_core/src/managed/gc_array.rs
@@ -15,9 +15,8 @@ use std::{
 };
 
 use super::{
-  gc_obj::ObjHeader,
   utils::{get_array_len_offset, get_array_offset, make_array_layout},
-  DebugHeap, DebugWrap, GcObject, GcObjectHandle,
+  DebugHeap, DebugWrap, GcObject, GcObjectHandle, header::ObjHeader,
 };
 
 pub type Tuple = GcArray<Value, ObjHeader>;

--- a/laythe_core/src/managed/gc_array.rs
+++ b/laythe_core/src/managed/gc_array.rs
@@ -1,3 +1,8 @@
+use super::{
+  header::{Header, ObjHeader},
+  utils::{get_array_len_offset, get_array_offset, make_array_layout},
+  AllocResult, Allocate, DebugHeap, DebugHeapRef, DebugWrap, GcObject, GcObjectHandle, Manage,
+};
 use crate::{
   managed::{Mark, Marked, Trace, Unmark},
   object::ObjectKind,
@@ -14,12 +19,11 @@ use std::{
   slice::{self},
 };
 
-use super::{
-  utils::{get_array_len_offset, get_array_offset, make_array_layout},
-  DebugHeap, DebugWrap, GcObject, GcObjectHandle, header::ObjHeader,
-};
-
-pub type Tuple = GcArray<Value, ObjHeader>;
+pub type ObjArray<T> = GcArray<T, ObjHeader>;
+pub type Array<T> = GcArray<T, Header>;
+pub type ObjArrayHandle<T> = GcArrayHandle<T, ObjHeader>;
+pub type Tuple = ObjArray<Value>;
+pub type TupleHandle = ObjArrayHandle<Value>;
 
 pub fn tuple_handle(slice: &[Value]) -> GcArrayHandle<Value, ObjHeader> {
   GcArrayHandle::from_slice(slice, ObjHeader::new(ObjectKind::Tuple))
@@ -168,7 +172,7 @@ impl<T, H: Marked> Marked for GcArray<T, H> {
   }
 }
 
-impl<T: Trace, H: Send + Mark> Trace for GcArray<T, H> {
+impl<T: Trace + DebugHeap, H: Send + Mark> Trace for GcArray<T, H> {
   fn trace(&self) {
     if self.mark() {
       return;
@@ -182,15 +186,36 @@ impl<T: Trace, H: Send + Mark> Trace for GcArray<T, H> {
       return;
     }
 
+    log
+      .write_fmt(format_args!(
+        "{:p} mark {:?}\n",
+        self.ptr,
+        DebugWrap(self, 1)
+      ))
+      .expect("unable to write to stdout");
+    log.flush().expect("unable to flush stdout");
+
     self.iter().for_each(|i| i.trace_debug(log));
   }
 }
 
-impl<T: 'static + Trace + DebugHeap, H> DebugHeap for GcArray<T, H> {
+impl<T: DebugHeap, H> DebugHeap for GcArray<T, H> {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
-    f.debug_list()
-      .entries(self.iter().map(|x| DebugWrap(x, depth)))
-      .finish()
+    if depth == 0 {
+      f.write_fmt(format_args!("{:p}", &self.ptr))
+    } else {
+      f.debug_list()
+        .entries(self.iter().map(|x| DebugWrap(x, depth.saturating_sub(1))))
+        .finish()
+    }
+  }
+}
+
+impl<T: DebugHeap, H> DebugHeapRef for GcArray<T, H> {}
+
+impl<T, H> fmt::Pointer for GcArray<T, H> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Pointer::fmt(&self.ptr, f)
   }
 }
 
@@ -244,7 +269,7 @@ impl<T: Display, H> Display for GcArray<T, H> {
 
 impl<T: Debug, H> Debug for GcArray<T, H> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.debug_list().entry(self).finish()
+    f.debug_list().entries(self.iter()).finish()
   }
 }
 
@@ -377,9 +402,35 @@ impl<T, H> DerefMut for GcArrayHandle<T, H> {
   }
 }
 
+impl<T: DebugHeap, H> DebugHeap for GcArrayHandle<T, H> {
+  fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
+    self.0.fmt_heap(f, depth)
+  }
+}
+
+impl<T, H> fmt::Pointer for GcArrayHandle<T, H> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.0.fmt(f)
+  }
+}
+
 impl<T: Copy, H: Default> From<&[T]> for GcArrayHandle<T, H> {
   fn from(slice: &[T]) -> Self {
     GcArrayHandle::from_slice(slice, H::default())
+  }
+}
+
+impl<T: DebugHeap, H: Unmark + Marked> Manage for GcArrayHandle<T, H> {
+  fn size(&self) -> usize {
+    self.size()
+  }
+
+  fn as_debug(&self) -> &dyn DebugHeap {
+    self
+  }
+
+  fn loc(&self) -> *const u8 {
+    self.0.as_alloc_ptr()
   }
 }
 
@@ -396,6 +447,18 @@ impl<T, H> Drop for GcArrayHandle<T, H> {
 
       dealloc(self.0.ptr.as_ptr(), make_array_layout::<H, T>(len));
     }
+  }
+}
+
+impl<T: 'static + Trace + Copy + DebugHeap> Allocate<GcArray<T, Header>> for &[T] {
+  fn alloc(self) -> AllocResult<GcArray<T, Header>> {
+    let handle = GcArrayHandle::from_slice(self, Header::new(false));
+    let reference = handle.value();
+
+    let handle = Box::new(handle);
+    let handle = handle as Box<dyn Manage>;
+
+    AllocResult { handle, reference }
   }
 }
 

--- a/laythe_core/src/managed/gc_obj.rs
+++ b/laythe_core/src/managed/gc_obj.rs
@@ -1,6 +1,6 @@
 use super::{
   gc_array::Tuple,
-  manage::{DebugHeap, DebugWrap, Manage, Trace},
+  manage::{DebugHeap, DebugWrap, Trace},
   utils::{get_array_len_offset, get_offset, make_array_layout, make_layout},
   GcArray, GcStr, Mark, Marked, Unmark,
 };
@@ -24,7 +24,7 @@ use std::{
   sync::atomic::{AtomicBool, Ordering},
 };
 
-pub trait Object: Manage {
+pub trait Object: Trace + DebugHeap {
   fn kind(&self) -> ObjectKind;
 }
 
@@ -252,18 +252,6 @@ impl<T: 'static + Object> DebugHeap for GcObj<T> {
         DebugWrap(self.data(), depth.saturating_sub(1))
       ))
     }
-  }
-}
-
-impl<T: 'static + Object> Manage for GcObj<T> {
-  #[inline]
-  fn size(&self) -> usize {
-    self.data().size()
-  }
-
-  #[inline]
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 
@@ -790,11 +778,11 @@ impl GcObjectHandle {
         ObjectKind::String => {
           let len = array_len(self);
           make_array_layout::<ObjHeader, u8>(len).size()
-        },
+        }
         ObjectKind::Tuple => {
           let len = array_len(self);
           make_array_layout::<ObjHeader, Value>(len).size()
-        },
+        }
       }
   }
 }
@@ -836,7 +824,7 @@ impl Drop for GcObjectHandle {
             self.ptr.as_ptr(),
             make_array_layout::<ObjHeader, Value>(len),
           );
-        },
+        }
         ObjectKind::Tuple => {
           let len = array_len(self);
 
@@ -851,7 +839,7 @@ impl Drop for GcObjectHandle {
             self.ptr.as_ptr(),
             make_array_layout::<ObjHeader, Value>(len),
           );
-        },
+        }
       }
     }
   }

--- a/laythe_core/src/managed/gc_obj.rs
+++ b/laythe_core/src/managed/gc_obj.rs
@@ -193,7 +193,7 @@ impl<T: 'static + Object> Trace for GcObj<T> {
 impl<T: 'static + Object> DebugHeap for GcObj<T> {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
     if depth == 0 {
-      f.write_fmt(format_args!("{:p}", &self.ptr))
+      f.write_fmt(format_args!("{:p}", self.ptr))
     } else {
       f.write_fmt(format_args!(
         "{:?}",
@@ -614,7 +614,7 @@ impl Trace for GcObject {
 impl DebugHeap for GcObject {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
     if depth == 0 {
-      return f.write_fmt(format_args!("{:p}", &self.ptr));
+      return f.write_fmt(format_args!("{:p}", self.ptr));
     }
 
     match_obj!((self) {

--- a/laythe_core/src/managed/gc_str.rs
+++ b/laythe_core/src/managed/gc_str.rs
@@ -138,7 +138,7 @@ impl Trace for GcStr {
 impl DebugHeap for GcStr {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> std::fmt::Result {
     if depth == 0 {
-      f.write_fmt(format_args!("{:p}", &self.0.ptr))
+      f.write_fmt(format_args!("{:p}", self.0.ptr))
     } else {
       f.write_fmt(format_args!("{}", self))
     }
@@ -210,6 +210,7 @@ impl Hash for GcStr {
 impl Deref for GcStr {
   type Target = str;
 
+  #[inline]
   fn deref(&self) -> &Self::Target {
     unsafe { str::from_utf8_unchecked(&self.0) }
   }

--- a/laythe_core/src/managed/gc_str.rs
+++ b/laythe_core/src/managed/gc_str.rs
@@ -1,7 +1,7 @@
 use crate::{
   managed::{
     gc_array::{GcArray, GcArrayHandle},
-    DebugHeap, Manage, Mark, Trace,
+    DebugHeap, Mark, Trace,
   },
   object::ObjectKind,
 };
@@ -145,16 +145,6 @@ impl DebugHeap for GcStr {
     } else {
       f.write_fmt(format_args!("{}", self))
     }
-  }
-}
-
-impl Manage for GcStr {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>() + make_array_layout::<ObjHeader, u8>(self.len()).size()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/managed/gc_str.rs
+++ b/laythe_core/src/managed/gc_str.rs
@@ -11,16 +11,13 @@ use std::{
   fmt,
   hash::{Hash, Hasher},
   io::Write,
-  mem,
   ops::Deref,
   ptr::{self, NonNull},
   str,
 };
 
 use super::{
-  gc_obj::{GcObject},
-  utils::make_array_layout,
-  GcObjectHandle, Marked, Unmark, header::ObjHeader,
+  gc_obj::GcObject, header::ObjHeader, utils::make_array_layout, GcObjectHandle, Marked, Unmark,
 };
 
 /// A non owning reference to a Garbage collector
@@ -141,7 +138,7 @@ impl Trace for GcStr {
 impl DebugHeap for GcStr {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> std::fmt::Result {
     if depth == 0 {
-      f.write_str("*")
+      f.write_fmt(format_args!("{:p}", &self.0.ptr))
     } else {
       f.write_fmt(format_args!("{}", self))
     }
@@ -304,11 +301,11 @@ impl GcStrHandle {
   /// let data = &"example";
   /// let handle = GcStrHandle::from(data);
   ///
-  /// assert_eq!(handle.size(), 31);
+  /// assert_eq!(handle.size(), 23);
   /// ```
   #[inline]
   pub fn size(&self) -> usize {
-    mem::size_of::<Self>() + make_array_layout::<ObjHeader, u8>(self.0.len()).size()
+    make_array_layout::<ObjHeader, u8>(self.0.len()).size()
   }
 }
 

--- a/laythe_core/src/managed/gc_str.rs
+++ b/laythe_core/src/managed/gc_str.rs
@@ -18,9 +18,9 @@ use std::{
 };
 
 use super::{
-  gc_obj::{GcObject, ObjHeader},
+  gc_obj::{GcObject},
   utils::make_array_layout,
-  GcObjectHandle, Marked, Unmark,
+  GcObjectHandle, Marked, Unmark, header::ObjHeader,
 };
 
 /// A non owning reference to a Garbage collector

--- a/laythe_core/src/managed/header.rs
+++ b/laythe_core/src/managed/header.rs
@@ -1,0 +1,95 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::object::ObjectKind;
+
+use super::{Mark, Marked, Unmark};
+
+/// The header of an allocation indicate meta data about the object
+#[derive(Debug, Default)]
+pub struct Header {
+  // has this allocation been marked by the garbage collector
+  marked: AtomicBool,
+}
+
+impl Header {
+  pub fn new(marked: bool) -> Self {
+    Self {
+      marked: AtomicBool::new(marked),
+    }
+  }
+}
+
+impl Mark for Header {
+  /// Mark this allocation as visited, returning
+  /// the existing marked status
+  #[inline]
+  fn mark(&self) -> bool {
+    self.marked.swap(true, Ordering::Release)
+  }
+}
+
+impl Marked for Header {
+  #[inline]
+  fn marked(&self) -> bool {
+    self.marked.load(Ordering::Acquire)
+  }
+}
+
+impl Unmark for Header {
+  #[inline]
+  fn unmark(&self) -> bool {
+    self.marked.swap(false, Ordering::Release)
+  }
+}
+
+/// The `Header` meta data for `GcObj<T>` and `GcObject`. This struct
+/// is positioned at the front of the array such that the layout looks like
+/// this
+/// ```markdown
+/// [Header (potential padding)| T ]
+/// ```
+pub struct ObjHeader {
+  /// Has this allocation been marked by the garbage collector
+  marked: AtomicBool,
+
+  /// The underlying value kind of this object
+  kind: ObjectKind,
+}
+
+impl ObjHeader {
+  /// Create a new object header
+  #[inline]
+  pub fn new(kind: ObjectKind) -> Self {
+    Self {
+      marked: AtomicBool::new(false),
+      kind,
+    }
+  }
+
+  /// What is the value kind of this object
+  #[inline]
+  pub fn kind(&self) -> ObjectKind {
+    self.kind
+  }
+}
+
+impl Mark for ObjHeader {
+  #[inline]
+  fn mark(&self) -> bool {
+    self.marked.swap(true, Ordering::Release)
+  }
+}
+
+impl Unmark for ObjHeader {
+  #[inline]
+  fn unmark(&self) -> bool {
+    self.marked.swap(false, Ordering::Release)
+  }
+}
+
+impl Marked for ObjHeader {
+  #[inline]
+  fn marked(&self) -> bool {
+    self.marked.load(Ordering::Acquire)
+  }
+}

--- a/laythe_core/src/managed/manage.rs
+++ b/laythe_core/src/managed/manage.rs
@@ -29,6 +29,9 @@ pub trait DebugHeap {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result;
 }
 
+/// A utility to print debug information to a fixed depth in the Laythe heap
+pub trait DebugHeapRef: DebugHeap + fmt::Pointer {}
+
 /// A struct that can indicate it's status are marked or unmarked
 pub trait Marked {
   /// Is this structure marked
@@ -72,12 +75,16 @@ pub trait TraceRoot {
 
 /// An entity that can be managed and collected by the garbage collector.
 /// This trait provided debugging capabilities and statistics for the gc.
-pub trait Manage: DebugHeap + Mark + Unmark + Marked {
+pub trait Manage: DebugHeap + Unmark {
   /// What is the size of this allocation
   fn size(&self) -> usize;
 
   /// Helper function to get a trait object for Debug Heap
   fn as_debug(&self) -> &dyn DebugHeap;
+
+  /// Get the actual allocation location where
+  /// this resource is managed
+  fn loc(&self) -> *const u8;
 }
 
 /// Define how a struct should be allocated by the garbage collector
@@ -88,14 +95,11 @@ pub trait Allocate<R: Trace> {
 
 pub struct AllocResult<R> {
   pub handle: Box<dyn Manage>,
-  pub reference: R
+  pub reference: R,
 }
 
 impl<R> AllocResult<R> {
   pub fn new(handle: Box<dyn Manage>, reference: R) -> Self {
-    Self {
-      handle,
-      reference
-    }
+    Self { handle, reference }
   }
 }

--- a/laythe_core/src/managed/mod.rs
+++ b/laythe_core/src/managed/mod.rs
@@ -3,6 +3,7 @@ mod gc;
 mod gc_array;
 mod gc_obj;
 mod gc_str;
+mod header;
 mod manage;
 mod utils;
 
@@ -12,5 +13,6 @@ pub use gc_array::{tuple_handle, GcArray, GcArrayHandle, Tuple};
 pub use gc_obj::{GcObj, GcObject, GcObjectHandle, GcObjectHandleBuilder, Object};
 pub use gc_str::{GcStr, GcStrHandle};
 pub use manage::{
-  DebugHeap, DebugWrap, DebugWrapDyn, Manage, Mark, Marked, Trace, TraceRoot, Unmark,
+  AllocResult, Allocate, DebugHeap, DebugWrap, DebugWrapDyn, Manage, Mark, Marked, Trace,
+  TraceRoot, Unmark,
 };

--- a/laythe_core/src/managed/mod.rs
+++ b/laythe_core/src/managed/mod.rs
@@ -9,10 +9,10 @@ mod utils;
 
 pub use allocation::Allocation;
 pub use gc::Gc;
-pub use gc_array::{tuple_handle, GcArray, GcArrayHandle, Tuple};
+pub use gc_array::{tuple_handle, Array, GcArray, GcArrayHandle, Tuple, TupleHandle};
 pub use gc_obj::{GcObj, GcObject, GcObjectHandle, GcObjectHandleBuilder, Object};
 pub use gc_str::{GcStr, GcStrHandle};
 pub use manage::{
-  AllocResult, Allocate, DebugHeap, DebugWrap, DebugWrapDyn, Manage, Mark, Marked, Trace,
-  TraceRoot, Unmark,
+  AllocResult, Allocate, DebugHeap, DebugHeapRef, DebugWrap, DebugWrapDyn, Manage, Mark, Marked,
+  Trace, TraceRoot, Unmark,
 };

--- a/laythe_core/src/managed/utils.rs
+++ b/laythe_core/src/managed/utils.rs
@@ -64,7 +64,7 @@ pub fn make_array_layout<H, T>(len: usize) -> Layout {
 }
 
 /// Create a rust `Layout` for a `GcArray` of `len` length.
-pub fn make_layout<H, T>() -> Layout {
+pub fn make_obj_layout<H, T>() -> Layout {
   let alignment = max_align::<H, T>();
 
   let header_size = mem::size_of::<H>();
@@ -188,20 +188,20 @@ mod tests {
   fn make_layout_test() {
     // non-empty, less than
     //
-    let layout = make_layout::<u64, i32>();
+    let layout = make_obj_layout::<u64, i32>();
     assert!(mem::align_of::<i32>() < mem::align_of::<u64>());
     assert_eq!(layout.align(), mem::align_of::<u64>());
     assert_eq!(layout.size(), mem::size_of::<u64>() + mem::size_of::<i32>());
 
     // non-empty, equal
     //
-    let layout = make_layout::<u64, i64>();
+    let layout = make_obj_layout::<u64, i64>();
     assert_eq!(mem::align_of::<i64>(), mem::align_of::<u64>());
     assert_eq!(layout.align(), mem::align_of::<u64>());
     assert_eq!(layout.size(), mem::size_of::<u64>() + mem::size_of::<i64>());
 
     // non-empty, greater
-    let layout = make_layout::<u64, OverAligned>();
+    let layout = make_obj_layout::<u64, OverAligned>();
     assert!(mem::align_of::<OverAligned>() > mem::align_of::<u64>());
     assert_eq!(layout.align(), mem::align_of::<OverAligned>());
     assert_eq!(

--- a/laythe_core/src/memory.rs
+++ b/laythe_core/src/memory.rs
@@ -611,7 +611,7 @@ fn debug_free_obj(obj: &GcObjectHandle, free: bool) {
   if free {
     println!(
       "{:p} free {} bytes from {:?}",
-      obj,
+      *obj,
       obj.size(),
       DebugWrapDyn(obj, 1)
     )

--- a/laythe_core/src/memory.rs
+++ b/laythe_core/src/memory.rs
@@ -109,7 +109,11 @@ impl<'a> Allocator {
   ///
   /// assert_eq!(ly_box.value, Value::from(10.0));
   /// ```
-  pub fn manage_obj<T: Object, C: TraceRoot + ?Sized>(&mut self, data: T, context: &C) -> GcObj<T> {
+  pub fn manage_obj<T, C>(&mut self, data: T, context: &C) -> GcObj<T>
+  where
+    T: Object,
+    C: TraceRoot + ?Sized,
+  {
     self.allocate_obj(data, context)
   }
 
@@ -126,7 +130,11 @@ impl<'a> Allocator {
   ///
   /// assert_eq!(&*str, "hi!");
   /// ```
-  pub fn manage_str<S: AsRef<str>, C: TraceRoot + ?Sized>(&mut self, src: S, context: &C) -> GcStr {
+  pub fn manage_str<S, C>(&mut self, src: S, context: &C) -> GcStr
+  where
+    S: AsRef<str>,
+    C: TraceRoot + ?Sized,
+  {
     let string = src.as_ref();
     if let Some(cached) = self.intern_cache.get(string) {
       return *cached;
@@ -231,7 +239,11 @@ impl<'a> Allocator {
     reference
   }
 
-  fn allocate_obj<T: Object, C: TraceRoot + ?Sized>(&mut self, data: T, context: &C) -> GcObj<T> {
+  fn allocate_obj<T, C>(&mut self, data: T, context: &C) -> GcObj<T>
+  where
+    T: Object,
+    C: TraceRoot + ?Sized,
+  {
     // create own store of allocation
     let object_handle = GcObjectHandleBuilder::from(data);
     let size = object_handle.size();

--- a/laythe_core/src/memory.rs
+++ b/laythe_core/src/memory.rs
@@ -5,6 +5,7 @@ use crate::managed::{
 use crate::value::Value;
 use hashbrown::HashMap;
 use laythe_env::stdio::Stdio;
+use std::mem;
 use std::ptr::NonNull;
 use std::{cell::RefCell, io::Write};
 
@@ -208,7 +209,7 @@ impl<'a> Allocator {
     let mut alloc = Box::new(Allocation::new(data));
     let ptr = unsafe { NonNull::new_unchecked(&mut *alloc) };
 
-    let size = alloc.size();
+    let size = mem::size_of::<Allocation<T>>();
 
     // push onto heap
     self.bytes_allocated += size;
@@ -579,18 +580,6 @@ impl<'a> Allocator {
       string, size, string,
     )
     .expect("unable to write to stdout");
-  }
-}
-
-/// Debug logging for removing a string from the cache.
-#[cfg(feature = "gc_log_free")]
-fn debug_string_remove(string: &GcStrHandle, free: bool) {
-  if free {
-    println!(
-      "{:p} remove string from cache {:?}",
-      string,
-      DebugWrap(string, 1)
-    )
   }
 }
 

--- a/laythe_core/src/module/import.rs
+++ b/laythe_core/src/module/import.rs
@@ -10,12 +10,12 @@ use crate::{
 /// An object representing an import request from a file
 pub struct Import {
   package: GcStr,
-  path: Gc<List<GcStr>>,
+  path: List<GcStr>,
 }
 
 impl Import {
   /// Create a new import
-  pub fn new(package: GcStr, path: Gc<List<GcStr>>) -> Self {
+  pub fn new(package: GcStr, path: List<GcStr>) -> Self {
     Self { package, path }
   }
 
@@ -36,8 +36,7 @@ impl Import {
       let package = hooks.manage_str(package);
       hooks.push_root(package);
 
-      let path: Gc<List<GcStr>> = hooks.manage(List::with_capacity(path.len()));
-      hooks.push_root(path);
+      let path: List<GcStr> = List::with_capacity(path.len());
 
       let mut import = hooks.manage(Self::new(package, path));
       hooks.push_root(import);
@@ -46,7 +45,7 @@ impl Import {
         .path
         .extend(path_slice.iter().map(|segment| hooks.manage_str(segment)));
 
-      hooks.pop_roots(3);
+      hooks.pop_roots(2);
       Ok(import)
     } else {
       Err(ModuleError::InvalidImport)

--- a/laythe_core/src/module/import.rs
+++ b/laythe_core/src/module/import.rs
@@ -1,9 +1,7 @@
-use std::mem;
-
 use super::{ModuleError, ModuleResult};
 use crate::{
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, Gc, GcStr, Manage, Trace},
+  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcStr, Trace},
   object::List,
 };
 
@@ -65,13 +63,9 @@ impl Trace for Import {
   }
 }
 
-impl Manage for Import {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
+impl Allocate<Gc<Self>> for Import {
+  fn alloc(self) -> AllocResult<Gc<Self>> {
+    Gc::alloc_result(self)
   }
 }
 

--- a/laythe_core/src/module/mod.rs
+++ b/laythe_core/src/module/mod.rs
@@ -14,8 +14,8 @@ use crate::{
   LyHashSet,
 };
 use hashbrown::hash_map;
+use std::{path::PathBuf, mem};
 use std::{fmt, io::Write};
-use std::{mem, path::PathBuf};
 
 /// A struct representing a collection of class functions and variable of shared functionality
 #[derive(Clone)]

--- a/laythe_core/src/module/package.rs
+++ b/laythe_core/src/module/package.rs
@@ -1,11 +1,11 @@
 use super::{error::ModuleResult, import::Import, Module, ModuleError};
 use crate::{
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Manage, Trace},
+  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace, Allocate, AllocResult},
   object::Instance,
   value::Value,
 };
-use std::{fmt, io::Write, mem};
+use std::{fmt, io::Write};
 
 #[derive(Clone)]
 pub struct Package {
@@ -86,13 +86,9 @@ impl DebugHeap for Package {
   }
 }
 
-impl Manage for Package {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
+impl Allocate<Gc<Self>> for Package {
+  fn alloc(self) -> AllocResult<Gc<Self>> {
+    Gc::alloc_result(self)
   }
 }
 

--- a/laythe_core/src/module/package.rs
+++ b/laythe_core/src/module/package.rs
@@ -5,8 +5,7 @@ use crate::{
   object::Instance,
   value::Value,
 };
-use std::mem;
-use std::{fmt, io::Write};
+use std::{fmt, io::Write, mem};
 
 #[derive(Clone)]
 pub struct Package {

--- a/laythe_core/src/object/channel.rs
+++ b/laythe_core/src/object/channel.rs
@@ -1,11 +1,11 @@
 use super::{Fiber, ObjectKind};
 use crate::{
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, Gc, GcObj, Manage, Object, Trace},
+  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcObj, Object, Trace},
   value::Value,
   LyHashSet,
 };
-use std::{collections::VecDeque, usize, mem};
+use std::{collections::VecDeque, usize};
 use std::{fmt, io::Write};
 
 #[derive(PartialEq, Clone, Debug)]
@@ -255,13 +255,9 @@ impl DebugHeap for ChannelQueue {
   }
 }
 
-impl Manage for ChannelQueue {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>() + mem::size_of::<Value>() * self.queue.capacity()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
+impl Allocate<Gc<Self>> for ChannelQueue {
+  fn alloc(self) -> AllocResult<Gc<Self>> {
+    Gc::alloc_result(self)
   }
 }
 

--- a/laythe_core/src/object/channel.rs
+++ b/laythe_core/src/object/channel.rs
@@ -5,8 +5,8 @@ use crate::{
   value::Value,
   LyHashSet,
 };
-use std::{collections::VecDeque, usize};
-use std::{fmt, io::Write, mem};
+use std::{collections::VecDeque, usize, mem};
+use std::{fmt, io::Write};
 
 #[derive(PartialEq, Clone, Debug)]
 enum ChannelKind {
@@ -156,7 +156,7 @@ impl ChannelQueue {
           self.send_waiters.insert(fiber);
           SendResult::Full(get_runnable_from_set(&mut self.receive_waiters))
         }
-      },
+      }
       ChannelQueueState::Closed | ChannelQueueState::ClosedEmpty => SendResult::Closed,
     }
   }
@@ -176,14 +176,14 @@ impl ChannelQueue {
           } else {
             ReceiveResult::Empty(get_runnable_from_set(&mut self.send_waiters))
           }
-        },
+        }
       },
       ChannelQueueState::Closed => match self.queue.pop_front() {
         Some(value) => ReceiveResult::Ok(value),
         None => {
           self.state = ChannelQueueState::ClosedEmpty;
           ReceiveResult::Closed
-        },
+        }
       },
       ChannelQueueState::ClosedEmpty => ReceiveResult::Closed,
     }
@@ -199,7 +199,7 @@ impl ChannelQueue {
         } else {
           get_runnable_from_set(&mut self.receive_waiters)
         }
-      },
+      }
       ChannelQueueKind::Buffered => {
         if self.is_empty() && !self.is_closed() {
           get_runnable_from_set(&mut self.send_waiters)
@@ -209,7 +209,7 @@ impl ChannelQueue {
           get_runnable_from_set(&mut self.receive_waiters)
             .or_else(|| get_runnable_from_set(&mut self.send_waiters))
         }
-      },
+      }
     }
   }
 
@@ -404,16 +404,6 @@ impl DebugHeap for Channel {
   }
 }
 
-impl Manage for Channel {
-  fn size(&self) -> usize {
-    mem::size_of::<Channel>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
-  }
-}
-
 impl Object for Channel {
   fn kind(&self) -> ObjectKind {
     ObjectKind::Channel
@@ -587,7 +577,7 @@ mod test {
             } else {
               assert!(false)
             }
-          },
+          }
           _ => assert!(false),
         }
 

--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -1,11 +1,11 @@
 use crate::{
   constants::INIT,
-  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, GcObj, GcStr, Object, Trace},
 };
 use crate::{hooks::GcHooks, value::Value};
 use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
-use std::{fmt, io::Write, mem};
+use std::{fmt, io::Write};
 
 use super::ObjectKind;
 
@@ -72,7 +72,7 @@ impl Class {
     &self.super_class
   }
 
-  pub fn is_subclass(&self, class: Gc<Class>) -> bool {
+  pub fn is_subclass(&self, class: GcObj<Class>) -> bool {
     if self == &*class {
       return true;
     }
@@ -237,17 +237,6 @@ impl DebugHeap for Class {
       .field("methods", &DebugWrap(&self.methods, depth))
       .field("init", &DebugWrap(&self.init, depth))
       .finish()
-  }
-}
-
-impl Manage for Class {
-  fn size(&self) -> usize {
-    mem::size_of::<Class>()
-      + (mem::size_of::<GcStr>() + mem::size_of::<Value>()) * self.methods.capacity()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/closure.rs
+++ b/laythe_core/src/object/closure.rs
@@ -1,10 +1,9 @@
 use super::{Fun, ObjectKind};
 use crate::{
   captures::Captures,
-  managed::{DebugHeap, DebugWrap, GcObj, Manage, Object, Trace},
-  value::Value,
+  managed::{DebugHeap, DebugWrap, GcObj, Object, Trace},
 };
-use std::{fmt, io::Write, mem};
+use std::{fmt, io::Write};
 
 #[derive(PartialEq, Clone)]
 pub struct Closure {
@@ -84,16 +83,6 @@ impl DebugHeap for Closure {
       .field("fun", &DebugWrap(&self.fun, depth))
       .field("captures", &DebugWrap(&self.captures, depth))
       .finish()
-  }
-}
-
-impl Manage for Closure {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>() + mem::size_of::<Value>() * self.captures.len()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/closure.rs
+++ b/laythe_core/src/object/closure.rs
@@ -20,11 +20,11 @@ impl Closure {
   /// use laythe_core::signature::Arity;
   /// use laythe_core::module::Module;
   /// use laythe_core::captures::Captures;
-  /// use laythe_core::hooks::{NoContext, Hooks};
+  /// use laythe_core::hooks::{NoContext, GcHooks};
   /// use std::path::PathBuf;
   ///
   /// let mut context = NoContext::default();
-  /// let hooks = Hooks::new(&mut context);
+  /// let hooks = GcHooks::new(&mut context);
   ///
   /// let module = hooks.manage(Module::new(
   ///   hooks.manage_obj(Class::bare(hooks.manage_str("module"))),
@@ -32,9 +32,9 @@ impl Closure {
   ///   0,
   /// ));
   /// let mut builder = FunBuilder::new(hooks.manage_str("example"), module, Arity::default());
-  /// let managed_fun = hooks.manage_obj(builder.build());
+  /// let managed_fun = hooks.manage_obj(builder.build(&hooks));
   ///
-  /// let captures = Captures::new(&hooks.as_gc(), &[]);
+  /// let captures = Captures::new(&hooks, &[]);
   /// let closure = Closure::new(managed_fun, captures);
   /// assert_eq!(&*closure.fun().name(), "example");
   /// ```

--- a/laythe_core/src/object/enumerator.rs
+++ b/laythe_core/src/object/enumerator.rs
@@ -1,6 +1,6 @@
 use crate::{
   hooks::Hooks,
-  managed::{DebugHeap, DebugWrap, DebugWrapDyn, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, DebugWrapDyn, Object, Trace},
   value::{Value, VALUE_NIL},
   Call,
 };
@@ -88,7 +88,9 @@ impl Object for Enumerator {
   }
 }
 
-pub trait Enumerate: Manage + fmt::Debug {
+unsafe impl Send for Enumerator {}
+
+pub trait Enumerate: Trace + fmt::Debug {
   /// The name of the iterator mostly for debugging purposes
   fn name(&self) -> &str;
 
@@ -101,6 +103,6 @@ pub trait Enumerate: Manage + fmt::Debug {
   /// If known how many elements will this iterator produce
   fn size_hint(&self) -> Option<usize>;
 
-  // /// What is the size of this iterator
-  // fn size(&self) -> usize;
+  // Get this enumerator as a DebugHeap
+  fn as_debug(&self) -> &dyn DebugHeap;
 }

--- a/laythe_core/src/object/enumerator.rs
+++ b/laythe_core/src/object/enumerator.rs
@@ -90,7 +90,7 @@ impl Object for Enumerator {
 
 unsafe impl Send for Enumerator {}
 
-pub trait Enumerate: Trace + fmt::Debug {
+pub trait Enumerate: Trace + fmt::Debug + Send {
   /// The name of the iterator mostly for debugging purposes
   fn name(&self) -> &str;
 

--- a/laythe_core/src/object/enumerator.rs
+++ b/laythe_core/src/object/enumerator.rs
@@ -4,8 +4,8 @@ use crate::{
   value::{Value, VALUE_NIL},
   Call,
 };
+use std::fmt::Debug;
 use std::{fmt, io::Write};
-use std::{fmt::Debug, mem};
 
 use super::ObjectKind;
 
@@ -79,16 +79,6 @@ impl DebugHeap for Enumerator {
       .field("current", &DebugWrap(&self.current, depth))
       .field("iterator", &DebugWrapDyn(self.iterator.as_debug(), depth))
       .finish()
-  }
-}
-
-impl Manage for Enumerator {
-  fn size(&self) -> usize {
-    mem::size_of::<Enumerator>() + self.iterator.size()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/fiber.rs
+++ b/laythe_core/src/object/fiber.rs
@@ -1189,11 +1189,11 @@ mod test {
 
     let mut fun1 = test_fun_builder(&hooks, "first", "first module");
     fun1.update_max_slots(4);
-    let fun1 = hooks.manage_obj(fun1.build());
+    let fun1 = hooks.manage_obj(fun1.build(&hooks));
 
     let mut fun2 = test_fun_builder(&hooks, "second", "second module");
     fun2.update_max_slots(3);
-    let fun2 = hooks.manage_obj(fun2.build());
+    let fun2 = hooks.manage_obj(fun2.build(&hooks));
 
     let captures = Captures::new(&hooks, &[]);
 

--- a/laythe_core/src/object/fiber.rs
+++ b/laythe_core/src/object/fiber.rs
@@ -6,7 +6,7 @@ use crate::{
   captures::Captures,
   constants::SCRIPT,
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, GcObj, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, GcObj, Object, Trace},
   val,
   value::{Value, VALUE_NIL},
 };
@@ -612,18 +612,6 @@ impl fmt::Debug for Fiber {
 impl Object for Fiber {
   fn kind(&self) -> ObjectKind {
     ObjectKind::Fiber
-  }
-}
-
-impl Manage for Fiber {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-      + mem::size_of::<CallFrame>() * self.frames.capacity()
-      + mem::size_of::<Value>() * self.stack.capacity()
-  }
-
-  fn as_debug(&self) -> &dyn crate::managed::DebugHeap {
-    todo!()
   }
 }
 

--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -1,8 +1,8 @@
-use std::{fmt, io::Write, mem};
+use std::{fmt, io::Write};
 
 use crate::{
   chunk::{Chunk, ChunkBuilder, Encode},
-  managed::{DebugHeap, DebugWrap, Gc, GcStr, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, Gc, GcStr, Object, Trace},
   module::Module,
   signature::Arity,
   value::Value,
@@ -310,16 +310,6 @@ impl DebugHeap for Fun {
       .field("Module", &DebugWrap(&self.module, depth))
       .field("chunk", &self.chunk)
       .finish()
-  }
-}
-
-impl Manage for Fun {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>() + self.chunk.size() + mem::size_of::<TryBlock>() * self.try_blocks.len()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -2,7 +2,9 @@ use std::{fmt, io::Write};
 
 use crate::{
   chunk::{Chunk, ChunkBuilder, Encode},
-  managed::{DebugHeap, DebugWrap, Gc, GcStr, Object, Trace},
+  hooks::GcHooks,
+  impl_debug_heap, impl_trace,
+  managed::{Array, DebugHeap, DebugWrap, Gc, GcStr, Object, Trace},
   module::Module,
   signature::Arity,
   value::Value,
@@ -33,7 +35,7 @@ impl fmt::Display for FunKind {
   }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct TryBlock {
   /// Start of the try block
   start: usize,
@@ -43,7 +45,7 @@ pub struct TryBlock {
 
   /// How many slots were used at the beginning of this
   /// try catch
-  slots: usize
+  slots: usize,
 }
 
 impl TryBlock {
@@ -51,6 +53,9 @@ impl TryBlock {
     TryBlock { start, end, slots }
   }
 }
+
+impl_trace!(TryBlock);
+impl_debug_heap!(TryBlock);
 
 /// A mutable builder for an immutable function
 pub struct FunBuilder {
@@ -146,7 +151,12 @@ impl FunBuilder {
   }
 
   /// Build a final immutable Fun from this builder
-  pub fn build(self) -> Fun {
+  pub fn build(self, hooks: &GcHooks) -> Fun {
+    let try_blocks = hooks.manage(&*self.try_blocks);
+    hooks.push_root(try_blocks);
+    let chunk = self.chunk.build(hooks);
+    hooks.pop_roots(1);
+
     Fun {
       name: self.name,
       arity: self.arity,
@@ -154,8 +164,8 @@ impl FunBuilder {
       max_slot: self.max_slots as u32,
       module_id: self.module.id(),
       module: self.module,
-      try_blocks: self.try_blocks.into_boxed_slice(),
-      chunk: self.chunk.build(),
+      try_blocks,
+      chunk,
     }
   }
 }
@@ -188,25 +198,25 @@ pub struct Fun {
   /// The max number of slots for this function
   max_slot: u32,
 
-  /// What is the idea of the associated module
+  /// What is the id of the associated module
   module_id: usize,
 
   /// The module this function belongs to
   module: Gc<Module>,
 
   /// Catch block present in this function
-  try_blocks: Box<[TryBlock]>,
+  try_blocks: Array<TryBlock>,
 
   /// Code for the function body
   chunk: Chunk,
 }
 
 impl Fun {
-  pub fn stub<T: Encode>(name: GcStr, module: Gc<Module>, instruction: T) -> Fun {
+  pub fn stub<T: Encode>(hooks: &GcHooks, name: GcStr, module: Gc<Module>, instruction: T) -> Fun {
     let mut builder = FunBuilder::new(name, module, Arity::Variadic(0));
     builder.write_instruction(instruction, 0);
 
-    builder.build()
+    builder.build(hooks)
   }
 
   /// Name of this function
@@ -290,14 +300,16 @@ impl fmt::Debug for Fun {
 impl Trace for Fun {
   fn trace(&self) {
     self.name.trace();
-    self.chunk.trace();
     self.module.trace();
+    self.try_blocks.trace();
+    self.chunk.trace();
   }
 
   fn trace_debug(&self, log: &mut dyn Write) {
     self.name.trace_debug(log);
-    self.chunk.trace_debug(log);
     self.module.trace_debug(log);
+    self.try_blocks.trace_debug(log);
+    self.chunk.trace_debug(log);
   }
 }
 
@@ -307,8 +319,11 @@ impl DebugHeap for Fun {
       .field("name", &DebugWrap(&self.name, depth))
       .field("arity", &self.arity)
       .field("capture_count", &self.capture_count)
-      .field("Module", &DebugWrap(&self.module, depth))
-      .field("chunk", &self.chunk)
+      .field("max_slots", &self.max_slot)
+      .field("module_id", &self.module_id)
+      .field("module", &DebugWrap(&self.module, depth))
+      .field("try_blocks", &DebugWrap(&self.try_blocks, depth))
+      .field("chunk", &DebugWrap(&self.chunk, depth))
       .finish()
   }
 }

--- a/laythe_core/src/object/instance.rs
+++ b/laythe_core/src/object/instance.rs
@@ -1,12 +1,11 @@
 use super::{Class, ObjectKind};
 use crate::{
-  managed::{DebugHeap, DebugWrap, GcObj, GcStr, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, GcObj, GcStr, Object, Trace},
   value::{Value, VALUE_NIL},
 };
 use std::{
   fmt,
   io::Write,
-  mem,
   ops::{Index, IndexMut},
 };
 
@@ -107,17 +106,6 @@ impl DebugHeap for Instance {
       .field("class", &DebugWrap(&self.class, depth))
       .field("fields", &DebugWrap(&&*self.fields, depth))
       .finish()
-  }
-}
-
-impl Manage for Instance {
-  fn size(&self) -> usize {
-    mem::size_of::<Instance>()
-      + (mem::size_of::<GcStr>() + mem::size_of::<Value>()) * self.fields.len()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/list.rs
+++ b/laythe_core/src/object/list.rs
@@ -3,13 +3,12 @@ use std::{
   fmt::{self, Display},
   io::Write,
   iter::FromIterator,
-  mem,
   ops::{Deref, Index, IndexMut},
   slice::{self, SliceIndex},
 };
 
 use crate::{
-  managed::{DebugHeap, DebugWrap, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, Object, Trace},
   value::Value,
 };
 
@@ -179,16 +178,6 @@ impl<T: 'static + Trace + DebugHeap> DebugHeap for List<T> {
     f.debug_list()
       .entries(self.0.iter().map(|x| DebugWrap(x, depth)))
       .finish()
-  }
-}
-
-impl<T: 'static + Trace + DebugHeap> Manage for List<T> {
-  fn size(&self) -> usize {
-    mem::size_of::<Vec<T>>() + mem::size_of::<T>() * self.capacity()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/ly_box.rs
+++ b/laythe_core/src/object/ly_box.rs
@@ -1,10 +1,10 @@
 use fmt::Display;
 
 use crate::{
-  managed::{DebugHeap, DebugWrap, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, Object, Trace},
   value::{Value, VALUE_NIL},
 };
-use std::{fmt, io::Write, mem};
+use std::{fmt, io::Write};
 
 use super::ObjectKind;
 
@@ -46,16 +46,6 @@ impl DebugHeap for LyBox {
     f.debug_struct("Capture")
       .field("value", &DebugWrap(&self.value, depth))
       .finish()
-  }
-}
-
-impl Manage for LyBox {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/map.rs
+++ b/laythe_core/src/object/map.rs
@@ -1,11 +1,11 @@
 use crate::{
-  managed::{DebugHeap, DebugWrap, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, Object, Trace},
   value::Value,
 };
 use fmt::Display;
 use fnv::FnvBuildHasher;
 use hashbrown::{hash_map, HashMap};
-use std::{fmt, hash::Hash, io::Write, mem};
+use std::{fmt, hash::Hash, io::Write};
 
 use super::ObjectKind;
 
@@ -131,20 +131,6 @@ impl<K: 'static + DebugHeap, V: 'static + DebugHeap> DebugHeap for Map<K, V> {
           .map(|(k, v)| (DebugWrap(k, depth), DebugWrap(v, depth))),
       )
       .finish()
-  }
-}
-
-impl<K, V> Manage for Map<K, V>
-where
-  K: 'static + DebugHeap + Trace,
-  V: 'static + DebugHeap + Trace,
-{
-  fn size(&self) -> usize {
-    mem::size_of::<Map<Value, Value>>() + self.capacity() * mem::size_of::<Value>() * 2
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/method.rs
+++ b/laythe_core/src/object/method.rs
@@ -1,11 +1,10 @@
 use crate::{
-  managed::{DebugHeap, DebugWrap, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, Object, Trace},
   value::Value,
 };
 use std::{
   fmt::{self, Display},
   io::Write,
-  mem,
 };
 
 use super::ObjectKind;
@@ -63,16 +62,6 @@ impl DebugHeap for Method {
       .field("receiver", &DebugWrap(&self.receiver, depth))
       .field("method", &DebugWrap(&self.method, depth))
       .finish()
-  }
-}
-
-impl Manage for Method {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/object/native.rs
+++ b/laythe_core/src/object/native.rs
@@ -1,11 +1,10 @@
 use crate::{
   hooks::{GcHooks, Hooks},
-  managed::{DebugHeap, DebugWrap, GcStr, Manage, Object, Trace},
+  managed::{DebugHeap, DebugWrap, GcStr, Object, Trace},
   signature::{Arity, Environment, ParameterBuilder, Signature, SignatureBuilder},
   value::Value,
   Call,
 };
-use std::mem;
 use std::{fmt, io::Write};
 
 use super::ObjectKind;
@@ -151,16 +150,6 @@ impl Trace for Native {
   fn trace_debug(&self, log: &mut dyn Write) {
     self.meta.trace_debug(log);
     self.native.trace_debug(log);
-  }
-}
-
-impl Manage for Native {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_core/src/support/mod.rs
+++ b/laythe_core/src/support/mod.rs
@@ -70,7 +70,7 @@ where
     }
     fun.update_max_slots(self.max_slots);
 
-    let fun = hooks.manage_obj(fun.build());
+    let fun = hooks.manage_obj(fun.build(hooks));
     hooks.push_root(fun);
 
     let captures = Captures::new(hooks, &[]);
@@ -151,7 +151,7 @@ pub fn test_fun(hooks: &GcHooks, name: &str, module_name: &str) -> GcObj<Fun> {
   let module = hooks.manage(module);
   let builder = FunBuilder::new(hooks.manage_str(name), module, Arity::default());
 
-  hooks.manage_obj(builder.build())
+  hooks.manage_obj(builder.build(hooks))
 }
 
 pub fn test_fun_builder(hooks: &GcHooks, name: &str, module_name: &str) -> FunBuilder {

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -788,7 +788,7 @@ mod boxed {
       assert_eq!(mem::size_of::<List<Value>>(), 24);
       assert_eq!(mem::size_of::<Map<Value, Value>>(), 32);
       assert_eq!(mem::size_of::<Closure>(), 16);
-      assert_eq!(mem::size_of::<Fun>(), 96);
+      assert_eq!(mem::size_of::<Fun>(), 64);
       assert_eq!(mem::size_of::<Fiber>(), 104);
       assert_eq!(mem::size_of::<Class>(), 104);
       assert_eq!(mem::size_of::<Instance>(), 24);
@@ -923,7 +923,7 @@ mod test {
     let name = test_string(hooks);
     let module = test_module(hooks);
 
-    hooks.manage_obj(Fun::stub(name, module, 0))
+    hooks.manage_obj(Fun::stub(hooks, name, module, 0))
   }
 
   fn test_closure(hooks: &GcHooks) -> GcObj<Closure> {

--- a/laythe_lib/src/global/primitives/closure.rs
+++ b/laythe_lib/src/global/primitives/closure.rs
@@ -152,19 +152,28 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
-      let closure = hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build()), captures));
+      let closure = hooks.manage_obj(Closure::new(
+        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        captures,
+      ));
 
       let result = closure_name.call(&mut hooks, Some(val!(closure)), &[]);
       assert_eq!(result.unwrap().to_num(), 4.0);
 
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
-      let closure = hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build()), captures));
+      let closure = hooks.manage_obj(Closure::new(
+        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        captures,
+      ));
 
       let result = closure_name.call(&mut hooks, Some(val!(closure)), &[]);
       assert_eq!(result.unwrap().to_num(), 2.0);
 
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
-      let closure = hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build()), captures));
+      let closure = hooks.manage_obj(Closure::new(
+        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        captures,
+      ));
 
       let result = closure_name.call(&mut hooks, Some(val!(closure)), &[]);
       assert_eq!(result.unwrap().to_num(), 5.0);
@@ -200,7 +209,10 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let closure = hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build()), captures));
+      let closure = hooks.manage_obj(Closure::new(
+        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        captures,
+      ));
 
       let args = &[val!(hooks.manage_str("input".to_string()))];
       let result1 = closure_call.call(&mut hooks, Some(val!(closure)), args);

--- a/laythe_lib/src/global/primitives/fun.rs
+++ b/laythe_lib/src/global/primitives/fun.rs
@@ -143,19 +143,19 @@ mod test {
       let fun_name = FunLen::native(&hooks.as_gc());
 
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
-      let fun = hooks.manage_obj(builder.build());
+      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 4.0);
 
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
-      let fun = hooks.manage_obj(builder.build());
+      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 2.0);
 
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
-      let fun = hooks.manage_obj(builder.build());
+      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 5.0);
@@ -189,7 +189,7 @@ mod test {
 
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
 
-      let fun = hooks.manage_obj(builder.build());
+      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
 
       let args = &[val!(hooks.manage_str("input".to_string()))];
       let result1 = fun_call.call(&mut hooks, Some(val!(fun)), args);

--- a/laythe_lib/src/global/primitives/iter.rs
+++ b/laythe_lib/src/global/primitives/iter.rs
@@ -1324,7 +1324,7 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build()), captures)));
+      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build(&hooks.as_gc())), captures)));
 
       let result = iter_map.call(&mut hooks, Some(this), &[fun]);
       match result {
@@ -1373,7 +1373,7 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build()), captures)));
+      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build(&hooks.as_gc())), captures)));
 
       let result = iter_filter.call(&mut hooks, Some(this), &[fun]);
       match result {
@@ -1429,7 +1429,7 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(2));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build()), captures)));
+      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build(&hooks.as_gc())), captures)));
 
       let result = iter_reduce.call(&mut hooks, Some(this), &[val!(0.0), fun]);
       match result {
@@ -1512,7 +1512,7 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build()), captures)));
+      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build(&hooks.as_gc())), captures)));
 
       let result = iter_each.call(&mut hooks, Some(this), &[fun]);
       match result {

--- a/laythe_lib/src/global/primitives/list.rs
+++ b/laythe_lib/src/global/primitives/list.rs
@@ -7,7 +7,7 @@ use laythe_core::{
   constants::{INDEX_GET, INDEX_SET},
   hooks::{GcHooks, Hooks},
   if_let_obj,
-  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Manage, Trace},
+  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace},
   module::Module,
   object::{Enumerate, Enumerator, List, LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::{Arity, ParameterBuilder, ParameterKind},
@@ -17,8 +17,8 @@ use laythe_core::{
   value::{Value, VALUE_NIL},
   Call, LyError, LyResult,
 };
+use std::slice::Iter;
 use std::{cmp::Ordering, io::Write};
-use std::{mem, slice::Iter};
 
 use super::{
   class_inheritance,
@@ -659,6 +659,10 @@ impl Enumerate for ListIterator {
   fn size_hint(&self) -> Option<usize> {
     Some(self.list.len())
   }
+
+  fn as_debug(&self) -> &dyn DebugHeap {
+    self
+  }
 }
 
 impl Trace for ListIterator {
@@ -678,16 +682,6 @@ impl DebugHeap for ListIterator {
       .field("current", &DebugWrap(&self.current, depth))
       .field("iter", &"*")
       .finish()
-  }
-}
-
-impl Manage for ListIterator {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_lib/src/global/primitives/map.rs
+++ b/laythe_lib/src/global/primitives/map.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   constants::INDEX_SET,
   hooks::{GcHooks, Hooks},
   if_let_obj,
-  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Manage, Trace},
+  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace},
   module::Module,
   object::{Enumerate, Enumerator, List, LyNative, Map, Native, NativeMetaBuilder, ObjectKind},
   signature::{Arity, ParameterBuilder, ParameterKind},
@@ -21,7 +21,6 @@ use laythe_core::{
   Call, LyError,
 };
 use std::io::Write;
-use std::mem;
 
 pub const MAP_CLASS_NAME: &str = "Map";
 pub const KEY_ERROR_NAME: &str = "KeyError";
@@ -396,6 +395,10 @@ impl Enumerate for MapIterator {
   fn size_hint(&self) -> Option<usize> {
     Some(self.map.len())
   }
+
+  fn as_debug(&self) -> &dyn DebugHeap {
+    self
+  }
 }
 
 impl Trace for MapIterator {
@@ -415,16 +418,6 @@ impl DebugHeap for MapIterator {
       .field("iter", &"*")
       .field("current", &DebugWrap(&self.current, depth))
       .finish()
-  }
-}
-
-impl Manage for MapIterator {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 #[cfg(test)]

--- a/laythe_lib/src/global/primitives/number.rs
+++ b/laythe_lib/src/global/primitives/number.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use laythe_core::{
   hooks::{GcHooks, Hooks},
+  managed::Trace,
   managed::{DebugHeap, Gc, GcObj},
-  managed::{Manage, Trace},
   module::Module,
   object::{Enumerate, Enumerator, LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::{Arity, ParameterBuilder, ParameterKind},
@@ -15,7 +15,6 @@ use laythe_core::{
   Call, LyError,
 };
 use std::io::Write;
-use std::mem;
 
 use super::{
   class_inheritance,
@@ -213,6 +212,10 @@ impl Enumerate for TimesIterator {
   fn size_hint(&self) -> Option<usize> {
     Some((self.max + 1.0) as usize)
   }
+
+  fn as_debug(&self) -> &dyn DebugHeap {
+    self
+  }
 }
 
 impl Trace for TimesIterator {}
@@ -220,16 +223,6 @@ impl Trace for TimesIterator {}
 impl DebugHeap for TimesIterator {
   fn fmt_heap(&self, f: &mut std::fmt::Formatter, _: usize) -> std::fmt::Result {
     f.write_fmt(format_args!("{:?}", self))
-  }
-}
-
-impl Manage for TimesIterator {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 
@@ -295,6 +288,10 @@ impl Enumerate for UntilIterator {
   fn size_hint(&self) -> Option<usize> {
     None
   }
+
+  fn as_debug(&self) -> &dyn DebugHeap {
+    self
+  }
 }
 
 impl Trace for UntilIterator {}
@@ -302,16 +299,6 @@ impl Trace for UntilIterator {}
 impl DebugHeap for UntilIterator {
   fn fmt_heap(&self, f: &mut std::fmt::Formatter, _: usize) -> std::fmt::Result {
     f.write_fmt(format_args!("{:?}", self))
-  }
-}
-
-impl Manage for UntilIterator {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_lib/src/global/primitives/string.rs
+++ b/laythe_lib/src/global/primitives/string.rs
@@ -7,7 +7,7 @@ use laythe_core::{
   constants::INDEX_GET,
   hooks::{GcHooks, Hooks},
   managed::GcObj,
-  managed::{DebugHeap, DebugWrap, Gc, GcStr, Manage, Trace},
+  managed::{DebugHeap, DebugWrap, Gc, GcStr, Trace},
   module::Module,
   object::{Enumerate, Enumerator, LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::{Arity, ParameterBuilder, ParameterKind},
@@ -15,8 +15,8 @@ use laythe_core::{
   value::{Value, VALUE_NIL},
   Call, LyError, LyResult,
 };
+use std::str::Chars;
 use std::{io::Write, str::Split};
-use std::{mem, str::Chars};
 
 use super::{class_inheritance, error::INDEX_ERROR_NAME};
 
@@ -253,6 +253,10 @@ impl Enumerate for SplitIterator {
   fn size_hint(&self) -> Option<usize> {
     None
   }
+
+  fn as_debug(&self) -> &dyn DebugHeap {
+    self
+  }
 }
 
 impl Trace for SplitIterator {
@@ -277,16 +281,6 @@ impl DebugHeap for SplitIterator {
       .field("iter", &"*")
       .field("current", &DebugWrap(&self.current, depth))
       .finish()
-  }
-}
-
-impl Manage for SplitIterator {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 
@@ -406,6 +400,10 @@ impl Enumerate for StringIterator {
   fn size_hint(&self) -> Option<usize> {
     None
   }
+
+  fn as_debug(&self) -> &dyn DebugHeap {
+    self
+  }
 }
 
 impl Trace for StringIterator {
@@ -427,16 +425,6 @@ impl DebugHeap for StringIterator {
       .field("iter", &"*")
       .field("current", &DebugWrap(&self.current, depth))
       .finish()
-  }
-}
-
-impl Manage for StringIterator {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_lib/src/global/primitives/tuple.rs
+++ b/laythe_lib/src/global/primitives/tuple.rs
@@ -7,7 +7,7 @@ use laythe_core::{
   constants::INDEX_GET,
   hooks::{GcHooks, Hooks},
   if_let_obj,
-  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Manage, Trace, Tuple},
+  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace, Tuple},
   module::Module,
   object::{Enumerate, Enumerator, List, LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::{Arity, ParameterBuilder, ParameterKind},
@@ -18,7 +18,7 @@ use laythe_core::{
   Call, LyError, LyResult,
 };
 use std::io::Write;
-use std::{mem, slice::Iter};
+use std::slice::Iter;
 
 use super::{
   class_inheritance,
@@ -422,6 +422,10 @@ impl Enumerate for TupleIterator {
   fn size_hint(&self) -> Option<usize> {
     Some(self.tuple.len())
   }
+
+  fn as_debug(&self) -> &dyn DebugHeap {
+    self
+  }
 }
 
 impl Trace for TupleIterator {
@@ -441,16 +445,6 @@ impl DebugHeap for TupleIterator {
       .field("current", &DebugWrap(&self.current, depth))
       .field("iter", &"*")
       .finish()
-  }
-}
-
-impl Manage for TupleIterator {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
   }
 }
 

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -127,7 +127,7 @@ mod test {
   };
   use laythe_core::{
     hooks::{GcContext, GcHooks, HookContext, Hooks, ValueContext},
-    managed::{DebugHeap, GcObj, GcObject, GcStr, Manage, Trace, TraceRoot},
+    managed::{DebugHeap, GcObj, GcObject, GcStr, Trace, TraceRoot},
     match_obj,
     memory::{Allocator, NoGc},
     module::{Module, ModuleResult},
@@ -144,7 +144,7 @@ mod test {
     io::Io,
     stdio::support::{IoStdioTest, StdioTestContainer},
   };
-  use std::{cell::RefCell, io::Write, mem, path::PathBuf, sync::Arc};
+  use std::{cell::RefCell, io::Write, path::PathBuf, sync::Arc};
 
   pub struct MockedContext {
     pub gc: RefCell<Allocator>,
@@ -381,6 +381,10 @@ mod test {
     fn size_hint(&self) -> Option<usize> {
       Some(4)
     }
+
+    fn as_debug(&self) -> &dyn DebugHeap {
+      self
+    }
   }
 
   impl Trace for TestIterator {}
@@ -388,16 +392,6 @@ mod test {
   impl DebugHeap for TestIterator {
     fn fmt_heap(&self, f: &mut std::fmt::Formatter, _: usize) -> std::fmt::Result {
       f.write_fmt(format_args!("{:?}", self))
-    }
-  }
-
-  impl Manage for TestIterator {
-    fn size(&self) -> usize {
-      mem::size_of::<Self>()
-    }
-
-    fn as_debug(&self) -> &dyn DebugHeap {
-      self
     }
   }
 

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -433,7 +433,7 @@ mod test {
     let module = hooks.manage(module);
     let builder = FunBuilder::new(hooks.manage_str(name), module, Arity::default());
 
-    hooks.manage_obj(builder.build())
+    hooks.manage_obj(builder.build(&hooks))
   }
 
   pub fn test_fun_builder(

--- a/laythe_vm/src/compiler/ir/token.rs
+++ b/laythe_vm/src/compiler/ir/token.rs
@@ -1,5 +1,4 @@
-use laythe_core::managed::{DebugHeap, Manage, Trace};
-use std::{fmt, mem};
+use std::fmt;
 
 use super::ast::Spanned;
 
@@ -56,38 +55,6 @@ impl<'a> Spanned for Token<'a> {
 
   fn end(&self) -> u32 {
     self.end
-  }
-}
-
-impl Trace for Token<'static> {
-  fn trace(&self) {}
-
-  fn trace_debug(&self, _log: &mut dyn std::io::Write) {}
-}
-
-impl Manage for Token<'static> {
-  fn size(&self) -> usize {
-    let string = match &self.lexeme {
-      Lexeme::Slice(_) => 0,
-      Lexeme::Owned(str) => str.capacity(),
-    };
-
-    mem::size_of::<Self>() + string
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
-  }
-}
-
-impl DebugHeap for Token<'static> {
-  fn fmt_heap(&self, f: &mut fmt::Formatter, _depth: usize) -> fmt::Result {
-    f.debug_struct("Token")
-      .field("start", &self.start)
-      .field("end", &self.end)
-      .field("lexeme", &self.str())
-      .field("kind", &self.kind)
-      .finish()
   }
 }
 

--- a/laythe_vm/src/compiler/mod.rs
+++ b/laythe_vm/src/compiler/mod.rs
@@ -2123,7 +2123,7 @@ mod test {
     source::Source,
   };
   use laythe_core::{
-    hooks::{NoContext, GcHooks},
+    hooks::{GcHooks, NoContext},
     managed::GcObj,
     memory::{NoGc, NO_GC},
     object::{Class, ObjectKind},

--- a/laythe_vm/src/compiler/mod.rs
+++ b/laythe_vm/src/compiler/mod.rs
@@ -23,7 +23,7 @@ use laythe_core::{
   constants::{INDEX_GET, INDEX_SET, OBJECT, SUPER, UNINITIALIZED_VAR},
   constants::{ITER, ITER_VAR, SCRIPT, SELF},
   hooks::GcContext,
-  managed::{DebugHeap, Gc, GcObj, GcStr, Manage, Trace, TraceRoot},
+  managed::{AllocResult, Allocate, DebugHeap, Gc, GcObj, GcStr, Trace, TraceRoot},
   memory::Allocator,
   module, object,
   object::{FunBuilder, FunKind, List, Map},
@@ -92,13 +92,9 @@ impl DebugHeap for ClassAttributes {
   }
 }
 
-impl Manage for ClassAttributes {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>() + mem::size_of::<GcStr>() * self.fields.capacity()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
+impl Allocate<Gc<Self>> for ClassAttributes {
+  fn alloc(self) -> AllocResult<Gc<Self>> {
+    Gc::alloc_result(self)
   }
 }
 
@@ -131,13 +127,9 @@ impl DebugHeap for LoopAttributes {
   }
 }
 
-impl Manage for LoopAttributes {
-  fn size(&self) -> usize {
-    mem::size_of::<Self>()
-  }
-
-  fn as_debug(&self) -> &dyn DebugHeap {
-    self
+impl Allocate<Gc<Self>> for LoopAttributes {
+  fn alloc(self) -> AllocResult<Gc<Self>> {
+    Gc::alloc_result(self)
   }
 }
 

--- a/laythe_vm/src/compiler/resolver.rs
+++ b/laythe_vm/src/compiler/resolver.rs
@@ -976,7 +976,7 @@ mod test {
       dummy_module(hooks)
     };
 
-    let gc = context.gc.replace(Allocator::default());
+    let gc = context.done();
     let resolver = Resolver::new(module, &gc, &source, &line_offsets, repl);
 
     let result = resolver.resolve(&mut ast);

--- a/laythe_vm/src/vm.rs
+++ b/laythe_vm/src/vm.rs
@@ -12,7 +12,7 @@ use laythe_core::{
   constants::{PLACEHOLDER_NAME, SELF},
   hooks::{GcContext, GcHooks, HookContext, Hooks, NoContext, ValueContext},
   if_let_obj,
-  managed::{Gc, GcObj, GcObject, GcStr, Manage, Object, Trace, TraceRoot, Tuple},
+  managed::{Allocate, Gc, GcObj, GcObject, GcStr, Object, Trace, TraceRoot, Tuple},
   match_obj,
   memory::Allocator,
   module::{Import, Module, Package},
@@ -580,7 +580,7 @@ impl Vm {
     self.builtin.primitives.for_value(value)
   }
 
-  fn manage<T: 'static + Manage>(&self, data: T) -> Gc<T> {
+  fn manage<R: 'static + Trace + Copy, T: 'static + Allocate<R>>(&self, data: T) -> R {
     self.gc.borrow_mut().manage(data, self)
   }
 

--- a/laythe_vm/src/vm.rs
+++ b/laythe_vm/src/vm.rs
@@ -2327,6 +2327,7 @@ impl TraceRoot for Vm {
     self.files.trace();
     self.packages.trace();
     self.module_cache.trace();
+    self.capture_stub.trace();
 
     for stub in &self.native_fun_stubs {
       stub.trace();
@@ -2342,6 +2343,7 @@ impl TraceRoot for Vm {
     self.files.trace_debug(log);
     self.packages.trace_debug(log);
     self.module_cache.trace_debug(log);
+    self.capture_stub.trace_debug(log);
 
     for stub in &self.native_fun_stubs {
       stub.trace_debug(log);


### PR DESCRIPTION
## Summary
The PR primarily removes the need for the majority of struct to implement `Manage`. Additionally this PR allows `GcArray` to be used outside of the `Tuple` type. This can be used to replace uses of `Box<[T]>`