### PR TITLE
Inline instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,15 +265,15 @@ Running the original benchmark suite on a 2015 dell xps we have.
 
 |benchmark|clox|Laythe|relative speed|notes|
 |--|--|--|--|--|
-|binary_tress.lox|total: 2.58032|total: 2.35423|1.1|This likely due to the small number of properties and the init optimization. We essentially avoid hashing altogether in this bench|
-|equality.lox|loop: 2.54958 elapsed: 2.08519|loop: 2.647906 elapsed: 3.131277|0.80|Similar to above we have essentially zero hashing and again perform pretty equal to clox|
-|fib.lox|total: 1.33588|total: 2.08769|0.63|Here we have some hashing from the `fib` lookup but even making this local shows a difference. It appears there is still some performance difference in function calling here|
-|instantiation.lox|total: 0.794824|total: 1.50812|0.53|Again localizing this gives a decent speedup but hashing and function calls still seem to slow Laythe down|
-|invocation.lox|total: 0.419431|total: 0.814637|0.52|Now the hashing speed difference is quite apparent|
-|method_call.lox|total: 0.26644|total: 0.341227|0.65|Same as above|
-|properties.lox|total: 0.645307|total: 0.937192|0.69|Same as above|
+|binary_tress.lox|total: 2.58032|total: 2.07827|1.1|We've optimized instance to allocate properties inline and have an init optimization that benefits speed|
+|equality.lox|loop: 2.54958 elapsed: 2.08519|loop: 2.53177 elapsed: 2.52173|0.80|Similar to above we have essentially zero hashing and again perform pretty equal to clox|
+|fib.lox|total: 1.33588|total: 2.09226|0.63|Here we have some hashing from the `fib` lookup but even making this local shows a difference. It appears there is still some performance difference in function calling here|
+|instantiation.lox|total: 0.794824|total: 1.58841|0.53|Again localizing this gives a decent speedup but hashing and function calls still seem to slow Laythe down|
+|invocation.lox|total: 0.419431|total: 0.782444|0.52|Now the hashing speed difference is quite apparent|
+|method_call.lox|total: 0.26644|total: 0.326959|0.65|Same as above|
+|properties.lox|total: 0.645307|total: 0.889522|0.69|Same as above|
 |trees.lox|total: 3.09063|total: 3.387378|0.91|Same as above|
-|zoo.lox|total: 0.495144|total: 0.709942|0.70|Same as above|
+|zoo.lox|total: 0.495144|total: 0.680576|0.70|Same as above|
 
 ## Future Ideas
 

--- a/laythe_core/src/hooks.rs
+++ b/laythe_core/src/hooks.rs
@@ -4,8 +4,9 @@ use std::{
 };
 
 use crate::{
-  managed::{Allocate, DebugHeapRef, GcObj, GcStr, Object, Trace, TraceRoot, Tuple},
+  managed::{Allocate, DebugHeapRef, GcObj, GcStr, Instance, Object, Trace, TraceRoot, Tuple},
   memory::Allocator,
+  object::Class,
   value::{Value, VALUE_NIL},
   Call,
 };
@@ -93,6 +94,11 @@ impl<'a> Hooks<'a> {
     self.as_gc().manage_tuple(slice)
   }
 
+  /// Request a instance be managed by this allocator
+  pub fn manage_instance(&self, class: GcObj<Class>) -> Instance {
+    self.as_gc().manage_instance(class)
+  }
+
   /// Request a string be managed by this allocator
   pub fn manage_str<S: AsRef<str>>(&self, string: S) -> GcStr {
     self.as_gc().manage_str(string)
@@ -156,10 +162,15 @@ impl<'a> GcHooks<'a> {
     self.context.gc().manage_obj(obj, self.context)
   }
 
-  /// Request a string be managed by this allocator
+  /// Request a tuple be managed by this allocator
   #[inline]
   pub fn manage_tuple(&self, slice: &[Value]) -> Tuple {
     self.context.gc().manage_tuple(slice, self.context)
+  }
+
+  /// Request a instance be managed by this allocator
+  pub fn manage_instance(&self, class: GcObj<Class>) -> Instance {
+    self.context.gc().manage_instance(class, self.context)
   }
 
   /// Request a string be managed by this allocator

--- a/laythe_core/src/lib.rs
+++ b/laythe_core/src/lib.rs
@@ -19,7 +19,7 @@ pub type LyResult<T> = Result<T, LyError>;
 
 #[derive(Debug, PartialEq)]
 pub enum LyError {
-  Err(GcObj<Instance>),
+  Err(Instance),
   Exit(u16),
 }
 
@@ -27,8 +27,7 @@ pub type LyHashSet<K> = HashSet<K, FnvBuildHasher>;
 
 use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
-use managed::GcObj;
-use object::Instance;
+use managed::Instance;
 
 #[macro_export]
 macro_rules! impl_trace {

--- a/laythe_core/src/managed/gc_obj.rs
+++ b/laythe_core/src/managed/gc_obj.rs
@@ -3,13 +3,12 @@ use super::{
   header::ObjHeader,
   manage::{DebugHeap, DebugWrap, Trace},
   utils::{get_array_len_offset, get_offset, make_array_layout, make_obj_layout},
-  GcArray, GcStr, Mark, Marked, Unmark,
+  GcArray, GcStr, Mark, Marked, Unmark, Instance,
 };
 use crate::{
   managed::utils::get_array_offset,
   object::{
-    Channel, Class, Closure, Enumerator, Fiber, Fun, Instance, List, LyBox, Map, Method, Native,
-    ObjectKind,
+    Channel, Class, Closure, Enumerator, Fiber, Fun, List, LyBox, Map, Method, Native, ObjectKind,
   },
   value::Value,
 };
@@ -388,10 +387,8 @@ impl GcObject {
   }
 
   #[inline]
-  pub fn to_instance(self) -> GcObj<Instance> {
-    GcObj {
-      ptr: unsafe { self.data_ptr::<Instance>() },
-    }
+  pub fn to_instance(self) -> Instance {
+    unsafe { GcArray::from_alloc_ptr(self.ptr) }
   }
 
   #[inline]
@@ -726,11 +723,11 @@ impl GcObjectHandle {
         ObjectKind::String => {
           let len = array_len(self);
           make_array_layout::<ObjHeader, u8>(len).size()
-        }
+        },
         ObjectKind::Tuple => {
           let len = array_len(self);
           make_array_layout::<ObjHeader, Value>(len).size()
-        }
+        },
       }
   }
 }
@@ -772,7 +769,7 @@ impl Drop for GcObjectHandle {
             self.ptr.as_ptr(),
             make_array_layout::<ObjHeader, Value>(len),
           );
-        }
+        },
         ObjectKind::Tuple => {
           let len = array_len(self);
 
@@ -787,7 +784,7 @@ impl Drop for GcObjectHandle {
             self.ptr.as_ptr(),
             make_array_layout::<ObjHeader, Value>(len),
           );
-        }
+        },
       }
     }
   }

--- a/laythe_core/src/managed/gc_str.rs
+++ b/laythe_core/src/managed/gc_str.rs
@@ -138,7 +138,7 @@ impl Trace for GcStr {
 impl DebugHeap for GcStr {
   fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> std::fmt::Result {
     if depth == 0 {
-      f.write_fmt(format_args!("{:p}", self.0.ptr))
+      f.write_fmt(format_args!("{:p}", self.0.ptr()))
     } else {
       f.write_fmt(format_args!("{}", self))
     }
@@ -341,7 +341,7 @@ impl DebugHeap for GcStrHandle {
 
 impl fmt::Pointer for GcStrHandle {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    self.value().0.ptr.fmt(f)
+    self.value().0.ptr().fmt(f)
   }
 }
 

--- a/laythe_core/src/managed/header.rs
+++ b/laythe_core/src/managed/header.rs
@@ -1,8 +1,9 @@
+use super::{GcObj, Mark, Marked, Trace, Unmark};
+use crate::{
+  impl_trace,
+  object::{Class, ObjectKind},
+};
 use std::sync::atomic::{AtomicBool, Ordering};
-
-use crate::object::{Class, ObjectKind};
-
-use super::{GcObj, Mark, Marked, Unmark};
 
 /// The header of an allocation indicate meta data about the object
 #[derive(Debug, Default)]
@@ -42,6 +43,8 @@ impl Unmark for Header {
     self.marked.swap(false, Ordering::Release)
   }
 }
+
+impl_trace!(Header);
 
 /// The `Header` meta data for `GcObj<T>` and `GcObject`. This struct
 /// is positioned at the front of the array such that the layout looks like
@@ -95,6 +98,8 @@ impl Marked for ObjHeader {
     self.marked.load(Ordering::Acquire)
   }
 }
+
+impl_trace!(ObjHeader);
 
 /// The `Header` meta data for `GcObj<T>` and `GcObject`. This struct
 /// is positioned at the front of the array such that the layout looks like
@@ -155,6 +160,16 @@ impl Marked for InstanceHeader {
   #[inline]
   fn marked(&self) -> bool {
     self.marked.load(Ordering::Acquire)
+  }
+}
+
+impl Trace for InstanceHeader {
+  fn trace(&self) {
+    self.class.trace();
+  }
+
+  fn trace_debug(&self, log: &mut dyn std::io::Write) {
+    self.class.trace_debug(log);
   }
 }
 

--- a/laythe_core/src/managed/header.rs
+++ b/laythe_core/src/managed/header.rs
@@ -6,6 +6,7 @@ use super::{Mark, Marked, Unmark};
 
 /// The header of an allocation indicate meta data about the object
 #[derive(Debug, Default)]
+#[repr(C)]
 pub struct Header {
   // has this allocation been marked by the garbage collector
   marked: AtomicBool,
@@ -48,6 +49,7 @@ impl Unmark for Header {
 /// ```markdown
 /// [Header (potential padding)| T ]
 /// ```
+#[repr(C)]
 pub struct ObjHeader {
   /// Has this allocation been marked by the garbage collector
   marked: AtomicBool,
@@ -91,5 +93,38 @@ impl Marked for ObjHeader {
   #[inline]
   fn marked(&self) -> bool {
     self.marked.load(Ordering::Acquire)
+  }
+}
+
+#[cfg(test)]
+mod test {
+  mod header {
+    use crate::managed::header::Header;
+    use std::mem;
+
+    #[test]
+    fn size() {
+      assert_eq!(mem::size_of::<Header>(), 1);
+    }
+
+    #[test]
+    fn alignment() {
+      assert_eq!(mem::align_of::<Header>(), 1);
+    }
+  }
+
+  mod obj_header {
+    use crate::managed::header::ObjHeader;
+    use std::mem;
+
+    #[test]
+    fn size() {
+      assert_eq!(mem::size_of::<ObjHeader>(), 2);
+    }
+
+    #[test]
+    fn alignment() {
+      assert_eq!(mem::align_of::<ObjHeader>(), 1);
+    }
   }
 }

--- a/laythe_core/src/managed/header.rs
+++ b/laythe_core/src/managed/header.rs
@@ -130,6 +130,11 @@ impl InstanceHeader {
   pub fn kind(&self) -> ObjectKind {
     self.kind
   }
+
+  #[inline]
+  pub fn class(&self) -> GcObj<Class> {
+    self.class
+  }
 }
 
 impl Mark for InstanceHeader {

--- a/laythe_core/src/managed/mod.rs
+++ b/laythe_core/src/managed/mod.rs
@@ -9,7 +9,9 @@ mod utils;
 
 pub use allocation::Allocation;
 pub use gc::Gc;
-pub use gc_array::{tuple_handle, Array, GcArray, GcArrayHandle, Tuple, TupleHandle};
+pub use gc_array::{
+  instance_handle, tuple_handle, Array, GcArray, GcArrayHandle, Instance, Tuple, TupleHandle,
+};
 pub use gc_obj::{GcObj, GcObject, GcObjectHandle, GcObjectHandleBuilder, Object};
 pub use gc_str::{GcStr, GcStrHandle};
 pub use manage::{

--- a/laythe_core/src/module/mod.rs
+++ b/laythe_core/src/module/mod.rs
@@ -318,8 +318,8 @@ mod test {
   use crate::{
     hooks::{GcHooks, NoContext},
     module::{ModuleError, ModuleResult},
-    object::{test_class, Class},
-    val,
+    object::{Class},
+    val, support::test_class,
   };
   use std::path::PathBuf;
 

--- a/laythe_core/src/module/mod.rs
+++ b/laythe_core/src/module/mod.rs
@@ -8,8 +8,8 @@ pub use package::Package;
 
 use crate::{
   hooks::GcHooks,
-  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace},
-  object::{Class, Instance, Map, MapEntry},
+  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace, Instance},
+  object::{Class, Map, MapEntry},
   value::Value,
   LyHashSet,
 };
@@ -103,10 +103,10 @@ impl Module {
   }
 
   /// Get the instance that represents
-  pub fn module_instance(&self, hooks: &GcHooks) -> GcObj<Instance> {
+  pub fn module_instance(&self, hooks: &GcHooks) -> Instance {
     let class = self.module_class;
 
-    let mut import = hooks.manage_obj(Instance::new(class));
+    let mut import = hooks.manage_instance(class);
     hooks.push_root(import);
 
     self.exports.iter().for_each(|export| {
@@ -136,7 +136,7 @@ impl Module {
         if parent.to_str() != Some("") {
           return Err(ModuleError::ModuleNotDirectDecedent);
         }
-      }
+      },
       None => return Err(ModuleError::ModuleNotDecedent),
     }
 
@@ -150,7 +150,7 @@ impl Module {
   }
 
   /// Get a reference to all exported symbols in this module
-  pub fn import(&self, hooks: &GcHooks, path: &[GcStr]) -> ModuleResult<GcObj<Instance>> {
+  pub fn import(&self, hooks: &GcHooks, path: &[GcStr]) -> ModuleResult<Instance> {
     if path.is_empty() {
       Ok(self.module_instance(hooks))
     } else {
@@ -176,7 +176,7 @@ impl Module {
   }
 
   /// Add export a new symbol from this module. Exported names must be unique
-  pub fn export_symbol(&mut self, hooks: &GcHooks, name: GcStr) -> ModuleResult<()> {
+  pub fn export_symbol(&mut self, name: GcStr) -> ModuleResult<()> {
     if !self.symbols.contains_key(&name) {
       return Err(ModuleError::SymbolDoesNotExist);
     }
@@ -184,7 +184,7 @@ impl Module {
     if self.exports.contains(&name) {
       Err(ModuleError::SymbolAlreadyExported)
     } else {
-      self.module_class.add_field(hooks, name);
+      self.module_class.add_field(name);
       self.exports.insert(name);
       Ok(())
     }
@@ -197,7 +197,7 @@ impl Module {
       Some(value) => {
         *value = symbol;
         Ok(())
-      }
+      },
       None => Err(ModuleError::SymbolDoesNotExist),
     }
   }
@@ -318,8 +318,9 @@ mod test {
   use crate::{
     hooks::{GcHooks, NoContext},
     module::{ModuleError, ModuleResult},
-    object::{Class},
-    val, support::test_class,
+    object::Class,
+    support::test_class,
+    val,
   };
   use std::path::PathBuf;
 
@@ -380,7 +381,7 @@ mod test {
     assert!(module
       .insert_symbol(&hooks, export_name, val!(true))
       .is_ok());
-    assert!(module.export_symbol(&hooks, export_name).is_ok());
+    assert!(module.export_symbol(export_name).is_ok());
 
     let symbols = module.module_instance(&hooks);
 
@@ -465,7 +466,7 @@ mod test {
     let symbol_name2 = hooks.manage_str("test2");
     let not_symbol_name = hooks.manage_str("not_test");
     inner_module.insert_symbol(&hooks, symbol_name1, val!(false))?;
-    inner_module.export_symbol(&hooks, symbol_name1)?;
+    inner_module.export_symbol(symbol_name1)?;
     inner_module.insert_symbol(&hooks, symbol_name2, val!(true))?;
 
     assert!(module.insert_module(&hooks, inner_module).is_ok());
@@ -513,8 +514,8 @@ mod test {
     assert!(module
       .insert_symbol(&hooks, export_name, val!(true))
       .is_ok());
-    let result1 = module.export_symbol(&hooks, export_name);
-    let result2 = module.export_symbol(&hooks, export_name);
+    let result1 = module.export_symbol(export_name);
+    let result2 = module.export_symbol(export_name);
 
     assert!(result1.is_ok());
     assert_eq!(result2, Err(ModuleError::SymbolAlreadyExported));
@@ -620,7 +621,7 @@ mod test {
       Err(ModuleError::SymbolNotExported)
     );
 
-    module.export_symbol(&hooks, name)?;
+    module.export_symbol(name)?;
     assert_eq!(module.get_exported_symbol(name), Ok(val!(10.0)));
 
     Ok(())

--- a/laythe_core/src/module/package.rs
+++ b/laythe_core/src/module/package.rs
@@ -1,7 +1,7 @@
 use super::{error::ModuleResult, import::Import, Module, ModuleError};
 use crate::{
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace, Allocate, AllocResult},
+  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace},
   object::Instance,
   value::Value,
 };
@@ -101,8 +101,8 @@ mod test {
     managed::Gc,
     memory::{Allocator, NO_GC},
     module::{Import, Module, ModuleError},
-    object::{test_class, Class},
-    val,
+    object::Class,
+    val, support::test_class,
   };
 
   fn test_module(alloc: &mut Allocator, name: &str) -> Gc<Module> {

--- a/laythe_core/src/module/package.rs
+++ b/laythe_core/src/module/package.rs
@@ -1,8 +1,7 @@
 use super::{error::ModuleResult, import::Import, Module, ModuleError};
 use crate::{
   hooks::GcHooks,
-  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcObj, GcStr, Trace},
-  object::Instance,
+  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcStr, Trace, Instance},
   value::Value,
 };
 use std::{fmt, io::Write};
@@ -35,7 +34,7 @@ impl Package {
 
   /// Get a set of symbols from this package using a requested import. This
   /// operation can fail if some or all of the symbols are not found.
-  pub fn import(&self, hooks: &GcHooks, import: Gc<Import>) -> ModuleResult<GcObj<Instance>> {
+  pub fn import(&self, hooks: &GcHooks, import: Gc<Import>) -> ModuleResult<Instance> {
     if import.package() == self.name {
       self.root_module.import(hooks, import.path())
     } else {
@@ -102,7 +101,8 @@ mod test {
     memory::{Allocator, NO_GC},
     module::{Import, Module, ModuleError},
     object::Class,
-    val, support::test_class,
+    support::test_class,
+    val,
   };
 
   fn test_module(alloc: &mut Allocator, name: &str) -> Gc<Module> {
@@ -158,7 +158,7 @@ mod test {
     assert!(inner_module
       .insert_symbol(&hooks, export_name, val!(true))
       .is_ok());
-    assert!(inner_module.export_symbol(&hooks, export_name).is_ok());
+    assert!(inner_module.export_symbol(export_name).is_ok());
     assert!(module.insert_module(&hooks, inner_module).is_ok());
 
     let package = Package::new(hooks.manage_str("my_package".to_string()), module);
@@ -204,7 +204,7 @@ mod test {
     assert!(inner_module
       .insert_symbol(&hooks, export_name, val!(true))
       .is_ok());
-    assert!(inner_module.export_symbol(&hooks, export_name).is_ok());
+    assert!(inner_module.export_symbol(export_name).is_ok());
     assert!(module.insert_module(&hooks, inner_module).is_ok());
 
     let package = Package::new(hooks.manage_str("my_package".to_string()), module);

--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -245,24 +245,3 @@ impl Object for Class {
     ObjectKind::Class
   }
 }
-
-#[cfg(test)]
-pub fn test_class(hooks: &GcHooks, name: &str) -> GcObj<Class> {
-  let mut object_class = hooks.manage_obj(Class::bare(hooks.manage_str("Object")));
-  let mut class_class = hooks.manage_obj(Class::bare(hooks.manage_str("Class")));
-  class_class.inherit(hooks, object_class);
-
-  let class_copy = class_class;
-  class_class.set_meta(class_copy);
-
-  // create object's meta class
-  let mut object_meta_class = hooks.manage_obj(Class::bare(
-    hooks.manage_str(format!("{} metaClass", &*object_class.name())),
-  ));
-
-  object_meta_class.inherit(hooks, class_class);
-  object_meta_class.set_meta(class_class);
-
-  object_class.set_meta(object_meta_class);
-  Class::with_inheritance(hooks, hooks.manage_str(name), object_class)
-}

--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -92,13 +92,13 @@ impl Class {
     self
   }
 
-  pub fn add_field(&mut self, _hooks: &GcHooks, name: GcStr) -> Option<u16> {
+  pub fn add_field(&mut self, name: GcStr) -> Option<u16> {
     let len = self.fields.len();
 
     self.fields.insert(name, len as u16)
   }
 
-  pub fn add_method(&mut self, _hooks: &GcHooks, name: GcStr, method: Value) -> Option<Value> {
+  pub fn add_method(&mut self, name: GcStr, method: Value) -> Option<Value> {
     if &*name == INIT {
       self.init = Some(method)
     }

--- a/laythe_core/src/object/fiber.rs
+++ b/laythe_core/src/object/fiber.rs
@@ -1,12 +1,12 @@
 use std::{fmt, io::Write, mem, ptr, usize};
 
-use super::{Channel, Fun, Instance, ObjectKind};
+use super::{Channel, Fun, ObjectKind};
 use crate::{
   call_frame::CallFrame,
   captures::Captures,
   constants::SCRIPT,
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, GcObj, Object, Trace},
+  managed::{DebugHeap, DebugWrap, GcObj, Object, Trace, Instance},
   val,
   value::{Value, VALUE_NIL},
 };
@@ -55,7 +55,7 @@ pub struct Fiber {
   state: FiberState,
 
   /// The current error if one is active
-  error: Option<GcObj<Instance>>,
+  error: Option<Instance>,
 }
 
 impl Fiber {
@@ -328,12 +328,12 @@ impl Fiber {
 
   /// Retrieve the current error on this fiber
   #[inline]
-  pub fn error(&self) -> Option<GcObj<Instance>> {
+  pub fn error(&self) -> Option<Instance> {
     self.error
   }
 
   /// Set the current error on this fiber
-  pub fn set_error(&mut self, error: GcObj<Instance>) {
+  pub fn set_error(&mut self, error: Instance) {
     self.error = Some(error);
   }
 
@@ -373,11 +373,11 @@ impl Fiber {
         self.assert_frame_inbounds();
 
         Some(frame.fun())
-      }
+      },
       None => {
         self.frame = ptr::null_mut();
         None
-      }
+      },
     })
   }
 
@@ -506,19 +506,19 @@ impl Fiber {
         self.stack_top = stack_top;
 
         UnwindResult::Handled(frame)
-      }
+      },
       None => {
         if bottom_frame == 0 {
           UnwindResult::Unhandled
         } else {
           UnwindResult::UnwindStopped
         }
-      }
+      },
     }
   }
 
   /// Print a error message with the associated stack track if found
-  pub fn print_error(&self, log: &mut dyn Write, error: GcObj<Instance>) {
+  pub fn print_error(&self, log: &mut dyn Write, error: Instance) {
     let message = error[0].to_obj().to_str();
     writeln!(log, "{}: {}", &*error.class().name(), &*message).expect("Unable to write to stderr");
 

--- a/laythe_core/src/object/instance.rs
+++ b/laythe_core/src/object/instance.rs
@@ -1,44 +1,33 @@
-use super::{Class, ObjectKind};
+use super::Class;
 use crate::{
-  managed::{DebugHeap, DebugWrap, GcObj, GcStr, Object, Trace},
-  value::{Value, VALUE_NIL},
+  managed::{GcObj, GcObject, GcStr, Instance},
+  value::Value,
 };
-use std::{
-  fmt,
-  io::Write,
-  ops::{Index, IndexMut},
-};
-
-#[derive(PartialEq, Clone)]
-pub struct Instance {
-  class: GcObj<Class>,
-  fields: Box<[Value]>,
-}
+use std::fmt;
 
 impl Instance {
-  #[inline]
-  pub fn new(class: GcObj<Class>) -> Self {
-    Instance {
-      class,
-      fields: vec![VALUE_NIL; class.fields()].into_boxed_slice(),
-    }
+  /// Degrade this GcArray into the more generic GcObject.
+  /// This allows the array to meet the same interface
+  /// as the other managed objects
+  pub fn degrade(self) -> GcObject {
+    GcObject::new(self.ptr())
   }
 
   #[inline]
   pub fn class(&self) -> GcObj<Class> {
-    self.class
+    self.header().class()
   }
 
   #[inline]
   pub fn fields(&self) -> &[Value] {
-    &self.fields
+    &*self
   }
 
   #[inline]
   pub fn set_field(&mut self, name: GcStr, value: Value) -> bool {
-    match self.class.get_field_index(&name) {
+    match self.class().get_field_index(&name) {
       Some(index) => {
-        self.fields[index as usize] = value;
+        self[index as usize] = value;
         true
       },
       None => false,
@@ -48,69 +37,14 @@ impl Instance {
   #[inline]
   pub fn get_field(&self, name: GcStr) -> Option<&Value> {
     self
-      .class
+      .class()
       .get_field_index(&name)
-      .map(|index| &self.fields[index as usize])
+      .map(|index| &self[index as usize])
   }
 }
 
 impl fmt::Display for Instance {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "<{} {:p}>", &*self.class().name(), &*self)
-  }
-}
-
-impl Index<usize> for Instance {
-  type Output = Value;
-
-  #[inline]
-  fn index(&self, index: usize) -> &Value {
-    &self.fields[index]
-  }
-}
-
-impl IndexMut<usize> for Instance {
-  #[inline]
-  fn index_mut(&mut self, index: usize) -> &mut Value {
-    &mut self.fields[index]
-  }
-}
-
-impl fmt::Debug for Instance {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    self.fmt_heap(f, 1)
-  }
-}
-
-impl Trace for Instance {
-  fn trace(&self) {
-    self.class.trace();
-
-    self.fields.iter().for_each(|val| {
-      val.trace();
-    });
-  }
-
-  fn trace_debug(&self, stdio: &mut dyn Write) {
-    self.class.trace_debug(stdio);
-
-    self.fields.iter().for_each(|val| {
-      val.trace_debug(stdio);
-    });
-  }
-}
-
-impl DebugHeap for Instance {
-  fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
-    f.debug_struct("Instance")
-      .field("class", &DebugWrap(&self.class, depth))
-      .field("fields", &DebugWrap(&&*self.fields, depth))
-      .finish()
-  }
-}
-
-impl Object for Instance {
-  fn kind(&self) -> ObjectKind {
-    ObjectKind::Instance
   }
 }

--- a/laythe_core/src/object/mod.rs
+++ b/laythe_core/src/object/mod.rs
@@ -17,7 +17,7 @@ pub use closure::Closure;
 pub use enumerator::{Enumerate, Enumerator};
 pub use fiber::{Fiber, FiberResult, FiberState, UnwindResult};
 pub use fun::{Fun, FunBuilder, FunKind, TryBlock};
-pub use instance::Instance;
+// pub use instance::Instance;
 pub use list::List;
 pub use ly_box::LyBox;
 pub use map::{Map, MapEntry};

--- a/laythe_core/src/object/mod.rs
+++ b/laythe_core/src/object/mod.rs
@@ -24,9 +24,6 @@ pub use map::{Map, MapEntry};
 pub use method::Method;
 pub use native::{LyNative, Native, NativeMeta, NativeMetaBuilder};
 
-#[cfg(test)]
-pub use class::test_class;
-
 /// Enum of value types in laythe
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub enum ObjectKind {

--- a/laythe_core/src/support/mod.rs
+++ b/laythe_core/src/support/mod.rs
@@ -121,11 +121,11 @@ impl ClassBuilder {
     let mut class = Class::with_inheritance(hooks, hooks.manage_str(self.name), super_cls);
 
     for (name, method) in self.methods {
-      class.add_method(hooks, name, method);
+      class.add_method(name, method);
     }
 
     for field in self.fields {
-      class.add_field(hooks, field);
+      class.add_field(field);
     }
 
     class

--- a/laythe_core/src/support/mod.rs
+++ b/laythe_core/src/support/mod.rs
@@ -169,7 +169,7 @@ pub fn test_fun_builder(hooks: &GcHooks, name: &str, module_name: &str) -> FunBu
   FunBuilder::new(hooks.manage_str(name), module, Arity::default())
 }
 
-fn test_object_class(hooks: &GcHooks) -> GcObj<Class> {
+pub fn test_object_class(hooks: &GcHooks) -> GcObj<Class> {
   let mut object_class = hooks.manage_obj(Class::bare(hooks.manage_str("Object")));
   let mut class_class = hooks.manage_obj(Class::bare(hooks.manage_str("Class")));
   class_class.inherit(hooks, object_class);

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -73,10 +73,9 @@ pub use self::boxed::*;
 #[cfg(not(feature = "nan_boxing"))]
 mod unboxed {
   use crate::{
-    managed::{DebugHeap, DebugWrap, GcObj, GcObject, GcStr, Trace, Tuple},
+    managed::{DebugHeap, DebugWrap, GcObj, GcObject, GcStr, Instance, Trace, Tuple},
     object::{
-      Channel, Class, Closure, Enumerator, Fiber, Fun, Instance, List, LyBox, Map, Method, Native,
-      ObjectKind,
+      Channel, Class, Closure, Enumerator, Fiber, Fun, List, LyBox, Map, Method, Native, ObjectKind,
     },
   };
 
@@ -330,8 +329,8 @@ mod unboxed {
     }
   }
 
-  impl From<GcObj<Instance>> for Value {
-    fn from(managed: GcObj<Instance>) -> Value {
+  impl From<Instance> for Value {
+    fn from(managed: Instance) -> Value {
       Value::Obj(managed.degrade())
     }
   }
@@ -400,16 +399,16 @@ mod unboxed {
         Self::Number(num) => {
           ValueKind::Number.hash(state);
           (*num as u64).hash(state);
-        }
+        },
         Self::Bool(b) => {
           ValueKind::Bool.hash(state);
           b.hash(state);
-        }
+        },
         Self::Nil => ValueKind::Nil.hash(state),
         Self::Obj(obj) => {
           ValueKind::Obj.hash(state);
           obj.hash(state);
-        }
+        },
       };
     }
   }
@@ -451,7 +450,6 @@ mod unboxed {
       assert_eq!(mem::size_of::<Closure>(), 24);
       assert_eq!(mem::size_of::<Fun>(), 96);
       assert_eq!(mem::size_of::<Class>(), 104);
-      assert_eq!(mem::size_of::<Instance>(), 24);
       assert_eq!(mem::size_of::<Method>(), 32);
       assert_eq!(mem::size_of::<Enumerator>(), 32);
       assert_eq!(mem::size_of::<Native>(), 56);
@@ -467,7 +465,6 @@ mod unboxed {
       assert_eq!(mem::align_of::<Closure>(), target);
       assert_eq!(mem::align_of::<Fun>(), target);
       assert_eq!(mem::align_of::<Class>(), target);
-      assert_eq!(mem::align_of::<Instance>(), target);
       assert_eq!(mem::align_of::<Method>(), target);
       assert_eq!(mem::align_of::<Enumerator>(), target);
       assert_eq!(mem::align_of::<Native>(), target);
@@ -480,10 +477,9 @@ mod unboxed {
 mod boxed {
   use super::{Nil, ValueKind};
   use crate::{
-    managed::{DebugHeap, GcObj, GcObject, GcStr, Trace, Tuple},
+    managed::{DebugHeap, GcObj, GcObject, GcStr, Instance, Trace, Tuple},
     object::{
-      Channel, Class, Closure, Enumerator, Fiber, Fun, Instance, List, LyBox, Map, Method, Native,
-      ObjectKind,
+      Channel, Class, Closure, Enumerator, Fiber, Fun, List, LyBox, Map, Method, Native, ObjectKind,
     },
   };
 
@@ -742,8 +738,8 @@ mod boxed {
     }
   }
 
-  impl From<GcObj<Instance>> for Value {
-    fn from(managed: GcObj<Instance>) -> Value {
+  impl From<Instance> for Value {
+    fn from(managed: Instance) -> Value {
       Self(managed.to_usize() as u64 | TAG_OBJ)
     }
   }
@@ -791,7 +787,6 @@ mod boxed {
       assert_eq!(mem::size_of::<Fun>(), 64);
       assert_eq!(mem::size_of::<Fiber>(), 104);
       assert_eq!(mem::size_of::<Class>(), 104);
-      assert_eq!(mem::size_of::<Instance>(), 24);
       assert_eq!(mem::size_of::<Method>(), 16);
       assert_eq!(mem::size_of::<Enumerator>(), 24);
       assert_eq!(mem::size_of::<Native>(), 56);
@@ -807,7 +802,6 @@ mod boxed {
       assert_eq!(mem::align_of::<Closure>(), target);
       assert_eq!(mem::align_of::<Fun>(), target);
       assert_eq!(mem::align_of::<Class>(), target);
-      assert_eq!(mem::align_of::<Instance>(), target);
       assert_eq!(mem::align_of::<Method>(), target);
       assert_eq!(mem::align_of::<Enumerator>(), target);
       assert_eq!(mem::align_of::<Native>(), target);

--- a/laythe_lib/src/global/primitives/bool.rs
+++ b/laythe_lib/src/global/primitives/bool.rs
@@ -29,7 +29,6 @@ pub fn define_bool_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   let mut bool_class = load_class_from_module(hooks, module, BOOL_CLASS_NAME)?;
 
   bool_class.add_method(
-    hooks,
     hooks.manage_str(String::from(BOOL_STR.name)),
     val!(BoolStr::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/channel.rs
+++ b/laythe_lib/src/global/primitives/channel.rs
@@ -36,25 +36,21 @@ pub fn define_channel_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()
   let channel_error = val!(load_class_from_module(hooks, module, CHANNEL_ERROR_NAME)?);
 
   channel_class.add_method(
-    hooks,
     hooks.manage_str(String::from(CHANNEL_STR.name)),
     val!(ChannelStr::native(hooks)),
   );
 
   channel_class.add_method(
-    hooks,
     hooks.manage_str(String::from(CHANNEL_LEN.name)),
     val!(ChannelLen::native(hooks)),
   );
 
   channel_class.add_method(
-    hooks,
     hooks.manage_str(String::from(CHANNEL_CAPACITY.name)),
     val!(ChannelCapacity::native(hooks)),
   );
 
   channel_class.add_method(
-    hooks,
     hooks.manage_str(String::from(CHANNEL_CLOSE.name)),
     val!(ChannelClose::native(hooks, channel_error)),
   );

--- a/laythe_lib/src/global/primitives/class.rs
+++ b/laythe_lib/src/global/primitives/class.rs
@@ -22,19 +22,16 @@ pub fn create_class_class(hooks: &GcHooks, object: GcObj<Class>) -> GcObj<Class>
   class.inherit(hooks, object);
 
   class.add_method(
-    hooks,
     hooks.manage_str(CLASS_SUPER_CLS.name),
     val!(ClassSuperCls::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(CLASS_STR.name),
     val!(ClassStr::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(CLASS_NAME.name),
     val!(ClassName::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/closure.rs
+++ b/laythe_lib/src/global/primitives/closure.rs
@@ -36,19 +36,16 @@ pub fn define_closure_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()
   let mut class = load_class_from_module(hooks, module, CLOSURE_CLASS_NAME)?;
 
   class.add_method(
-    hooks,
     hooks.manage_str(CLOSURE_NAME.name),
     val!(ClosureName::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(CLOSURE_LEN.name),
     val!(ClosureLen::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(CLOSURE_CALL.name),
     val!(ClosureCall::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/error.rs
+++ b/laythe_lib/src/global/primitives/error.rs
@@ -40,12 +40,11 @@ const ERROR_INIT: NativeMetaBuilder = NativeMetaBuilder::method("init", Arity::D
 pub fn create_error_class(hooks: &GcHooks, object: GcObj<Class>) -> GcObj<Class> {
   let mut class = Class::with_inheritance(hooks, hooks.manage_str(ERROR_CLASS_NAME), object);
 
-  class.add_field(hooks, hooks.manage_str(ERROR_FIELD_MESSAGE));
-  class.add_field(hooks, hooks.manage_str(ERROR_FIELD_STACK));
-  class.add_field(hooks, hooks.manage_str(ERROR_FIELD_INNER));
+  class.add_field(hooks.manage_str(ERROR_FIELD_MESSAGE));
+  class.add_field(hooks.manage_str(ERROR_FIELD_STACK));
+  class.add_field(hooks.manage_str(ERROR_FIELD_INNER));
 
   class.add_method(
-    hooks,
     hooks.manage_str(ERROR_INIT.name),
     val!(ErrorInit::native(hooks)),
   );
@@ -112,7 +111,7 @@ mod test {
   use super::*;
 
   mod init {
-    use laythe_core::object::{Class, Instance, ObjectKind};
+    use laythe_core::object::{Class, ObjectKind};
 
     use super::*;
     use crate::support::MockedContext;
@@ -143,11 +142,11 @@ mod test {
 
       let error_init = ErrorInit::native(&hooks.as_gc());
       let mut test_class = hooks.manage_obj(Class::bare(hooks.manage_str("test")));
-      test_class.add_field(&hooks.as_gc(), hooks.manage_str(ERROR_FIELD_MESSAGE));
-      test_class.add_field(&hooks.as_gc(), hooks.manage_str(ERROR_FIELD_STACK));
-      test_class.add_field(&hooks.as_gc(), hooks.manage_str(ERROR_FIELD_INNER));
+      test_class.add_field(hooks.manage_str(ERROR_FIELD_MESSAGE));
+      test_class.add_field(hooks.manage_str(ERROR_FIELD_STACK));
+      test_class.add_field(hooks.manage_str(ERROR_FIELD_INNER));
 
-      let instance = hooks.manage_obj(Instance::new(test_class));
+      let instance = hooks.manage_instance(test_class);
 
       let name = val!(hooks.manage_str("test"));
       let args = [name];

--- a/laythe_lib/src/global/primitives/fiber.rs
+++ b/laythe_lib/src/global/primitives/fiber.rs
@@ -29,7 +29,6 @@ pub fn define_fiber_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> 
   let mut bool_class = load_class_from_module(hooks, module, FIBER_CLASS_NAME)?;
 
   bool_class.add_method(
-    hooks,
     hooks.manage_str(String::from(FIBER_STR.name)),
     val!(FiberStr::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/fun.rs
+++ b/laythe_lib/src/global/primitives/fun.rs
@@ -36,19 +36,16 @@ pub fn define_fun_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   let mut class = load_class_from_module(hooks, module, FUN_CLASS_NAME)?;
 
   class.add_method(
-    hooks,
     hooks.manage_str(FUN_NAME.name),
     val!(FunName::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(FUN_LEN.name),
     val!(FunLen::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(FUN_CALL.name),
     val!(FunCall::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/iter.rs
+++ b/laythe_lib/src/global/primitives/iter.rs
@@ -95,115 +95,96 @@ pub fn define_iter_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   let value_error = val!(load_class_from_module(hooks, module, VALUE_ERROR_NAME)?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_STR.name),
     val!(IterStr::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_NEXT.name),
     val!(IterNext::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_CURRENT.name),
     val!(IterCurrent::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_ITER.name),
     val!(IterIter::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_FIRST.name),
     val!(IterFirst::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_LAST.name),
     val!(IterLast::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_TAKE.name),
     val!(IterTake::native(hooks, value_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_SKIP.name),
     val!(IterSkip::native(hooks, value_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_MAP.name),
     val!(IterMap::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_FILTER.name),
     val!(IterFilter::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_REDUCE.name),
     val!(IterReduce::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_LEN.name),
     val!(IterLen::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_EACH.name),
     val!(IterEach::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_ZIP.name),
     val!(IterZip::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_CHAIN.name),
     val!(IterChain::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_ALL.name),
     val!(IterAll::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_ANY.name),
     val!(IterAny::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_LIST.name),
     val!(IterToList::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(ITER_INTO.name),
     val!(IterInto::native(hooks)),
   );
@@ -668,7 +649,7 @@ impl LyNative for IterLen {
         }
 
         Call::Ok(val!(size as f64))
-      }
+      },
     }
   }
 }
@@ -1324,7 +1305,10 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build(&hooks.as_gc())), captures)));
+      let fun = val!(hooks.manage_obj(Closure::new(
+        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        captures
+      )));
 
       let result = iter_map.call(&mut hooks, Some(this), &[fun]);
       match result {
@@ -1332,7 +1316,7 @@ mod test {
           let mut map_iter = r.to_obj().to_enumerator();
           assert_eq!(map_iter.next(&mut hooks).unwrap(), val!(true));
           assert_eq!(map_iter.current(), val!(5.0));
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1373,7 +1357,10 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build(&hooks.as_gc())), captures)));
+      let fun = val!(hooks.manage_obj(Closure::new(
+        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        captures
+      )));
 
       let result = iter_filter.call(&mut hooks, Some(this), &[fun]);
       match result {
@@ -1383,7 +1370,7 @@ mod test {
           assert_eq!(filter_iter.current(), val!(2.0));
           assert_eq!(filter_iter.next(&mut hooks).unwrap(), val!(true));
           assert_eq!(filter_iter.current(), val!(3.0));
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1429,14 +1416,17 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(2));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build(&hooks.as_gc())), captures)));
+      let fun = val!(hooks.manage_obj(Closure::new(
+        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        captures
+      )));
 
       let result = iter_reduce.call(&mut hooks, Some(this), &[val!(0.0), fun]);
       match result {
         Call::Ok(r) => {
           assert!(r.is_num());
           assert_eq!(r.to_num(), 10.1);
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1470,7 +1460,7 @@ mod test {
         Call::Ok(r) => {
           assert!(r.is_num());
           assert_eq!(r.to_num(), 4.0);
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1512,7 +1502,10 @@ mod test {
       let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let fun = val!(hooks.manage_obj(Closure::new(hooks.manage_obj(builder.build(&hooks.as_gc())), captures)));
+      let fun = val!(hooks.manage_obj(Closure::new(
+        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        captures
+      )));
 
       let result = iter_each.call(&mut hooks, Some(this), &[fun]);
       match result {

--- a/laythe_lib/src/global/primitives/list.rs
+++ b/laythe_lib/src/global/primitives/list.rs
@@ -94,55 +94,46 @@ pub fn define_list_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   let type_error = val!(load_class_from_module(hooks, module, TYPE_ERROR_NAME)?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_INDEX_GET.name),
     val!(ListIndexGet::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_INDEX_SET.name),
     val!(ListIndexSet::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_LEN.name),
     val!(ListLen::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_PUSH.name),
     val!(ListPush::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_POP.name),
     val!(ListPop::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_REMOVE.name),
     val!(ListRemove::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_INDEX.name),
     val!(ListIndex::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_INSERT.name),
     val!(ListInsert::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_STR.name),
     val!(ListStr::native(
       hooks,
@@ -152,43 +143,36 @@ pub fn define_list_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_SLICE.name),
     val!(ListSlice::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_CLEAR.name),
     val!(ListClear::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_HAS.name),
     val!(ListHas::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_ITER.name),
     val!(ListIter::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_REV.name),
     val!(ListRev::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(LIST_SORT.name),
     val!(ListSort::native(hooks, type_error)),
   );
 
   class.meta_class().expect("Meta class not set.").add_method(
-    hooks,
     hooks.manage_str(LIST_COLLECT.name),
     val!(ListCollect::native(hooks)),
   );
@@ -400,7 +384,7 @@ impl LyNative for ListIndexSet {
       Ok(index) => {
         list[index] = args[0];
         Call::Ok(args[0])
-      }
+      },
       Err(message) => self.call_error(hooks, message),
     }
   }
@@ -573,18 +557,18 @@ impl LyNative for ListSort {
                   self.call_error(hooks, "comparator must return a valid number.")
                 });
                 Ordering::Equal
-              }
+              },
             }
           } else {
             failure
               .get_or_insert_with(|| self.call_error(hooks, "comparator must return a number."));
             Ordering::Equal
           }
-        }
+        },
         Call::Err(err) => {
           failure.get_or_insert(Err(err));
           Ordering::Equal
-        }
+        },
       }
     });
 
@@ -648,11 +632,11 @@ impl Enumerate for ListIterator {
       Some(value) => {
         self.current = *value;
         Call::Ok(val!(true))
-      }
+      },
       None => {
         self.current = VALUE_NIL;
         Call::Ok(val!(false))
-      }
+      },
     }
   }
 
@@ -941,7 +925,7 @@ mod test {
           assert_eq!(r, VALUE_NIL);
           assert_eq!(list_value.unwrap().to_obj().to_list().len(), 3);
           assert_eq!(list_value.unwrap().to_obj().to_list()[2], val!(false));
-        }
+        },
         _ => assert!(false),
       }
 
@@ -952,7 +936,7 @@ mod test {
           assert_eq!(list_value.unwrap().to_obj().to_list().len(), 5);
           assert_eq!(list_value.unwrap().to_obj().to_list()[3], val!(10.3));
           assert_eq!(list_value.unwrap().to_obj().to_list()[4], VALUE_NIL);
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -989,7 +973,7 @@ mod test {
         Call::Ok(r) => {
           assert_eq!(r.to_bool(), true);
           assert_eq!(this.len(), 0);
-        }
+        },
         _ => assert!(false),
       }
 
@@ -998,7 +982,7 @@ mod test {
         Call::Ok(r) => {
           assert!(r.is_nil());
           assert_eq!(this.len(), 0);
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1041,7 +1025,7 @@ mod test {
         Call::Ok(r) => {
           assert_eq!(r.to_num(), 10.0);
           assert_eq!(this.len(), 2);
-        }
+        },
         _ => assert!(false),
       }
 
@@ -1093,7 +1077,7 @@ mod test {
       match result {
         Call::Ok(r) => {
           assert_eq!(r.to_num(), 1.0);
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1141,7 +1125,7 @@ mod test {
           assert!(r.is_nil());
           assert_eq!(this[1], val!(false));
           assert_eq!(this.len(), 4);
-        }
+        },
         _ => assert!(false),
       }
 
@@ -1190,7 +1174,7 @@ mod test {
         Call::Ok(r) => {
           assert!(r.is_nil());
           assert_eq!(this.len(), 0);
-        }
+        },
         _ => assert!(false),
       }
 
@@ -1199,7 +1183,7 @@ mod test {
         Call::Ok(r) => {
           assert!(r.is_nil());
           assert_eq!(this.len(), 0);
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1239,7 +1223,7 @@ mod test {
       match result {
         Call::Ok(r) => {
           assert!(r.to_bool());
-        }
+        },
         _ => assert!(false),
       }
 
@@ -1247,7 +1231,7 @@ mod test {
       match result {
         Call::Ok(r) => {
           assert!(!r.to_bool());
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1285,7 +1269,7 @@ mod test {
           assert_eq!(iter.current(), VALUE_NIL);
           assert_eq!(iter.next(&mut hooks).unwrap(), val!(true));
           assert_eq!(iter.current(), VALUE_NIL);
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -1411,7 +1395,7 @@ mod test {
         Call::Ok(r) => {
           let list = r.to_obj().to_list();
           assert_eq!(list.len(), 4);
-        }
+        },
         _ => assert!(false),
       }
     }

--- a/laythe_lib/src/global/primitives/map.rs
+++ b/laythe_lib/src/global/primitives/map.rs
@@ -75,25 +75,21 @@ pub fn define_map_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   let type_error = val!(load_class_from_module(hooks, module, TYPE_ERROR_NAME)?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_LEN.name),
     val!(MapLen::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_INDEX_GET.name),
     val!(MapIndexGet::native(hooks, key_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_INDEX_SET.name),
     val!(MapIndexSet::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_STR.name),
     val!(MapStr::native(
       hooks,
@@ -103,37 +99,31 @@ pub fn define_map_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_HAS.name),
     val!(MapHas::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_GET.name),
     val!(MapGet::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_SET.name),
     val!(MapSet::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_REMOVE.name),
     val!(MapRemove::native(hooks, key_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_INSERT.name),
     val!(MapInsert::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(MAP_ITER.name),
     val!(MapIter::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/method.rs
+++ b/laythe_lib/src/global/primitives/method.rs
@@ -34,7 +34,6 @@ pub fn define_method_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()>
   let mut class = load_class_from_module(hooks, module, METHOD_CLASS_NAME)?;
 
   class.add_method(
-    hooks,
     hooks.manage_str(METHOD_NAME.name),
     val!(MethodName::native(
       hooks,
@@ -43,7 +42,6 @@ pub fn define_method_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()>
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(METHOD_CALL.name),
     val!(MethodCall::native(hooks)),
   );
@@ -104,8 +102,9 @@ mod test {
     use super::*;
     use crate::support::{test_fun, MockedContext};
     use laythe_core::{
+      captures::Captures,
       memory::NO_GC,
-      object::{Class, Closure, Instance, Method}, captures::Captures,
+      object::{Class, Closure, Method},
     };
 
     #[test]
@@ -132,7 +131,7 @@ mod test {
       let class = hooks.manage_obj(Class::bare(hooks.manage_str("exampleClass".to_string())));
       let captures = Captures::new(&hooks.as_gc(), &[]);
       let closure = hooks.manage_obj(Closure::new(fun, captures));
-      let instance = hooks.manage_obj(Instance::new(class));
+      let instance = hooks.manage_instance(class);
       let method = hooks.manage_obj(Method::new(val!(instance), val!(closure)));
 
       let result1 = method_name.call(&mut hooks, Some(val!(method)), &[]);
@@ -147,7 +146,10 @@ mod test {
   mod call {
     use super::*;
     use crate::support::{test_fun, MockedContext};
-    use laythe_core::{object::{Class, Closure, Instance, Method}, captures::Captures};
+    use laythe_core::{
+      captures::Captures,
+      object::{Class, Closure, Method},
+    };
 
     #[test]
     fn new() {
@@ -174,7 +176,7 @@ mod test {
       let class = hooks.manage_obj(Class::bare(hooks.manage_str("exampleClass".to_string())));
       let captures = Captures::new(&hooks.as_gc(), &[]);
       let closure = hooks.manage_obj(Closure::new(fun, captures));
-      let instance = hooks.manage_obj(Instance::new(class));
+      let instance = hooks.manage_instance(class);
       let method = hooks.manage_obj(Method::new(val!(instance), val!(closure)));
 
       let result1 = method_call.call(&mut hooks, Some(val!(method)), &[]);

--- a/laythe_lib/src/global/primitives/native.rs
+++ b/laythe_lib/src/global/primitives/native.rs
@@ -35,13 +35,11 @@ pub fn define_native_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()>
   let mut class = load_class_from_module(hooks, module, NATIVE_CLASS_NAME)?;
 
   class.add_method(
-    hooks,
     hooks.manage_str(NATIVE_NAME.name),
     val!(NativeName::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(NATIVE_CALL.name),
     val!(NativeCall::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/nil.rs
+++ b/laythe_lib/src/global/primitives/nil.rs
@@ -30,7 +30,6 @@ pub fn define_nil_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   let mut class = load_class_from_module(hooks, module, NIL_CLASS_NAME)?;
 
   class.add_method(
-    hooks,
     hooks.manage_str(NIL_STR.name),
     val!(NilStr::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/number.rs
+++ b/laythe_lib/src/global/primitives/number.rs
@@ -57,49 +57,41 @@ pub fn define_number_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()>
   let value_error = val!(load_class_from_module(hooks, module, VALUE_ERROR_NAME)?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(NUMBER_STR.name),
     val!(NumberStr::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(NUMBER_FLOOR.name),
     val!(NumberFloor::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(NUMBER_CEIL.name),
     val!(NumberCeil::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(NUMBER_ROUND.name),
     val!(NumberRound::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(NUMBER_TIMES.name),
     val!(NumberTimes::native(hooks, value_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(NUMBER_UNTIL.name),
     val!(NumberUntil::native(hooks, value_error)),
   );
 
   class.meta_class().expect("Meta class not set.").add_method(
-    hooks,
     hooks.manage_str(NUMBER_PARSE.name),
     val!(NumberParse::native(hooks, format_error)),
   );
 
   class.meta_class().expect("Meta class not set.").add_method(
-    hooks,
     hooks.manage_str(NUMBER_CMP.name),
     val!(NumberCmp::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/object.rs
+++ b/laythe_lib/src/global/primitives/object.rs
@@ -26,19 +26,16 @@ pub fn create_object_class(hooks: &GcHooks) -> GcObj<Class> {
   let mut object = hooks.manage_obj(Class::bare(name));
 
   object.add_method(
-    hooks,
     hooks.manage_str(OBJECT_EQUALS.name),
     val!(ObjectEquals::native(hooks)),
   );
 
   object.add_method(
-    hooks,
     hooks.manage_str(OBJECT_CLASS.name),
     val!(ObjectCls::native(hooks)),
   );
 
   object.add_method(
-    hooks,
     hooks.manage_str(OBJECT_STR.name),
     val!(ObjectStr::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/string.rs
+++ b/laythe_lib/src/global/primitives/string.rs
@@ -59,55 +59,46 @@ pub fn define_string_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()>
   let index_error = val!(load_class_from_module(hooks, module, INDEX_ERROR_NAME)?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_INDEX_GET.name),
     val!(StringIndexGet::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_STR.name),
     val!(StringStr::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_LEN.name),
     val!(StringLen::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_HAS.name),
     val!(StringHas::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_UP_CASE.name),
     val!(StringUpCase::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_DOWN_CASE.name),
     val!(StringDownCase::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_SLICE.name),
     val!(StringSlice::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_SPLIT.name),
     val!(StringSplit::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STRING_ITER.name),
     val!(StringIter::native(hooks)),
   );

--- a/laythe_lib/src/global/primitives/tuple.rs
+++ b/laythe_lib/src/global/primitives/tuple.rs
@@ -64,25 +64,21 @@ pub fn define_tuple_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> 
   let type_error = val!(load_class_from_module(hooks, module, TYPE_ERROR_NAME)?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(TUPLE_INDEX_GET.name),
     val!(TupleIndexGet::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(TUPLE_LEN.name),
     val!(TupleLen::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(TUPLE_INDEX.name),
     val!(TupleIndex::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(TUPLE_STR.name),
     val!(TupleStr::native(
       hooks,
@@ -92,25 +88,21 @@ pub fn define_tuple_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> 
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(TUPLE_SLICE.name),
     val!(TupleSlice::native(hooks, index_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(TUPLE_HAS.name),
     val!(TupleHas::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(TUPLE_ITER.name),
     val!(TupleIter::native(hooks)),
   );
 
   class.meta_class().expect("Meta class not set.").add_method(
-    hooks,
     hooks.manage_str(TUPLE_COLLECT.name),
     val!(TupleCollect::native(hooks)),
   );

--- a/laythe_lib/src/io/fs/file.rs
+++ b/laythe_lib/src/io/fs/file.rs
@@ -41,7 +41,6 @@ pub fn define_file(hooks: &GcHooks, module: Gc<Module>, std: Gc<Package>) -> Std
   )?);
 
   class.meta_class().expect("Meta class not set.").add_method(
-    hooks,
     hooks.manage_str(FILE_READ_ALL_TEXT.name),
     val!(FileReadAllText::native(hooks, io_error)),
   );

--- a/laythe_lib/src/io/stdio/stderr.rs
+++ b/laythe_lib/src/io/stdio/stderr.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   managed::Trace,
   managed::{Gc, GcObj},
   module::{Module, Package},
-  object::{Instance, LyNative, Native, NativeMetaBuilder, ObjectKind},
+  object::{LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::{Arity, ParameterBuilder, ParameterKind},
   val,
   value::{Value, VALUE_NIL},
@@ -34,7 +34,7 @@ const STDERR_FLUSH: NativeMetaBuilder =
 
 pub fn declare_stderr(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) -> StdResult<()> {
   let class = default_class_inheritance(hooks, package, STDERR_CLASS_NAME)?;
-  let instance = hooks.manage_obj(Instance::new(class));
+  let instance = hooks.manage_instance(class);
 
   export_and_insert(
     hooks,
@@ -55,19 +55,16 @@ pub fn define_stderr(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) 
   )?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(STDERR_WRITE.name),
     val!(StderrWrite::native(hooks, io_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STDERR_WRITELN.name),
     val!(StderrWriteln::native(hooks, io_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STDERR_FLUSH.name),
     val!(StderrFlush::native(hooks, io_error)),
   );

--- a/laythe_lib/src/io/stdio/stdin.rs
+++ b/laythe_lib/src/io/stdio/stdin.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   managed::Trace,
   managed::{Gc, GcObj},
   module::{Module, Package},
-  object::{Instance, LyNative, Native, NativeMetaBuilder, ObjectKind},
+  object::{LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::Arity,
   val,
   value::Value,
@@ -28,7 +28,7 @@ const STDIN_READ_LINE: NativeMetaBuilder =
 
 pub fn declare_stdin(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) -> StdResult<()> {
   let class = default_class_inheritance(hooks, package, STDIN_CLASS_NAME)?;
-  let instance = hooks.manage_obj(Instance::new(class));
+  let instance = hooks.manage_instance(class);
 
   export_and_insert(
     hooks,
@@ -49,13 +49,11 @@ pub fn define_stdin(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) -
   )?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(STDIN_READ.name),
     val!(StdinRead::native(hooks, io_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STDIN_READ_LINE.name),
     val!(StdinReadLine::native(hooks, io_error)),
   );

--- a/laythe_lib/src/io/stdio/stdout.rs
+++ b/laythe_lib/src/io/stdio/stdout.rs
@@ -10,7 +10,7 @@ use laythe_core::{
   managed::Trace,
   managed::{Gc, GcObj},
   module::{Module, Package},
-  object::{Instance, LyNative, Native, NativeMetaBuilder, ObjectKind},
+  object::{LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::{Arity, ParameterBuilder, ParameterKind},
   val,
   value::{Value, VALUE_NIL},
@@ -34,7 +34,7 @@ const STDOUT_FLUSH: NativeMetaBuilder =
 
 pub fn declare_stdout(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) -> StdResult<()> {
   let class = default_class_inheritance(hooks, package, STDOUT_CLASS_NAME)?;
-  let instance = hooks.manage_obj(Instance::new(class));
+  let instance = hooks.manage_instance(class);
 
   export_and_insert(
     hooks,
@@ -55,19 +55,16 @@ pub fn define_stdout(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) 
   )?);
 
   class.add_method(
-    hooks,
     hooks.manage_str(STDOUT_WRITE.name),
     val!(StdoutWrite::native(hooks, io_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STDOUT_WRITELN.name),
     val!(StdoutWriteln::native(hooks, io_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(STDOUT_FLUSH.name),
     val!(StdoutFlush::native(hooks, io_error)),
   );

--- a/laythe_lib/src/regexp/class.rs
+++ b/laythe_lib/src/regexp/class.rs
@@ -63,29 +63,25 @@ pub fn define_regexp_class(
     SYNTAX_ERROR_NAME
   )?);
 
-  class.add_field(hooks, hooks.manage_str(REGEXP_FIELD_PATTERN));
-  class.add_field(hooks, hooks.manage_str(REGEXP_FIELD_FLAGS));
+  class.add_field(hooks.manage_str(REGEXP_FIELD_PATTERN));
+  class.add_field(hooks.manage_str(REGEXP_FIELD_FLAGS));
 
   class.add_method(
-    hooks,
     hooks.manage_str(REGEXP_INIT.name),
     val!(RegExpInit::native(hooks)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(REGEXP_TEST.name),
     val!(RegExpTest::native(hooks, syntax_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(REGEXP_MATCH.name),
     val!(RegExpMatch::native(hooks, syntax_error)),
   );
 
   class.add_method(
-    hooks,
     hooks.manage_str(REGEXP_CAPTURES.name),
     val!(RegExpCaptures::native(hooks, syntax_error)),
   );
@@ -161,7 +157,7 @@ impl LyNative for RegExpCaptures {
 
         hooks.pop_roots(1);
         Call::Ok(val!(results))
-      }
+      },
       None => Call::Ok(VALUE_NIL),
     }
   }
@@ -170,14 +166,14 @@ impl LyNative for RegExpCaptures {
 #[cfg(test)]
 mod test {
   use super::*;
-  use laythe_core::object::{Class, Instance};
+  use laythe_core::object::Class;
 
   fn regexp_instance(hooks: &mut Hooks, pattern: &str) -> Value {
     let mut regexp_class = Class::bare(hooks.manage_str(REGEXP_CLASS_NAME));
-    regexp_class.add_field(&hooks.as_gc(), hooks.manage_str(REGEXP_FIELD_PATTERN));
-    regexp_class.add_field(&hooks.as_gc(), hooks.manage_str(REGEXP_FIELD_FLAGS));
+    regexp_class.add_field(hooks.manage_str(REGEXP_FIELD_PATTERN));
+    regexp_class.add_field(hooks.manage_str(REGEXP_FIELD_FLAGS));
 
-    let regexp = hooks.manage_obj(Instance::new(hooks.manage_obj(regexp_class)));
+    let regexp = hooks.manage_instance(hooks.manage_obj(regexp_class));
     let init = RegExpInit::native(&hooks.as_gc());
     init
       .call(

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -5,9 +5,9 @@ use crate::{
 use laythe_core::{
   hooks::GcHooks,
   if_let_obj,
-  managed::{Gc, GcObj, GcStr},
+  managed::{Gc, GcObj, GcStr, Instance},
   module::{Import, Module, Package},
-  object::{Class, Instance, ObjectKind},
+  object::{Class, ObjectKind},
   to_obj_kind,
   value::Value,
 };
@@ -91,7 +91,7 @@ pub fn load_instance_from_module(
   hooks: &GcHooks,
   module: Gc<Module>,
   name: &str,
-) -> StdResult<GcObj<Instance>> {
+) -> StdResult<Instance> {
   let name = hooks.manage_str(name);
   match module.get_exported_symbol(name) {
     Ok(symbol) => {
@@ -112,7 +112,7 @@ pub fn export_and_insert(
   symbol: Value,
 ) -> StdResult<()> {
   module.insert_symbol(hooks, name, symbol)?;
-  module.export_symbol(hooks, name).map_err(StdError::from)
+  module.export_symbol(name).map_err(StdError::from)
 }
 
 #[cfg(test)]
@@ -460,7 +460,6 @@ mod test {
     let mut error_class = Class::bare(hooks.manage_str("Error"));
 
     error_class.add_method(
-      hooks,
       hooks.manage_str("init"),
       val!(TestInit::native(hooks)),
     );

--- a/laythe_vm/src/compiler/mod.rs
+++ b/laythe_vm/src/compiler/mod.rs
@@ -2182,8 +2182,8 @@ mod test {
     assert!(module
       .insert_symbol(hooks, object_class.name(), val!(object_class))
       .is_ok());
-    assert!(module.export_symbol(hooks, print.name()).is_ok());
-    assert!(module.export_symbol(hooks, object_class.name()).is_ok());
+    assert!(module.export_symbol(print.name()).is_ok());
+    assert!(module.export_symbol(object_class.name()).is_ok());
 
     hooks.pop_roots(1);
 


### PR DESCRIPTION
## Summary
Because we've constrained instance to only include fix number of inputs we know at instantiation how many values they may hold. Because of this we can really think of instances as a `GcArray` with a pointer to the class somewhere. 

To do this we create a new `InstanceHeader` which includes the class in the object header which follows the layout of `ObjHeader`. Because of this we change to repr(C) for these fields so we know they layout remains constant. Having recast and instance an an array with a header that includes a class pointer has a couple large benifits

* We save 8 bytes per instance. Because the data is inline we no longer have a pointer. The `.len` field moves from the boxed slice onto the instance.
* Remove 2nd call to malloc for boxed slice. Remove extra drop when cleaned up
* Data is located next to each other this is likely good for cpu cache.

