### PR TITLE
User Space Module Loading MVP

### DIFF
--- a/laythe_core/src/managed/gc_str.rs
+++ b/laythe_core/src/managed/gc_str.rs
@@ -231,7 +231,8 @@ impl AsRef<str> for GcStr {
 
 impl AsRef<OsStr> for GcStr {
   fn as_ref(&self) -> &OsStr {
-    OsStr::new(self)
+    let str: &str = self;
+    OsStr::new(str)
   }
 }
 

--- a/laythe_core/src/module/error.rs
+++ b/laythe_core/src/module/error.rs
@@ -6,6 +6,7 @@ pub enum ImportError {
   ModuleDoesNotExist,
   SymbolDoesNotExist,
   SymbolNotExported,
+  MalformedPath,
   InvalidImport,
 }
 
@@ -16,6 +17,7 @@ impl Display for ImportError {
       Self::ModuleDoesNotExist => write!(f, "Module does not exist."),
       Self::SymbolDoesNotExist => write!(f, "Symbol does not exist."),
       Self::SymbolNotExported => write!(f, "Symbol not exported."),
+      Self::MalformedPath => write!(f, "Malformed path."),
       Self::InvalidImport => write!(f, "Invalid import."),
     }
   }

--- a/laythe_core/src/module/import.rs
+++ b/laythe_core/src/module/import.rs
@@ -3,6 +3,7 @@ use crate::{
   hooks::GcHooks,
   managed::{AllocResult, Allocate, Array, DebugHeap, DebugWrap, Gc, GcStr, Trace},
 };
+use std::fmt;
 
 /// An object representing an import request from a file
 pub struct Import {
@@ -65,6 +66,22 @@ impl Trace for Import {
 impl Allocate<Gc<Self>> for Import {
   fn alloc(self) -> AllocResult<Gc<Self>> {
     Gc::alloc_result(self)
+  }
+}
+
+impl fmt::Display for Import {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    if self.path.is_empty() {
+      write!(f, "{}", self.package)
+    } else {
+      write!(f, "{}", self.package)?;
+
+      for segement in &*self.path {
+        write!(f, ".{}", segement)?;
+      }
+
+      Ok(())
+    }
   }
 }
 

--- a/laythe_core/src/module/mod.rs
+++ b/laythe_core/src/module/mod.rs
@@ -111,10 +111,12 @@ impl Module {
     }
   }
 
+  /// Retrieve a module for the given that if it exists
   pub fn get_module(&self, name: GcStr) -> Option<Gc<Module>> {
     self.modules.get(&name).copied()
   }
 
+  /// Attempt to import a module from the provided path
   pub fn import(&self, hooks: &GcHooks, path: &[GcStr]) -> ImportResult<Gc<Module>> {
     if path.is_empty() {
       Err(ImportError::MalformedPath)

--- a/laythe_core/src/module/mod.rs
+++ b/laythe_core/src/module/mod.rs
@@ -112,10 +112,7 @@ impl Module {
   }
 
   pub fn get_module(&self, name: GcStr) -> Option<Gc<Module>> {
-    match self.modules.get(&name) {
-      Some(module) => Some(*module),
-      None => None,
-    }
+    self.modules.get(&name).copied()
   }
 
   pub fn import(&self, hooks: &GcHooks, path: &[GcStr]) -> ImportResult<Gc<Module>> {

--- a/laythe_core/src/module/package.rs
+++ b/laythe_core/src/module/package.rs
@@ -31,6 +31,7 @@ impl Package {
     self.root_module
   }
 
+  /// Attempt to import a module from the provided import object
   pub fn import(&self, hooks: &GcHooks, import: Gc<Import>) -> ImportResult<Gc<Module>> {
     if import.package() == self.name {
       let path = import.path();

--- a/laythe_core/src/module/package.rs
+++ b/laythe_core/src/module/package.rs
@@ -31,9 +31,14 @@ impl Package {
     self.root_module
   }
 
-  pub fn import(&self, hooks: &GcHooks, import: Gc<Import>) -> ImportResult<&Module> {
+  pub fn import(&self, hooks: &GcHooks, import: Gc<Import>) -> ImportResult<Gc<Module>> {
     if import.package() == self.name {
-      self.root_module.import(hooks, import.path())
+      let path = import.path();
+      if path.is_empty() {
+        Ok(self.root_module)
+      } else {
+        self.root_module.import(hooks, import.path())
+      }
     } else {
       Err(ImportError::PackageDoesNotMatch)
     }

--- a/laythe_core/src/object/fiber.rs
+++ b/laythe_core/src/object/fiber.rs
@@ -185,6 +185,7 @@ impl Fiber {
     assert_eq!(fiber.state, FiberState::Running);
     fiber.state = FiberState::Complete;
 
+    // load from waiting fiber biases toward the parent fiber
     let waiter = fiber
       .parent
       .filter(|parent| parent.is_pending())
@@ -611,6 +612,7 @@ impl Fiber {
   }
 }
 
+/// Assert the provided pointer is inbounds this slice
 #[cfg(debug_assertions)]
 fn assert_inbounds<T>(slice: &[T], ptr: *mut T) {
   unsafe {

--- a/laythe_core/src/object/fiber.rs
+++ b/laythe_core/src/object/fiber.rs
@@ -6,7 +6,7 @@ use crate::{
   captures::Captures,
   constants::SCRIPT,
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, GcObj, Object, Trace, Instance},
+  managed::{DebugHeap, DebugWrap, GcObj, Instance, Object, Trace},
   val,
   value::{Value, VALUE_NIL},
 };
@@ -45,6 +45,9 @@ pub struct Fiber {
   /// A list of channels executed on this fiber
   channels: Vec<GcObj<Channel>>,
 
+  /// The parent fiber to this fiber
+  parent: Option<GcObj<Fiber>>,
+
   /// pointer to the top of the value stack
   stack_top: *mut Value,
 
@@ -62,20 +65,22 @@ impl Fiber {
   /// Create a new fiber from the provided closure. The fiber uses
   /// this initial closure to determine how much stack space to initially
   /// reserve
-  pub fn new(fun: GcObj<Fun>, captures: Captures) -> FiberResult<Self> {
-    Fiber::new_inner(fun, captures, fun.max_slots() + 1)
-  }
-
-  /// Create a new from the provided closure, used by split_fiber to use
-  /// the top call frame to initialize a new fiber. This reserves stack space
-  /// for the initial frame slots and arguments.
-  fn split(fun: GcObj<Fun>, captures: Captures, arg_count: usize) -> FiberResult<Self> {
-    Fiber::new_inner(fun, captures, fun.max_slots() + arg_count + 1)
+  pub fn new(
+    parent: Option<GcObj<Fiber>>,
+    fun: GcObj<Fun>,
+    captures: Captures,
+  ) -> FiberResult<Self> {
+    Fiber::new_inner(parent, fun, captures, fun.max_slots() + 1)
   }
 
   /// Inner initialization function that actually reserver and create
   /// each structure
-  fn new_inner(fun: GcObj<Fun>, captures: Captures, stack_count: usize) -> FiberResult<Self> {
+  fn new_inner(
+    parent: Option<GcObj<Fiber>>,
+    fun: GcObj<Fun>,
+    captures: Captures,
+    stack_count: usize,
+  ) -> FiberResult<Self> {
     // reserve resources
     let mut frames = Vec::<CallFrame>::with_capacity(INITIAL_FRAME_SIZE);
     let mut stack = vec![VALUE_NIL; stack_count];
@@ -96,6 +101,7 @@ impl Fiber {
     Ok(Self {
       stack,
       frames,
+      parent,
       channels: vec![],
       state: FiberState::Pending,
       error: None,
@@ -128,9 +134,16 @@ impl Fiber {
     self.frame().captures()
   }
 
+  /// Is this fiber complete
   #[inline]
   pub fn is_complete(&self) -> bool {
     self.state == FiberState::Complete
+  }
+
+  /// Is this fiber pending
+  #[inline]
+  pub fn is_pending(&self) -> bool {
+    self.state == FiberState::Pending
   }
 
   /// Activate the current fiber
@@ -172,7 +185,10 @@ impl Fiber {
     assert_eq!(fiber.state, FiberState::Running);
     fiber.state = FiberState::Complete;
 
-    let waiter = fiber.get_runnable();
+    let waiter = fiber
+      .parent
+      .filter(|parent| parent.is_pending())
+      .or_else(|| fiber.get_runnable());
 
     let channels = mem::take(&mut fiber.channels);
     for mut channel in channels {
@@ -382,31 +398,32 @@ impl Fiber {
   }
 
   /// Attempt to create a new fiber using the most recent call frame
-  pub fn split_fiber(
-    &mut self,
+  pub fn split(
+    mut fiber: GcObj<Fiber>,
     hooks: &GcHooks,
     frame_count: usize,
     arg_count: usize,
   ) -> Option<GcObj<Fiber>> {
-    if self.frames().len() != frame_count + 1 {
+    if fiber.frames().len() != frame_count + 1 {
       return None;
     }
 
-    let frame = self.frames.pop().expect("Expected call frame");
+    let frame = fiber.frames.pop().expect("Expected call frame");
     hooks.push_root(frame.fun());
     let mut fiber = hooks.manage_obj(
-      Fiber::split(frame.fun(), frame.captures(), arg_count).expect("Assumed valid closure"),
+      Fiber::new_inner(Some(fiber), frame.fun(), frame.captures(), arg_count + 1)
+        .expect("Assumed valid closure"),
     );
     hooks.pop_roots(1);
 
-    let slots = self.frame_stack().len();
+    let slots = fiber.frame_stack().len();
     assert_eq!(slots, arg_count + 1);
 
     // if we have any argument bulk copy them to the fiber
     if slots > 1 {
       unsafe {
         ptr::copy_nonoverlapping(
-          self.frame().stack_start().offset(1),
+          fiber.frame().stack_start().offset(1),
           fiber.stack_top,
           arg_count,
         );
@@ -417,8 +434,8 @@ impl Fiber {
     // Effectively pop the current fibers frame so they're 'moved'
     // to the new fiber
     unsafe {
-      self.stack_top = self.frame().stack_start();
-      self.frame = self.frame.sub(1);
+      fiber.stack_top = fiber.frame().stack_start();
+      fiber.frame = fiber.frame.sub(1);
     }
 
     Some(fiber)
@@ -685,7 +702,9 @@ mod test {
   use super::*;
   use crate::{
     hooks::{GcHooks, NoContext},
-    support::{test_fun, test_fun_builder, FiberBuilder},
+    object::FunBuilder,
+    signature::Arity,
+    support::{test_fun, test_fun_builder, test_module, FiberBuilder},
   };
 
   #[test]
@@ -936,6 +955,114 @@ mod test {
     unsafe {
       fiber.peek_set(1, val!(true));
     }
+  }
+
+  #[test]
+  fn is_complete() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .build(&hooks)
+      .expect("Expected to build");
+
+    assert_eq!(fiber.is_complete(), false);
+
+    fiber.activate();
+    Fiber::complete(fiber);
+
+    assert_eq!(fiber.is_complete(), true);
+  }
+
+  #[test]
+  fn is_pending() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .build(&hooks)
+      .expect("Expected to build");
+
+    assert_eq!(fiber.is_pending(), true);
+
+    fiber.activate();
+
+    assert_eq!(fiber.is_pending(), false);
+
+    fiber.sleep();
+
+    assert_eq!(fiber.is_pending(), true);
+  }
+
+  #[test]
+  fn complete_without_parent_or_channels() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .build(&hooks)
+      .expect("Expected to build");
+
+    fiber.activate();
+
+    assert_eq!(Fiber::complete(fiber), None)
+  }
+
+  #[test]
+  fn split() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let module = test_module(&hooks, "test module");
+
+    let mut builder = FunBuilder::new(hooks.manage_str("test"), module, Arity::default());
+    builder.write_instruction(0, 0);
+    builder.write_instruction(0, 0);
+    builder.write_instruction(0, 0);
+
+    let fun = hooks.manage_obj(builder.build(&hooks));
+    let captures = Captures::new(&hooks, &[]);
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .max_slots(3)
+      .build(&hooks)
+      .expect("Expected to build");
+
+    fiber.activate();
+
+    unsafe {
+      fiber.push(val!(fun));
+      fiber.push(val!(10.0));
+      fiber.push(val!(true));
+    }
+
+    fiber.push_frame(fun, captures, 2);
+
+    let mut child = Fiber::split(fiber, &hooks, 1, 0).expect("Expected split");
+
+    fiber.sleep();
+    child.activate();
+
+    assert_eq!(Fiber::complete(child), Some(fiber))
+  }
+
+  #[test]
+  fn complete_with_parent_but_no_channels() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let parent = FiberBuilder::<u8>::default()
+      .build(&hooks)
+      .expect("Expected to build");
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .parent(parent)
+      .build(&hooks)
+      .expect("Expected to build");
+
+    fiber.activate();
+
+    assert_eq!(Fiber::complete(fiber), Some(parent))
   }
 
   #[test]

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -785,7 +785,7 @@ mod boxed {
       assert_eq!(mem::size_of::<Map<Value, Value>>(), 32);
       assert_eq!(mem::size_of::<Closure>(), 16);
       assert_eq!(mem::size_of::<Fun>(), 64);
-      assert_eq!(mem::size_of::<Fiber>(), 104);
+      assert_eq!(mem::size_of::<Fiber>(), 112);
       assert_eq!(mem::size_of::<Class>(), 104);
       assert_eq!(mem::size_of::<Method>(), 16);
       assert_eq!(mem::size_of::<Enumerator>(), 24);

--- a/laythe_env/src/env.rs
+++ b/laythe_env/src/env.rs
@@ -56,3 +56,45 @@ impl EnvImpl for EnvMock {
     vec![]
   }
 }
+
+#[derive(Debug)]
+pub struct IoEnvTest {
+  current_dir: PathBuf,
+  args: Vec<String>,
+}
+
+impl IoEnvTest {
+  pub fn new(current_dir: PathBuf, args: Vec<String>) -> Self {
+    Self { current_dir, args }
+  }
+}
+
+impl IoImpl<Env> for IoEnvTest {
+  fn make(&self) -> Env {
+    Env::new(Box::new(EnvTest::new(
+      self.current_dir.clone(),
+      self.args.clone(),
+    )))
+  }
+}
+
+pub struct EnvTest {
+  current_dir: PathBuf,
+  args: Vec<String>,
+}
+
+impl EnvTest {
+  fn new(current_dir: PathBuf, args: Vec<String>) -> Self {
+    Self { current_dir, args }
+  }
+}
+
+impl EnvImpl for EnvTest {
+  fn current_dir(&self) -> io::Result<PathBuf> {
+    Ok(self.current_dir.clone())
+  }
+
+  fn args(&self) -> Vec<String> {
+    self.args.clone()
+  }
+}

--- a/laythe_env/src/fs.rs
+++ b/laythe_env/src/fs.rs
@@ -1,7 +1,7 @@
 use crate::io::IoImpl;
 use std::{
   io,
-  path::{Path, PathBuf},
+  path::{Path, PathBuf}, ffi::OsString, fs::FileType,
 };
 
 /// A wrapper around file system facilities provided to Laythe
@@ -24,8 +24,8 @@ impl Fs {
   }
 
   /// Read a file into String
-  pub fn read_to_string(&self, path: &Path) -> io::Result<String> {
-    self.fs.read_to_string(path)
+  pub fn read_file(&self, path: &Path) -> io::Result<String> {
+    self.fs.read_file(path)
   }
 
   /// Read a directory for files and sub directories
@@ -46,10 +46,12 @@ impl Fs {
 
 pub trait LyDirEntry {
   fn path(&self) -> PathBuf;
+  fn file_name(&self) -> OsString;
+  fn file_type(&self) -> io::Result<FileType>;
 }
 
 pub trait FsImpl: Send + Sync {
-  fn read_to_string(&self, path: &Path) -> io::Result<String>;
+  fn read_file(&self, path: &Path) -> io::Result<String>;
   fn read_directory(&self, path: &Path) -> io::Result<Vec<Box<dyn LyDirEntry>>>;
   fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;
   fn relative_path(&self, base: &Path, import: &Path) -> io::Result<PathBuf>;
@@ -67,7 +69,7 @@ impl IoImpl<Fs> for IoFsMock {
 pub struct FsMock();
 
 impl FsImpl for FsMock {
-  fn read_to_string(&self, _path: &Path) -> io::Result<String> {
+  fn read_file(&self, _path: &Path) -> io::Result<String> {
     Ok("let x = 10;".to_string())
   }
   fn read_directory(&self, _path: &Path) -> io::Result<Vec<Box<dyn LyDirEntry>>> {

--- a/laythe_lib/src/global/primitives/mod.rs
+++ b/laythe_lib/src/global/primitives/mod.rs
@@ -59,7 +59,10 @@ fn error_inheritance(
 ) -> StdResult<GcObj<Class>> {
   let name = hooks.manage_str(class_name);
   let error_name = hooks.manage_str(ERROR_CLASS_NAME);
-  let error_class = module.get_exported_symbol(error_name)?;
+  let error_class = match module.get_exported_symbol(error_name) {
+    Some(class) => class,
+    None => return Err(StdError::SymbolNotFound),
+  };
 
   if_let_obj!(ObjectKind::Class(class) = (error_class) {
     Ok(Class::with_inheritance(
@@ -79,7 +82,10 @@ fn class_inheritance(
 ) -> StdResult<GcObj<Class>> {
   let name = hooks.manage_str(class_name);
   let object_name = hooks.manage_str(OBJECT_CLASS_NAME);
-  let object_class = module.get_exported_symbol(object_name)?;
+  let object_class = match module.get_exported_symbol(object_name) {
+    Some(class) => class,
+    None => return Err(StdError::SymbolNotFound),
+  };
 
   if_let_obj!(ObjectKind::Class(class) = (object_class) {
     Ok(Class::with_inheritance(

--- a/laythe_lib/src/io/fs/file.rs
+++ b/laythe_lib/src/io/fs/file.rs
@@ -55,7 +55,7 @@ impl LyNative for FileReadAllText {
     let io = hooks.as_io();
     let path = args[0].to_obj().to_str();
 
-    match io.fs().read_to_string(Path::new(&*path)) {
+    match io.fs().read_file(Path::new(&*path)) {
       Ok(result) => Call::Ok(val!(hooks.manage_str(result))),
       Err(err) => self.call_error(hooks, err.to_string()),
     }

--- a/laythe_lib/src/lib.rs
+++ b/laythe_lib/src/lib.rs
@@ -13,7 +13,7 @@ use io::add_io_package;
 use laythe_core::{
   hooks::GcHooks,
   managed::Gc,
-  module::{ImportError, ModuleInsertError, Package, SymbolInsertError, SymbolExportError},
+  module::{ImportError, ModuleInsertError, Package, SymbolExportError, SymbolInsertError},
   utils::IdEmitter,
 };
 use math::add_math_module;
@@ -116,6 +116,7 @@ pub enum StdError {
   ModuleInsertError(ModuleInsertError),
   SymbolInsertError(SymbolInsertError),
   SymbolExportError(SymbolExportError),
+  SymbolNotFound,
   SymbolNotClass,
   SymbolNotInstance,
 }

--- a/laythe_native/src/fs.rs
+++ b/laythe_native/src/fs.rs
@@ -3,6 +3,7 @@ use laythe_env::{
   io::IoImpl,
 };
 use std::{
+  ffi::OsString,
   fs::{canonicalize, read_dir, read_to_string, DirEntry},
   io,
   path::{Path, PathBuf},
@@ -21,7 +22,7 @@ impl IoImpl<Fs> for IoFsNative {
 pub struct FsNative();
 
 impl FsImpl for FsNative {
-  fn read_to_string(&self, path: &Path) -> io::Result<String> {
+  fn read_file(&self, path: &Path) -> io::Result<String> {
     read_to_string(path)
   }
 
@@ -51,5 +52,13 @@ struct NativeDirEntry(DirEntry);
 impl LyDirEntry for NativeDirEntry {
   fn path(&self) -> PathBuf {
     self.0.path()
+  }
+
+  fn file_name(&self) -> OsString {
+    self.0.file_name()
+  }
+
+  fn file_type(&self) -> io::Result<std::fs::FileType> {
+    self.0.file_type()
   }
 }

--- a/laythe_vm/fixture/language/import/import_in_class.lay
+++ b/laythe_vm/fixture/language/import/import_in_class.lay
@@ -1,0 +1,7 @@
+class A {
+  foo() {
+    import std.math;
+  }
+}
+
+A().foo()

--- a/laythe_vm/fixture/language/import/import_in_fun.lay
+++ b/laythe_vm/fixture/language/import/import_in_fun.lay
@@ -1,0 +1,5 @@
+fn importer() {
+  import std.math:{abs};
+}
+
+importer()

--- a/laythe_vm/fixture/language/import/import_in_scope.lay
+++ b/laythe_vm/fixture/language/import/import_in_scope.lay
@@ -1,0 +1,3 @@
+if true {
+  import std.math:{abs};
+}

--- a/laythe_vm/fixture/language/import/module.lay
+++ b/laythe_vm/fixture/language/import/module.lay
@@ -1,0 +1,5 @@
+import std.math;
+
+assertEq(math.abs(-5), 5);
+assertEq(math.max(1, 3, 2), 3);
+assertEq(math.min(3, 1, 2), 1);

--- a/laythe_vm/fixture/language/import/module_rename.lay
+++ b/laythe_vm/fixture/language/import/module_rename.lay
@@ -1,0 +1,5 @@
+import std.math as mathematics;
+
+assertEq(mathematics.abs(-5), 5);
+assertEq(mathematics.max(1, 3, 2), 3);
+assertEq(mathematics.min(3, 1, 2), 1);

--- a/laythe_vm/fixture/language/import/symbol.lay
+++ b/laythe_vm/fixture/language/import/symbol.lay
@@ -1,0 +1,5 @@
+import std.math:{abs, max, min};
+
+assertEq(abs(-5), 5);
+assertEq(max(1, 3, 2), 3);
+assertEq(min(3, 1, 2), 1);

--- a/laythe_vm/fixture/language/import/symbol_rename.lay
+++ b/laythe_vm/fixture/language/import/symbol_rename.lay
@@ -1,0 +1,5 @@
+import std.math:{abs as absolute, max as maximum, min as minimum};
+
+assertEq(absolute(-5), 5);
+assertEq(maximum(1, 3, 2), 3);
+assertEq(minimum(3, 1, 2), 1);

--- a/laythe_vm/fixture/language/import/user_import/cycle_1.lay
+++ b/laythe_vm/fixture/language/import/user_import/cycle_1.lay
@@ -1,0 +1,5 @@
+import self.cycle_2:{x};
+
+assertEq(x, nil);
+
+export let z = 10;

--- a/laythe_vm/fixture/language/import/user_import/cycle_2.lay
+++ b/laythe_vm/fixture/language/import/user_import/cycle_2.lay
@@ -1,0 +1,3 @@
+import self.cycle_3:{y};
+
+export let x = y;

--- a/laythe_vm/fixture/language/import/user_import/cycle_3.lay
+++ b/laythe_vm/fixture/language/import/user_import/cycle_3.lay
@@ -1,0 +1,3 @@
+import self.cycle_1:{z};
+
+export let y = z;

--- a/laythe_vm/fixture/language/import/user_import/lib.lay
+++ b/laythe_vm/fixture/language/import/user_import/lib.lay
@@ -1,0 +1,5 @@
+export let x = 10;
+export fn y() { 10 }
+export class Z {
+  ans() { 10 }
+}

--- a/laythe_vm/fixture/language/import/user_import/module.lay
+++ b/laythe_vm/fixture/language/import/user_import/module.lay
@@ -1,0 +1,5 @@
+import self.lib;
+
+assertEq(lib.x, 10);
+assertEq(lib.y(), 10);
+assertEq(lib.Z().ans(), 10);

--- a/laythe_vm/fixture/language/import/user_import/symbol.lay
+++ b/laythe_vm/fixture/language/import/user_import/symbol.lay
@@ -1,0 +1,5 @@
+import self.lib:{x, y, Z};
+
+assertEq(x, 10);
+assertEq(y(), 10);
+assertEq(Z().ans(), 10);

--- a/laythe_vm/src/byte_code.rs
+++ b/laythe_vm/src/byte_code.rs
@@ -374,7 +374,7 @@ impl AlignedByteCode {
   }
 
   /// What effect will this instruction have on the stack
-  pub fn stack_effect(&self) -> i32 {
+  pub const fn stack_effect(&self) -> i32 {
     match self {
       AlignedByteCode::Return => 0,
       AlignedByteCode::Negate => 0,

--- a/laythe_vm/src/compiler/mod.rs
+++ b/laythe_vm/src/compiler/mod.rs
@@ -1268,7 +1268,7 @@ impl<'a, 'src: 'a, FileId: Copy> Compiler<'a, 'src, FileId> {
       },
       ast::ImportStem::Symbols(symbols) => {
         for symbol in symbols {
-          let (symbol_slot, _) = self.make_identifier(&symbol.symbol, import.start());
+          let symbol_slot = self.identifier_constant(symbol.symbol.str());
           self.emit_byte(
             AlignedByteCode::ImportSymbol((path, symbol_slot)),
             symbol.start(),
@@ -1276,7 +1276,7 @@ impl<'a, 'src: 'a, FileId: Copy> Compiler<'a, 'src, FileId> {
 
           let name = match &symbol.rename {
             Some(rename) => self.make_identifier(rename, import.start()).0,
-            None => symbol_slot,
+            None => self.make_identifier(&symbol.symbol, import.start()).0,
           };
 
           self.emit_byte(AlignedByteCode::DefineGlobal(name), import.end());

--- a/laythe_vm/src/compiler/resolver.rs
+++ b/laythe_vm/src/compiler/resolver.rs
@@ -278,7 +278,7 @@ impl<'a, 'src, FileId: Copy> Resolver<'a, 'src, FileId> {
         .gc
         .has_str(name.str())
         .ok_or(ImportError::SymbolDoesNotExist)
-        .and_then(|interned_name| self.global_module.get_exported_symbol(interned_name))
+        .and_then(|interned_name| self.global_module.get_exported_symbol(interned_name).ok_or(ImportError::SymbolDoesNotExist))
         .is_ok()
       {
         let table = &mut self.tables.first_mut().unwrap();

--- a/laythe_vm/src/debug.rs
+++ b/laythe_vm/src/debug.rs
@@ -27,19 +27,19 @@ pub fn disassemble_chunk(stdio: &mut Stdio, chunk: &Chunk, name: &str) -> io::Re
 pub fn disassemble_instruction(
   stdio: &mut Stdio,
   chunk: &Chunk,
-  ip: usize,
+  offset: usize,
   show_line: bool,
 ) -> io::Result<usize> {
   let stdout = stdio.stdout();
-  write!(stdout, "  {:0>4} ", ip)?;
+  write!(stdout, "  {:0>4} ", offset)?;
 
-  if ip != 0 && show_line {
+  if offset != 0 && show_line {
     write!(stdout, "   | ")?;
   } else {
-    write!(stdout, "{:>4} ", chunk.get_line(ip))?;
+    write!(stdout, "{:>4} ", chunk.get_line(offset))?;
   }
 
-  let (instruction, offset) = AlignedByteCode::decode(chunk.instructions(), ip as usize);
+  let (instruction, offset) = AlignedByteCode::decode(chunk.instructions(), offset as usize);
   match instruction {
     AlignedByteCode::Return => simple_instruction(stdio.stdout(), "Return", offset),
     AlignedByteCode::Negate => simple_instruction(stdio.stdout(), "Negate", offset),

--- a/laythe_vm/src/vm/mod.rs
+++ b/laythe_vm/src/vm/mod.rs
@@ -154,7 +154,7 @@ impl Vm {
     let current_fun = hooks.manage_obj(current_fun);
     let capture_stub = Captures::new(&hooks, &[]);
     let fiber = hooks.manage_obj(
-      Fiber::new(current_fun, capture_stub).expect("Unable to generate placeholder fiber"),
+      Fiber::new(None, current_fun, capture_stub).expect("Unable to generate placeholder fiber"),
     );
 
     let builtin = builtin_from_module(&hooks, &global)
@@ -298,7 +298,7 @@ impl Vm {
 
   /// Reset the vm to execute another script
   fn prepare(&mut self, script: GcObj<Fun>) {
-    let fiber = match Fiber::new(script, self.capture_stub) {
+    let fiber = match Fiber::new(None, script, self.capture_stub) {
       Ok(fiber) => fiber,
       Err(_) => self.internal_error("Unable to generate initial fiber"),
     };

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -3,7 +3,7 @@ use crate::{
   byte_code::{AlignedByteCode, CaptureIndex},
   constants::MAX_FRAME_SIZE,
 };
-use laythe_core::hooks::GcContext;
+use laythe_core::{hooks::GcContext, module::ImportError};
 use laythe_core::managed::GcObject;
 use laythe_core::{
   captures::Captures,
@@ -761,8 +761,11 @@ impl Vm {
       Some(package) => {
         match package
           .import(&GcHooks::new(self), import)
-          .and_then(|module| module.get_exported_symbol(name))
-        {
+          .and_then(|module| {
+            module
+              .get_exported_symbol(name)
+              .ok_or(ImportError::SymbolNotExported)
+          }) {
           Ok(symbol) => {
             self.fiber.push(val!(symbol));
             Signal::Ok

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -1,10 +1,9 @@
-use super::{Signal, Vm};
+use super::{source_loader::ImportResult, Signal, Vm};
 use crate::{
   byte_code::{AlignedByteCode, CaptureIndex},
   constants::MAX_FRAME_SIZE,
 };
-use laythe_core::{hooks::GcContext, module::ImportError};
-use laythe_core::managed::GcObject;
+use laythe_core::hooks::GcContext;
 use laythe_core::{
   captures::Captures,
   hooks::{GcHooks, Hooks},
@@ -23,6 +22,7 @@ use laythe_core::{
   value::{Value, VALUE_NIL, VALUE_TRUE},
   Call, LyError,
 };
+use laythe_core::{managed::GcObject, object::Fiber};
 use std::{cmp::Ordering, mem};
 
 impl Vm {
@@ -709,26 +709,40 @@ impl Vm {
     if let Some(module) = self.module_cache.get(&resolved) {
       let imported = module.module_instance(&GcHooks::new(self));
       self.fiber.push(val!(imported));
-      self.pop_roots(2);
+      self.pop_roots(1);
       return Signal::Ok;
     }
 
     let import = self.build_import(&path_segments);
     self.push_root(import);
 
-    let result = match self.packages.get(&import.package()) {
-      Some(package) => match package.import(&GcHooks::new(self), import) {
-        Ok(module) => {
-          let module = val!(module.module_instance(&GcHooks::new(self)));
-          self.fiber.push(module);
-          Signal::Ok
-        },
-        Err(err) => self.runtime_error(self.builtin.errors.runtime, &err.to_string()),
+    let result = match self.import_module(import) {
+      ImportResult::Loaded(module) => {
+        self.module_cache.insert(resolved, module);
+        let module_instance = val!(module.module_instance(&GcHooks::new(self)));
+
+        self.fiber.push(module_instance);
+        Signal::Ok
       },
-      None => self.runtime_error(
+      ImportResult::Compiled(fun) => {
+        self.update_ip(-3);
+        self.fiber.sleep();
+
+        let import_fiber = match Fiber::new(fun, self.capture_stub) {
+          Ok(fiber) => fiber,
+          Err(_) => self.internal_error("Importing fiber"),
+        };
+        let import_fiber = self.manage_obj(import_fiber);
+
+        self.fiber_queue.push_back(import_fiber);
+        self.fiber_queue.push_back(self.fiber);
+        Signal::ContextSwitch
+      },
+      ImportResult::NotFound => self.runtime_error(
         self.builtin.errors.import,
-        &format!("Package {} does not exist", &import.package()),
+        &format!("Module {} not found", &import),
       ),
+      ImportResult::CompileError => Signal::Exit,
     };
 
     self.pop_roots(2);
@@ -739,7 +753,7 @@ impl Vm {
     let index_path = self.read_short();
     let index_name = self.read_short();
     let path = self.read_constant(index_path).to_obj().to_list();
-    let name = self.read_string(index_name);
+    let symbol_name = self.read_string(index_name);
 
     let path_segments = self.extract_import_path(path);
 
@@ -750,33 +764,50 @@ impl Vm {
     if let Some(module) = self.module_cache.get(&resolved) {
       let imported = module.module_instance(&GcHooks::new(self));
       self.fiber.push(val!(imported));
-      self.pop_roots(2);
+      self.pop_roots(1);
       return Signal::Ok;
     }
 
     let import = self.build_import(&path_segments);
     self.push_root(import);
 
-    let result = match self.packages.get(&import.package()) {
-      Some(package) => {
-        match package
-          .import(&GcHooks::new(self), import)
-          .and_then(|module| {
-            module
-              .get_exported_symbol(name)
-              .ok_or(ImportError::SymbolNotExported)
-          }) {
-          Ok(symbol) => {
-            self.fiber.push(val!(symbol));
+    let result = match self.import_module(import) {
+      ImportResult::Loaded(module) => {
+        self.module_cache.insert(resolved, module);
+
+        match module.get_exported_symbol(symbol_name) {
+          Some(symbol) => {
+            self.fiber.push(symbol);
             Signal::Ok
           },
-          Err(err) => self.runtime_error(self.builtin.errors.runtime, &err.to_string()),
+          None => self.runtime_error(
+            self.builtin.errors.import,
+            &format!(
+              "Symbol {} not exported from module {}",
+              symbol_name, &import
+            ),
+          ),
         }
       },
-      None => self.runtime_error(
+      ImportResult::Compiled(fun) => {
+        self.update_ip(-5);
+        self.fiber.sleep();
+
+        let import_fiber = match Fiber::new(fun, self.capture_stub) {
+          Ok(fiber) => fiber,
+          Err(_) => self.internal_error("Importing fiber"),
+        };
+        let import_fiber = self.manage_obj(import_fiber);
+
+        self.fiber_queue.push_back(import_fiber);
+        self.fiber_queue.push_back(self.fiber);
+        Signal::ContextSwitch
+      },
+      ImportResult::NotFound => self.runtime_error(
         self.builtin.errors.import,
-        &format!("Package {} does not exist", &import.package()),
+        &format!("Module {} not found", &import),
       ),
+      ImportResult::CompileError => Signal::Exit,
     };
 
     self.pop_roots(2);

--- a/laythe_vm/src/vm/source_loader.rs
+++ b/laythe_vm/src/vm/source_loader.rs
@@ -194,7 +194,7 @@ mod test {
 
       let root_module = test_module(&hooks, "root");
 
-      let (found_module, beginning, end) = find_missing_module(root_module, &[], 0);
+      let (found_module, (beginning, end)) = find_missing_module(root_module, &[], 0);
 
       assert_eq!(found_module, root_module);
 
@@ -210,7 +210,7 @@ mod test {
       let root_module = test_module(&hooks, "root");
       let path = &[hooks.manage_str("first"), hooks.manage_str("second")];
 
-      let (found_module, beginning, end) = find_missing_module(root_module, path, 0);
+      let (found_module, (beginning, end)) = find_missing_module(root_module, path, 0);
 
       assert_eq!(found_module, root_module);
 
@@ -234,7 +234,7 @@ mod test {
 
       let path = &[hooks.manage_str("first"), hooks.manage_str("second")];
 
-      let (found_module, beginning, end) = find_missing_module(root_module, path, 0);
+      let (found_module, (beginning, end)) = find_missing_module(root_module, path, 0);
 
       assert_eq!(found_module, nested_module);
 

--- a/laythe_vm/src/vm/source_loader.rs
+++ b/laythe_vm/src/vm/source_loader.rs
@@ -160,11 +160,11 @@ impl Vm {
   }
 }
 
-fn find_missing_module<'a>(
+fn find_missing_module(
   module: Gc<Module>,
-  path: &'a [GcStr],
+  path: &[GcStr],
   index: usize,
-) -> (Gc<Module>, (&'a [GcStr], &'a [GcStr])) {
+) -> (Gc<Module>, (&[GcStr], &[GcStr])) {
   if path.is_empty() {
     return (module, (&[], &[]));
   }

--- a/laythe_vm/src/vm/source_loader.rs
+++ b/laythe_vm/src/vm/source_loader.rs
@@ -15,10 +15,18 @@ use laythe_core::{
 };
 use std::path::PathBuf;
 
+/// What was the outcome of the attempted import
 pub enum ImportResult {
+  /// The file was already loaded and the module is available
   Loaded(Gc<Module>),
+
+  /// The file was found be not yet executed
   Compiled(GcObj<Fun>),
+
+  /// The file was not present
   NotFound,
+
+  /// The file was present but contained compiler errors
   CompileError,
 }
 
@@ -87,6 +95,9 @@ impl Vm {
     module
   }
 
+  /// Import a module into the current fiber. If the
+  /// module already exists return that module otherwise attempt
+  /// to load the missing module from the file system.
   pub(super) fn import_module(&mut self, import: Gc<Import>) -> ImportResult {
     let package = self.packages.get(&import.package()).cloned();
 
@@ -103,6 +114,10 @@ impl Vm {
     }
   }
 
+  /// Attempt to load a missing module from the filesystem into Laythe.
+  /// This can error from a missing file or from the file
+  /// failing to compile. If successful attach the new module
+  /// onto it's parent
   fn load_missing_module(
     &mut self,
     existing_package: Gc<Package>,

--- a/laythe_vm/src/vm/source_loader.rs
+++ b/laythe_vm/src/vm/source_loader.rs
@@ -1,0 +1,250 @@
+use super::{Vm, VmFileId};
+use crate::{
+  cache::InlineCache,
+  compiler::{Compiler, Parser, Resolver},
+  source::Source,
+  FeResult,
+};
+use codespan_reporting::term::{Config, self};
+use laythe_core::{
+  hooks::GcHooks,
+  managed::{Gc, GcObj, GcStr},
+  memory::Allocator,
+  module::{Import, ImportError, Module, Package},
+  object::{Class, Fun},
+};
+use std::path::PathBuf;
+
+pub enum ImportResult {
+  Loaded(Gc<Module>),
+  Compiled(GcObj<Fun>),
+  LoadError,
+  NotFound,
+  CompileError,
+}
+
+impl Vm {
+  /// Compile the provided laythe source into the virtual machine's bytecode
+  pub(super) fn compile(
+    &mut self,
+    repl: bool,
+    module: Gc<Module>,
+    source: &Source,
+    file_id: VmFileId,
+  ) -> FeResult<GcObj<Fun>, VmFileId> {
+    let (ast, line_offsets) = Parser::new(source, file_id).parse();
+    self
+      .files
+      .update_line_offsets(file_id, line_offsets.clone())
+      .expect("File id not set for line offsets");
+
+    let mut ast = ast?;
+    Resolver::new(self.global, &self.gc.borrow(), source, file_id, repl).resolve(&mut ast)?;
+
+    let gc = self.gc.replace(Allocator::default());
+    let compiler = Compiler::new(module, &line_offsets, file_id, repl, self, gc);
+
+    #[cfg(feature = "debug")]
+    let compiler = compiler.with_io(self.io.clone());
+
+    let (result, gc, cache_id_emitter) = compiler.compile(&ast);
+    self.gc.replace(gc);
+
+    result.map(|fun| {
+      let cache = InlineCache::new(
+        cache_id_emitter.property_count(),
+        cache_id_emitter.invoke_count(),
+      );
+
+      if module.id() < self.inline_cache.len() {
+        self.inline_cache[module.id()] = cache;
+      } else {
+        self.inline_cache.push(cache);
+      }
+      self.manage_obj(fun)
+    })
+  }
+
+  /// Create a new module
+  pub(super) fn module(&mut self, name: &str) -> Gc<Module> {
+    let id = self.emitter.emit();
+    let hooks = GcHooks::new(self);
+
+    // create a new module class that subclass
+    // the base module class
+    let name = hooks.manage_str(name);
+    let module_class = Class::with_inheritance(&hooks, name, self.builtin.dependencies.module);
+
+    let mut module = hooks.manage(Module::new(module_class, id));
+    hooks.push_root(module);
+
+    // transfer the symbols from the global module into the main module
+    self.global.transfer_exported(&hooks, &mut module);
+
+    hooks.pop_roots(1);
+    let package = hooks.manage(Package::new(name, module));
+
+    self.packages.insert(name, package);
+    module
+  }
+
+  pub(super) fn import_module(&mut self, import: Gc<Import>) -> ImportResult {
+    let package = self.packages.get(&import.package()).cloned();
+
+    match package {
+      Some(existing_package) => {
+        self.push_root(import);
+
+        let result = match existing_package.import(&GcHooks::new(self), import) {
+          Ok(module) => ImportResult::Loaded(module),
+          Err(err) => match err {
+            ImportError::PackageDoesNotMatch => panic!("Unexpected package mismatch"),
+            ImportError::ModuleDoesNotExist => self.load_missing_module(existing_package, import),
+            _ => unreachable!(),
+          },
+        };
+
+        self.pop_roots(1);
+        todo!()
+      },
+      None => ImportResult::NotFound,
+    }
+  }
+
+  fn load_missing_module(
+    &mut self,
+    existing_package: Gc<Package>,
+    import: Gc<Import>,
+  ) -> ImportResult {
+    let (module, found_path, remaining_path) =
+      find_missing_module(existing_package.root_module(), import.path(), 0);
+
+    let fs = self.io.fs();
+    let env = self.io.env();
+    let mut resolved_path = env.current_dir().unwrap();
+
+    for path_segment in found_path {
+      resolved_path.push(PathBuf::from(path_segment));
+    }
+
+    let module_name = *remaining_path.first().unwrap();
+    resolved_path.push(PathBuf::from(&module_name));
+
+    match fs.read_file(&resolved_path) {
+      Ok(file_contents) => {
+        let source_content = self.manage_str(file_contents);
+
+        match resolved_path.into_os_string().into_string() {
+          Ok(name) => {
+            let name = self.manage_str(name);
+            let source = Source::new(source_content);
+            let file_id = self.files.upsert(name, source_content);
+
+            let module = self.module(&module_name);
+
+            match self.compile(false, module, &source, file_id) {
+              Ok(fun) => ImportResult::Compiled(fun),
+              Err(errors) => {
+                let mut stdio = self.io.stdio();
+                let stderr_color = stdio.stderr_color();
+                for error in errors.iter() {
+                  term::emit(stderr_color, &Config::default(), &self.files, error)
+                    .expect("Unable to write to stderr");
+                }
+                ImportResult::CompileError
+              },
+            }
+          },
+          Err(_) => ImportResult::NotFound,
+        }
+      },
+      Err(_) => ImportResult::NotFound,
+    }
+  }
+}
+
+fn find_missing_module<'a>(
+  module: Gc<Module>,
+  path: &'a [GcStr],
+  index: usize,
+) -> (Gc<Module>, &'a [GcStr], &'a [GcStr]) {
+  if path.is_empty() {
+    return (module, &[], &[]);
+  }
+
+  match module.get_module(path[0]) {
+    Some(module) => find_missing_module(module, path, index + 1),
+    None => (module, &path[0..index], &path[index..]),
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  mod find_missing_module {
+    use super::*;
+    use laythe_core::{
+      hooks::{GcHooks, NoContext},
+      module::module_class,
+      support::{test_class, test_module},
+    };
+
+    #[test]
+    fn empty_path() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let root_module = test_module(&hooks, "root");
+
+      let (found_module, beginning, end) = find_missing_module(root_module, &[], 0);
+
+      assert_eq!(found_module, root_module);
+
+      assert!(beginning.is_empty());
+      assert!(end.is_empty());
+    }
+
+    #[test]
+    fn no_nested_modules() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let root_module = test_module(&hooks, "root");
+      let path = &[hooks.manage_str("first"), hooks.manage_str("second")];
+
+      let (found_module, beginning, end) = find_missing_module(root_module, path, 0);
+
+      assert_eq!(found_module, root_module);
+
+      assert!(beginning.is_empty());
+      assert_eq!(end.len(), 2);
+      assert_eq!(end[0], hooks.manage_str("first"));
+      assert_eq!(end[1], hooks.manage_str("second"));
+    }
+
+    #[test]
+    fn partial_match() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let class = test_class(&hooks, "Module");
+
+      let mut root_module = hooks.manage(Module::new(module_class(&hooks, "root", class), 0));
+      let nested_module = hooks.manage(Module::new(module_class(&hooks, "first", class), 1));
+
+      assert!(root_module.insert_module(nested_module).is_ok());
+
+      let path = &[hooks.manage_str("first"), hooks.manage_str("second")];
+
+      let (found_module, beginning, end) = find_missing_module(root_module, path, 0);
+
+      assert_eq!(found_module, nested_module);
+
+      assert_eq!(beginning.len(), 1);
+      assert_eq!(beginning[0], hooks.manage_str("first"));
+      assert_eq!(end.len(), 1);
+      assert_eq!(end[0], hooks.manage_str("second"));
+    }
+  }
+}

--- a/laythe_vm/tests/language.rs
+++ b/laythe_vm/tests/language.rs
@@ -1,10 +1,18 @@
 use laythe_vm::vm::{default_native_vm, VmExit};
-use support::{assert_file_exit_and_stdio, assert_files_exit};
+use support::{assert_file_exit_and_stdio, assert_files_exit, assert_files_exit_with_cwd};
 
 mod support;
 
 fn test_file_exits(paths: &[&str], result: VmExit) -> Result<(), std::io::Error> {
   assert_files_exit(paths, FILE_PATH, result)
+}
+
+fn test_file_exits_with_cwd(
+  paths: &[&str],
+  cwd: &str,
+  result: VmExit,
+) -> Result<(), std::io::Error> {
+  assert_files_exit_with_cwd(paths, FILE_PATH, cwd, result)
 }
 
 fn test_file_with_stdio(

--- a/laythe_vm/tests/language.rs
+++ b/laythe_vm/tests/language.rs
@@ -564,15 +564,37 @@ fn implicit_return() -> Result<(), std::io::Error> {
 
 #[test]
 fn import() -> Result<(), std::io::Error> {
-  test_file_exits(&vec![], VmExit::Ok)?;
+  test_file_exits(
+    &vec![
+      "language/import/module.lay",
+      "language/import/module_rename.lay",
+      "language/import/symbol.lay",
+      "language/import/symbol_rename.lay",
+    ],
+    VmExit::Ok,
+  )?;
+
+  test_file_exits_with_cwd(
+    &vec![
+      "language/import/user_import/symbol.lay",
+      "language/import/user_import/module.lay",
+    ],
+    "language/import/user_import",
+    VmExit::Ok,
+  )?;
 
   test_file_exits(
     &vec![
+      "language/import/import_in_fun.lay",
+      "language/import/import_in_class.lay",
+      "language/import/import_in_scope.lay",
       "language/import/missing_path.lay",
       "language/import/missing_semicolon.lay",
       "language/import/non_identifier_path.lay",
       "language/import/rename_missing.lay",
       "language/import/rename_not_identifer.lay",
+      "language/import/rename_redefine.lay",
+      "language/import/symbols_redefine.lay",
       "language/import/symbols_rename_missing.lay",
       "language/import/symbols_rename_not_identifer.lay",
     ],
@@ -582,10 +604,14 @@ fn import() -> Result<(), std::io::Error> {
   test_file_exits(
     &vec![
       "language/import/module_not_real.lay",
-      // "language/import/rename_redefine.lay",
       "language/import/symbols_not_real.lay",
-      // "language/import/symbols_redefine.lay",
     ],
+    VmExit::RuntimeError,
+  )?;
+
+  test_file_exits_with_cwd(
+    &vec!["language/import/user_import/cycle_1.lay"],
+    "language/import/user_import",
     VmExit::RuntimeError,
   )
 }


### PR DESCRIPTION
## Problem
Currently in Laythe we're restricted to single file because we have not built out the infrastructure in order to support user defined modules. At some point this because really limiting in terms of using Laythe for a "real" project. Even for myself it would be nice to be able to do normal software practices of at least being able to load my own modules

## Solution
This PR add an MVP feature for user modules. Currently we're restricted to the immediate directory in which the Laythe was invoked. For example say we had this directory 

```
some_folder
├── lib.lay
├── main.lay
└── utils.lay
```

if we were to invoke Laythe in `some_folder` against main.lay we could now import `lib` and `utils` in the `self` package as follows

```laythe
import self.lib;
import self.utils;
```

Under the hood Laythe will do roughly the following to import a user module. Here I'll talk through the above line `import self.lib;`

* Attempt to do a module lookup using the import path
  * If successful either return the module instance or do a symbol lookup
* On failure use the current working directory and import path to search the a file `lib.lay`
  * If failure report a runtime error the module doesn't exist
* On source load create a new `Gc<Module>` that is empty then pass it to the compiler
* The compiler will compile the module in the same we do for `main.lay`
  * If a compiler error is encountered signal to vm to exit and print the compiler error
* On successful compile we create a new `GcObj<Fiber>` and attach the new file's module level function to it. We set this fiber's parent fiber the fiber the called import. In this case main.lay
* We tell the current running fiber to rewind the instruction pointer to just prior to import statement and tell this fiber to sleep and the signal to the vm to context switch.
* The new fiber is loaded into the vm and begins executing top to bottom as all scripts are. As export statements are encountered symbols are put into the modules public symbol table.
* Once the fiber hits end of file assuming it didn't import itself it gives back control to it's parent fiber in this case main.lay
* main.lay attempts the same import it did originally now with the module in place and presumably the relevant symbols it's the symbol table.
