### PR TITLE
Symbolic byte code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "laythe_env",
  "laythe_lib",
  "laythe_native",
+ "variant_count",
 ]
 
 [[package]]
@@ -775,6 +776,16 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "variant_count"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "version_check"

--- a/laythe_core/src/lib.rs
+++ b/laythe_core/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::all)]
-pub mod call_frame;
 pub mod captures;
 pub mod chunk;
 pub mod constants;

--- a/laythe_core/src/object/closure.rs
+++ b/laythe_core/src/object/closure.rs
@@ -30,8 +30,8 @@ impl Closure {
   ///   hooks.manage_obj(Class::bare(hooks.manage_str("module"))),
   ///   0,
   /// ));
-  /// let mut builder = FunBuilder::new(hooks.manage_str("example"), module, Arity::default());
-  /// let managed_fun = hooks.manage_obj(builder.build(&hooks));
+  /// let mut builder = FunBuilder::<u8>::new(hooks.manage_str("example"), module, Arity::default());
+  /// let managed_fun = hooks.manage_obj(builder.build(&hooks).unwrap());
   ///
   /// let captures = Captures::new(&hooks, &[]);
   /// let closure = Closure::new(managed_fun, captures);

--- a/laythe_core/src/object/fiber.rs
+++ b/laythe_core/src/object/fiber.rs
@@ -1326,11 +1326,11 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fun1 = test_fun_builder(&hooks, "first", "first module");
+    let mut fun1 = test_fun_builder::<u8>(&hooks, "first", "first module");
     fun1.update_max_slots(4);
     let fun1 = hooks.manage_obj(fun1.build(&hooks));
 
-    let mut fun2 = test_fun_builder(&hooks, "second", "second module");
+    let mut fun2 = test_fun_builder::<u8>(&hooks, "second", "second module");
     fun2.update_max_slots(3);
     let fun2 = hooks.manage_obj(fun2.build(&hooks));
 

--- a/laythe_core/src/object/fiber/call_frame.rs
+++ b/laythe_core/src/object/fiber/call_frame.rs
@@ -5,7 +5,7 @@ use crate::{
   value::Value,
 };
 
-/// A call frame in the space lox interpreter
+/// A call frame in the Laythe interpreter
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CallFrame {
   /// The function defining this call frame

--- a/laythe_core/src/object/fiber/exception_handler.rs
+++ b/laythe_core/src/object/fiber/exception_handler.rs
@@ -1,0 +1,34 @@
+/// An exception handler in Laythe
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ExceptionHandler {
+  /// The ip offset from the start call frame
+  offset: usize,
+
+  /// The calldepth of this handler
+  call_frame_depth: usize,
+
+  /// The slot depth at this handler
+  slot_depth: usize,
+}
+
+impl ExceptionHandler {
+  pub fn new(offset: usize, call_frame_depth: usize, slot_depth: usize) -> Self {
+    Self {
+      offset,
+      call_frame_depth,
+      slot_depth,
+    }
+  }
+
+  pub fn offset(&self) -> usize {
+    self.offset
+  }
+
+  pub fn call_frame_depth(&self) -> usize {
+    self.call_frame_depth
+  }
+
+  pub fn slot_depth(&self) -> usize {
+    self.slot_depth
+  }
+}

--- a/laythe_core/src/object/fiber/mod.rs
+++ b/laythe_core/src/object/fiber/mod.rs
@@ -1,8 +1,9 @@
-use std::{fmt, io::Write, mem, ptr, usize};
+mod call_frame;
+mod exception_handler;
 
+use self::{call_frame::CallFrame, exception_handler::ExceptionHandler};
 use super::{Channel, Fun, ObjectKind};
 use crate::{
-  call_frame::CallFrame,
   captures::Captures,
   constants::SCRIPT,
   hooks::GcHooks,
@@ -10,6 +11,7 @@ use crate::{
   val,
   value::{Value, VALUE_NIL},
 };
+use std::{fmt, io::Write, mem, ptr, usize};
 
 const INITIAL_FRAME_SIZE: usize = 4;
 
@@ -41,6 +43,9 @@ pub struct Fiber {
 
   /// A stack holding call frames currently in use
   frames: Vec<CallFrame>,
+
+  /// A stack of exception handlers active on this fiber
+  exception_handlers: Vec<ExceptionHandler>,
 
   /// A list of channels executed on this fiber
   channels: Vec<GcObj<Channel>>,
@@ -103,6 +108,7 @@ impl Fiber {
       frames,
       parent,
       channels: vec![],
+      exception_handlers: vec![],
       state: FiberState::Pending,
       error: None,
       frame: current_frame,
@@ -114,6 +120,11 @@ impl Fiber {
   #[inline]
   pub fn frames(&self) -> &[CallFrame] {
     &self.frames
+  }
+
+  /// Get the current number of call frames on this fiber
+  fn frame_count(&self) -> usize {
+    self.frames.len()
   }
 
   /// Get the current frame's stack start
@@ -291,6 +302,37 @@ impl Fiber {
   #[inline]
   pub unsafe fn peek_set(&mut self, distance: usize, val: Value) {
     self.set_val(distance + 1, val)
+  }
+
+  /// Push a new exception handler onto this fiber
+  pub fn push_exception_handler(&mut self, offset: usize, slot_depth: usize) {
+    debug_assert!(
+      offset < self.fun().chunk().instructions().len(),
+      "Offset past end of functions"
+    );
+    debug_assert!(
+      slot_depth < self.fun().max_slots(),
+      "Slot offset more than function maximum"
+    );
+
+    let call_frame_depth = self.frame_count();
+
+    self
+      .exception_handlers
+      .push(ExceptionHandler::new(offset, call_frame_depth, slot_depth));
+  }
+
+  /// Push a new exception handler onto this fiber
+  pub fn pop_exception_handler(&mut self) {
+    assert!(
+      self.exception_handlers.pop().is_some(),
+      "Attempted to pop an empty vec of exception handlers"
+    );
+  }
+
+  /// Do we currently have an active exception handler
+  pub fn exception_handler(&self) -> Option<ExceptionHandler> {
+    self.exception_handlers.last().copied()
   }
 
   /// Load the instruction pointer from the current frame
@@ -486,56 +528,36 @@ impl Fiber {
   /// # Safety
   /// Assumes the function try block slot offset points to a valid offset into the
   /// associated call frames slots
-  pub unsafe fn stack_unwind(&mut self, bottom_frame: usize) -> UnwindResult {
-    let mut stack_top = self.frame().stack_start();
-    let mut drop: usize = 0;
-    let mut catch_offset: Option<usize> = None;
+  pub unsafe fn stack_unwind(&mut self, bottom_frame: Option<usize>) -> UnwindResult {
+    match self.exception_handler() {
+      Some(exception_handler) => {
+        let bottom_frame = bottom_frame.unwrap_or(0);
+        if exception_handler.call_frame_depth() >= bottom_frame {
+          self.frames.truncate(exception_handler.call_frame_depth());
 
-    for frame in self.frames[bottom_frame..].iter().rev() {
-      let fun = frame.fun();
-      let instructions = fun.chunk().instructions();
+          let frame = self
+            .frames
+            .last_mut()
+            .expect("expected at least 1 frame to remain");
 
-      // see if the current functions has a catch block at
-      // this offset
-      let offset = frame.ip().offset_from(instructions.as_ptr()) as usize;
-      if let Some((offset, slots)) = fun.has_catch_jump(offset) {
-        debug_assert!(slots <= fun.max_slots(), "Fun has at most {} slots but attempted to offset at {}", fun.max_slots(), slots);
+          let fun = frame.fun();
+          let instructions = fun.chunk().instructions();
 
-        catch_offset = Some(offset);
-        stack_top = frame.stack_start().add(slots);
-        break;
-      }
+          let stack_top = frame.stack_start().add(exception_handler.slot_depth());
 
-      drop += 1;
-      stack_top = frame.stack_start();
-    }
+          // set the current ip frame and stack pointer
+          frame.store_ip(&instructions[exception_handler.offset()] as *const u8);
+          self.frame = frame as *mut CallFrame;
+          self.stack_top = stack_top;
 
-    match catch_offset {
-      Some(catch_offset) => {
-        // truncate the unwound frames
-        self.frames.truncate(self.frames.len() - drop);
-
-        let frame = self
-          .frames
-          .last_mut()
-          .expect("expected at least 1 frame to remain");
-
-        let fun = frame.fun();
-        let instructions = fun.chunk().instructions();
-
-        // set the current ip frame and stack pointer
-        frame.store_ip(&instructions[catch_offset as usize] as *const u8);
-        self.frame = frame as *mut CallFrame;
-        self.stack_top = stack_top;
-
-        UnwindResult::Handled(frame)
-      },
-      None => {
-        if bottom_frame == 0 {
-          UnwindResult::Unhandled
+          UnwindResult::Handled(frame)
         } else {
           UnwindResult::UnwindStopped
         }
+      },
+      None => match bottom_frame {
+        Some(_) => UnwindResult::UnwindStopped,
+        None => UnwindResult::Unhandled,
       },
     }
   }
@@ -969,6 +991,111 @@ mod test {
   }
 
   #[test]
+  fn push_exception_handler() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let module = test_module(&hooks, "test module");
+
+    let mut builder = FunBuilder::new(hooks.manage_str("test"), module, Arity::default());
+    builder.write_instruction(0, 0);
+    builder.write_instruction(0, 0);
+    builder.write_instruction(0, 0);
+    builder.update_max_slots(3);
+
+    let captures = Captures::new(&hooks, &[]);
+    let fun = hooks.manage_obj(builder.build(&hooks).unwrap());
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .max_slots(4)
+      .instructions(vec![1, 2, 3])
+      .build(&hooks)
+      .expect("Expected to build");
+
+    fiber.push_exception_handler(0, 1);
+
+    unsafe {
+      fiber.push(val!(fun));
+      fiber.push(val!(10.0));
+      fiber.push(val!(true));
+    }
+
+    fiber.push_frame(fun, captures, 2);
+    fiber.push_exception_handler(2, 2);
+
+    assert_eq!(fiber.exception_handlers[0].offset(), 0);
+    assert_eq!(fiber.exception_handlers[0].slot_depth(), 1);
+    assert_eq!(fiber.exception_handlers[0].call_frame_depth(), 1);
+
+    assert_eq!(fiber.exception_handlers[1].offset(), 2);
+    assert_eq!(fiber.exception_handlers[1].slot_depth(), 2);
+    assert_eq!(fiber.exception_handlers[1].call_frame_depth(), 2);
+  }
+
+  #[test]
+  #[should_panic]
+  fn push_exception_handler_offset_out_of_bounds() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .max_slots(3)
+      .instructions(vec![1])
+      .build(&hooks)
+      .expect("Expected to build");
+
+    fiber.push_exception_handler(2, 1);
+  }
+
+  #[test]
+  #[should_panic]
+  fn push_exception_handler_slot_depth_out_of_bounds() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .max_slots(1)
+      .instructions(vec![1, 2, 3])
+      .build(&hooks)
+      .expect("Expected to build");
+
+    fiber.push_exception_handler(2, 3);
+  }
+
+  #[test]
+  fn pop_exception_handler() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .max_slots(4)
+      .instructions(vec![1, 2, 3])
+      .build(&hooks)
+      .expect("Expected to build");
+
+    fiber.push_exception_handler(2, 3);
+
+    assert_eq!(fiber.exception_handlers.len(), 1);
+    fiber.pop_exception_handler();
+    assert_eq!(fiber.exception_handlers.len(), 0);
+  }
+
+  #[test]
+  #[should_panic]
+  fn pop_exception_handler_no_handler_to_pop() {
+    let context = NoContext::default();
+    let hooks = GcHooks::new(&context);
+
+    let mut fiber = FiberBuilder::<u8>::default()
+      .max_slots(4)
+      .instructions(vec![1, 2, 3])
+      .build(&hooks)
+      .expect("Expected to build");
+
+    fiber.pop_exception_handler();
+  }
+
+  #[test]
   fn is_complete() {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
@@ -1031,7 +1158,7 @@ mod test {
     builder.write_instruction(0, 0);
     builder.write_instruction(0, 0);
 
-    let fun = hooks.manage_obj(builder.build(&hooks));
+    let fun = hooks.manage_obj(builder.build(&hooks).unwrap());
     let captures = Captures::new(&hooks, &[]);
 
     let mut fiber = FiberBuilder::<u8>::default()
@@ -1313,7 +1440,7 @@ mod test {
     fiber.push_frame(fun2, captures, 1);
 
     unsafe {
-      assert_eq!(fiber.stack_unwind(0), UnwindResult::Unhandled);
+      assert_eq!(fiber.stack_unwind(None), UnwindResult::Unhandled);
     }
 
     assert_eq!(fiber.frames().len(), 3);
@@ -1328,11 +1455,11 @@ mod test {
 
     let mut fun1 = test_fun_builder::<u8>(&hooks, "first", "first module");
     fun1.update_max_slots(4);
-    let fun1 = hooks.manage_obj(fun1.build(&hooks));
+    let fun1 = hooks.manage_obj(fun1.build(&hooks).unwrap());
 
     let mut fun2 = test_fun_builder::<u8>(&hooks, "second", "second module");
     fun2.update_max_slots(3);
-    let fun2 = hooks.manage_obj(fun2.build(&hooks));
+    let fun2 = hooks.manage_obj(fun2.build(&hooks).unwrap());
 
     let captures = Captures::new(&hooks, &[]);
 
@@ -1359,7 +1486,7 @@ mod test {
     fiber.push_frame(fun2, captures, 1);
 
     unsafe {
-      assert_eq!(fiber.stack_unwind(2), UnwindResult::UnwindStopped);
+      assert_eq!(fiber.stack_unwind(Some(2)), UnwindResult::UnwindStopped);
     }
 
     assert_eq!(fiber.frames().len(), 3);

--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -1,10 +1,9 @@
-use std::{fmt, io::Write};
+use std::{fmt::{self, Debug}, io::Write};
 
 use crate::{
   chunk::{Chunk, ChunkBuilder, Encode},
   hooks::GcHooks,
-  impl_debug_heap, impl_trace,
-  managed::{Array, DebugHeap, DebugWrap, Gc, GcStr, Object, Trace},
+  managed::{DebugHeap, DebugWrap, Gc, GcStr, Object, Trace},
   module::Module,
   signature::Arity,
   value::Value,
@@ -35,28 +34,6 @@ impl fmt::Display for FunKind {
   }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct TryBlock {
-  /// Start of the try block
-  start: usize,
-
-  /// End of the try block
-  end: usize,
-
-  /// How many slots were used at the beginning of this
-  /// try catch
-  slots: usize,
-}
-
-impl TryBlock {
-  pub fn new(start: usize, end: usize, slots: usize) -> Self {
-    TryBlock { start, end, slots }
-  }
-}
-
-impl_trace!(TryBlock);
-impl_debug_heap!(TryBlock);
-
 /// A mutable builder for an immutable function
 pub struct FunBuilder<T> {
   /// Name if not top-level script
@@ -74,9 +51,6 @@ pub struct FunBuilder<T> {
   /// The module this function belongs to
   module: Gc<Module>,
 
-  /// Catch block present in this function
-  try_blocks: Vec<TryBlock>,
-
   /// Code for the function body
   chunk: ChunkBuilder<T>,
 }
@@ -90,7 +64,6 @@ impl<T: Default> FunBuilder<T> {
       chunk: ChunkBuilder::<T>::default(),
       module,
       name,
-      try_blocks: Vec::new(),
     }
   }
 }
@@ -146,31 +119,22 @@ impl<T> FunBuilder<T> {
   pub fn add_constant(&mut self, constant: Value) -> usize {
     self.chunk.add_constant(constant)
   }
-
-  /// Add a try block to this function
-  pub fn add_try(&mut self, try_block: TryBlock) {
-    self.try_blocks.push(try_block)
-  }
 }
 
 impl<T: Encode> FunBuilder<T> {
   /// Build a final immutable Fun from this builder
-  pub fn build(self, hooks: &GcHooks) -> Fun {
-    let try_blocks = hooks.manage(&*self.try_blocks);
-    hooks.push_root(try_blocks);
-    let chunk = self.chunk.build(hooks);
-    hooks.pop_roots(1);
+  pub fn build(self, hooks: &GcHooks) -> Result<Fun, T::Error> {
+    let chunk = self.chunk.build(hooks)?;
 
-    Fun {
+    Ok(Fun {
       name: self.name,
       arity: self.arity,
       capture_count: self.capture_count,
       max_slot: self.max_slots as u32,
       module_id: self.module.id(),
       module: self.module,
-      try_blocks,
       chunk,
-    }
+    })
   }
 }
 
@@ -208,19 +172,21 @@ pub struct Fun {
   /// The module this function belongs to
   module: Gc<Module>,
 
-  /// Catch block present in this function
-  try_blocks: Array<TryBlock>,
-
   /// Code for the function body
   chunk: Chunk,
 }
 
 impl Fun {
-  pub fn stub<T: Encode + Default>(hooks: &GcHooks, name: GcStr, module: Gc<Module>, instruction: T) -> Fun {
+  pub fn stub<T: Encode + Default + Debug>(
+    hooks: &GcHooks,
+    name: GcStr,
+    module: Gc<Module>,
+    instruction: T,
+  ) -> Fun {
     let mut builder = FunBuilder::new(name, module, Arity::Variadic(0));
     builder.write_instruction(instruction, 0);
 
-    builder.build(hooks)
+    builder.build(hooks).expect("Was unable to build stub function.")
   }
 
   /// Name of this function
@@ -269,24 +235,6 @@ impl Fun {
   pub fn max_slots(&self) -> usize {
     self.max_slot as usize
   }
-
-  pub fn has_catch_jump(&self, ip: usize) -> Option<(usize, usize)> {
-    let mut min_range = std::usize::MAX;
-    let mut catch = None;
-
-    for try_block in self.try_blocks.iter() {
-      if ip >= try_block.start && ip < try_block.end {
-        let len = try_block.end - try_block.start;
-
-        if len < min_range {
-          min_range = len;
-          catch = Some((try_block.end, try_block.slots));
-        }
-      }
-    }
-
-    catch
-  }
 }
 
 impl fmt::Display for Fun {
@@ -305,14 +253,12 @@ impl Trace for Fun {
   fn trace(&self) {
     self.name.trace();
     self.module.trace();
-    self.try_blocks.trace();
     self.chunk.trace();
   }
 
   fn trace_debug(&self, log: &mut dyn Write) {
     self.name.trace_debug(log);
     self.module.trace_debug(log);
-    self.try_blocks.trace_debug(log);
     self.chunk.trace_debug(log);
   }
 }
@@ -326,7 +272,6 @@ impl DebugHeap for Fun {
       .field("max_slots", &self.max_slot)
       .field("module_id", &self.module_id)
       .field("module", &DebugWrap(&self.module, depth))
-      .field("try_blocks", &DebugWrap(&self.try_blocks, depth))
       .field("chunk", &DebugWrap(&self.chunk, depth))
       .finish()
   }

--- a/laythe_core/src/object/ly_box.rs
+++ b/laythe_core/src/object/ly_box.rs
@@ -27,7 +27,7 @@ impl Default for LyBox {
 
 impl Display for LyBox {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "*{}", self.value)
+    write!(f, "<*{} {:p}>", self.value, &*self)
   }
 }
 

--- a/laythe_core/src/object/mod.rs
+++ b/laythe_core/src/object/mod.rs
@@ -16,7 +16,7 @@ pub use class::Class;
 pub use closure::Closure;
 pub use enumerator::{Enumerate, Enumerator};
 pub use fiber::{Fiber, FiberResult, FiberState, UnwindResult};
-pub use fun::{Fun, FunBuilder, FunKind, TryBlock};
+pub use fun::{Fun, FunBuilder, FunKind};
 // pub use instance::Instance;
 pub use list::List;
 pub use ly_box::LyBox;

--- a/laythe_core/src/support/mod.rs
+++ b/laythe_core/src/support/mod.rs
@@ -150,12 +150,16 @@ pub fn test_class(hooks: &GcHooks, name: &str) -> GcObj<Class> {
 pub fn test_fun(hooks: &GcHooks, name: &str, module_name: &str) -> GcObj<Fun> {
   let module = test_module(hooks, module_name);
 
-  let builder = FunBuilder::new(hooks.manage_str(name), module, Arity::default());
+  let builder = FunBuilder::<u8>::new(hooks.manage_str(name), module, Arity::default());
 
   hooks.manage_obj(builder.build(hooks))
 }
 
-pub fn test_fun_builder(hooks: &GcHooks, name: &str, module_name: &str) -> FunBuilder {
+pub fn test_fun_builder<T: Default>(
+  hooks: &GcHooks,
+  name: &str,
+  module_name: &str,
+) -> FunBuilder<T> {
   let module = test_module(hooks, module_name);
   FunBuilder::new(hooks.manage_str(name), module, Arity::default())
 }

--- a/laythe_core/src/support/mod.rs
+++ b/laythe_core/src/support/mod.rs
@@ -3,7 +3,7 @@ use hashbrown::HashMap;
 
 use crate::{
   captures::Captures,
-  chunk::Encode,
+  chunk::{Encode, Line},
   hooks::GcHooks,
   managed::{Gc, GcObj, GcStr},
   module::{module_class, Module},
@@ -75,7 +75,7 @@ where
     }
     fun.update_max_slots(self.max_slots);
 
-    let fun = hooks.manage_obj(fun.build(hooks));
+    let fun = hooks.manage_obj(fun.build(hooks).unwrap());
     hooks.push_root(fun);
 
     let captures = Captures::new(hooks, &[]);
@@ -86,9 +86,10 @@ where
 }
 
 impl Encode for u8 {
-  fn encode(self, buf: &mut Vec<u8>) -> u32 {
-    buf.push(self);
-    1
+  type Error = ();
+
+  fn encode(data: Vec<Self>, lines: Vec<Line>) -> Result<(Vec<u8>, Vec<Line>), Self::Error> {
+    Ok((data, lines))
   }
 }
 
@@ -152,7 +153,7 @@ pub fn test_fun(hooks: &GcHooks, name: &str, module_name: &str) -> GcObj<Fun> {
 
   let builder = FunBuilder::<u8>::new(hooks.manage_str(name), module, Arity::default());
 
-  hooks.manage_obj(builder.build(hooks))
+  hooks.manage_obj(builder.build(hooks).expect("Unable to build test function."))
 }
 
 pub fn test_fun_builder<T: Default>(

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -449,7 +449,7 @@ mod unboxed {
       assert_eq!(mem::size_of::<Map<Value, Value>>(), 32);
       assert_eq!(mem::size_of::<Closure>(), 24);
       assert_eq!(mem::size_of::<Fun>(), 96);
-      assert_eq!(mem::size_of::<Class>(), 104);
+      assert_eq!(mem::size_of::<Class>(), 128);
       assert_eq!(mem::size_of::<Method>(), 32);
       assert_eq!(mem::size_of::<Enumerator>(), 32);
       assert_eq!(mem::size_of::<Native>(), 56);
@@ -784,8 +784,8 @@ mod boxed {
       assert_eq!(mem::size_of::<List<Value>>(), 24);
       assert_eq!(mem::size_of::<Map<Value, Value>>(), 32);
       assert_eq!(mem::size_of::<Closure>(), 16);
-      assert_eq!(mem::size_of::<Fun>(), 64);
-      assert_eq!(mem::size_of::<Fiber>(), 112);
+      assert_eq!(mem::size_of::<Fun>(), 56);
+      assert_eq!(mem::size_of::<Fiber>(), 136);
       assert_eq!(mem::size_of::<Class>(), 104);
       assert_eq!(mem::size_of::<Method>(), 16);
       assert_eq!(mem::size_of::<Enumerator>(), 24);

--- a/laythe_frontend_bench/src/main.rs
+++ b/laythe_frontend_bench/src/main.rs
@@ -7,7 +7,7 @@ use laythe_core::{
 use laythe_lib::create_std_lib;
 use laythe_vm::{
   compiler::{Compiler, Parser, Resolver},
-  source::Source,
+  source::{Source, VM_FILE_TEST_ID},
 };
 use std::env;
 use std::fs::File;
@@ -39,16 +39,16 @@ fn compiler_bench(src: &str) {
       .to_obj()
       .to_class();
 
-    let (ast, line_offsets) = Parser::new(&source, 0).parse();
+    let (ast, line_offsets) = Parser::new(&source, VM_FILE_TEST_ID).parse();
     let mut ast = ast.unwrap();
     let module = hooks.manage(Module::new(module_class, 0));
 
     let gc = context.done();
-    assert!(Resolver::new(global_module, &gc, &source, 0, false)
+    assert!(Resolver::new(global_module, &gc, &source, VM_FILE_TEST_ID, false)
       .resolve(&mut ast)
       .is_ok());
 
-    let compiler = Compiler::new(module, &line_offsets, 0, false, &NO_GC, gc);
+    let compiler = Compiler::new(module, &line_offsets, VM_FILE_TEST_ID, false, &NO_GC, gc);
     compiler.compile(&ast).0.unwrap();
   }
 }
@@ -59,7 +59,7 @@ fn parser_bench(src: &str) {
 
   for _ in 0..1000000 {
     let source = Source::new(src);
-    let parser = Parser::new(&source, 0);
+    let parser = Parser::new(&source, VM_FILE_TEST_ID);
     parser.parse().0.unwrap();
   }
 }

--- a/laythe_lib/src/global/primitives/closure.rs
+++ b/laythe_lib/src/global/primitives/closure.rs
@@ -148,7 +148,7 @@ mod test {
 
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
       let closure = hooks.manage_obj(Closure::new(
         hooks.manage_obj(builder.build(&hooks.as_gc())),
         captures,
@@ -157,7 +157,7 @@ mod test {
       let result = closure_name.call(&mut hooks, Some(val!(closure)), &[]);
       assert_eq!(result.unwrap().to_num(), 4.0);
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
       let closure = hooks.manage_obj(Closure::new(
         hooks.manage_obj(builder.build(&hooks.as_gc())),
         captures,
@@ -166,7 +166,7 @@ mod test {
       let result = closure_name.call(&mut hooks, Some(val!(closure)), &[]);
       assert_eq!(result.unwrap().to_num(), 2.0);
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
       let closure = hooks.manage_obj(Closure::new(
         hooks.manage_obj(builder.build(&hooks.as_gc())),
         captures,
@@ -203,7 +203,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
       let closure_call = ClosureCall::native(&hooks.as_gc());
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let closure = hooks.manage_obj(Closure::new(

--- a/laythe_lib/src/global/primitives/closure.rs
+++ b/laythe_lib/src/global/primitives/closure.rs
@@ -150,7 +150,7 @@ mod test {
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
       let closure = hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
         captures,
       ));
 
@@ -159,7 +159,7 @@ mod test {
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
       let closure = hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
         captures,
       ));
 
@@ -168,7 +168,7 @@ mod test {
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
       let closure = hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
         captures,
       ));
 
@@ -207,7 +207,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let closure = hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
         captures,
       ));
 

--- a/laythe_lib/src/global/primitives/fun.rs
+++ b/laythe_lib/src/global/primitives/fun.rs
@@ -140,19 +140,19 @@ mod test {
       let fun_name = FunLen::native(&hooks.as_gc());
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
-      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
+      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap());
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 4.0);
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
-      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
+      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap());
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 2.0);
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
-      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
+      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap());
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 5.0);
@@ -186,7 +186,7 @@ mod test {
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
 
-      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
+      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap());
 
       let args = &[val!(hooks.manage_str("input".to_string()))];
       let result1 = fun_call.call(&mut hooks, Some(val!(fun)), args);

--- a/laythe_lib/src/global/primitives/fun.rs
+++ b/laythe_lib/src/global/primitives/fun.rs
@@ -139,19 +139,19 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
       let fun_name = FunLen::native(&hooks.as_gc());
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
       let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 4.0);
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
       let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 2.0);
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
       let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
@@ -184,7 +184,7 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
       let fun_call = FunCall::native(&hooks.as_gc());
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
 
       let fun = hooks.manage_obj(builder.build(&hooks.as_gc()));
 

--- a/laythe_lib/src/global/primitives/iter.rs
+++ b/laythe_lib/src/global/primitives/iter.rs
@@ -1302,7 +1302,7 @@ mod test {
       let iter = test_iter();
       let managed = hooks.manage_obj(Enumerator::new(iter));
       let this = val!(managed);
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
@@ -1354,7 +1354,7 @@ mod test {
       let iter = test_iter();
       let managed = hooks.manage_obj(Enumerator::new(iter));
       let this = val!(managed);
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
@@ -1413,7 +1413,7 @@ mod test {
       let managed = hooks.manage_obj(Enumerator::new(iter));
       let this = val!(managed);
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(2));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(2));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
@@ -1499,7 +1499,7 @@ mod test {
       let managed = hooks.manage_obj(Enumerator::new(iter));
       let this = val!(managed);
 
-      let builder = test_fun_builder(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
+      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(

--- a/laythe_lib/src/global/primitives/iter.rs
+++ b/laythe_lib/src/global/primitives/iter.rs
@@ -1306,7 +1306,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
         captures
       )));
 
@@ -1358,7 +1358,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
         captures
       )));
 
@@ -1417,7 +1417,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
         captures
       )));
 
@@ -1503,7 +1503,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc())),
+        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
         captures
       )));
 

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -437,17 +437,17 @@ mod test {
   pub fn test_fun(hooks: &GcHooks, name: &str, module_name: &str) -> GcObj<Fun> {
     let module = test_module(hooks, module_name);
 
-    let builder = FunBuilder::new(hooks.manage_str(name), module, Arity::default());
+    let builder = FunBuilder::<u8>::new(hooks.manage_str(name), module, Arity::default());
 
     hooks.manage_obj(builder.build(&hooks))
   }
 
-  pub fn test_fun_builder(
+  pub fn test_fun_builder<T: Default>(
     hooks: &GcHooks,
     name: &str,
     module_name: &str,
     arity: Arity,
-  ) -> FunBuilder {
+  ) -> FunBuilder<T> {
     let module = test_module(&hooks, module_name);
     FunBuilder::new(hooks.manage_str(name), module, arity)
   }

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -439,7 +439,7 @@ mod test {
 
     let builder = FunBuilder::<u8>::new(hooks.manage_str(name), module, Arity::default());
 
-    hooks.manage_obj(builder.build(&hooks))
+    hooks.manage_obj(builder.build(&hooks).unwrap())
   }
 
   pub fn test_fun_builder<T: Default>(

--- a/laythe_vm/Cargo.toml
+++ b/laythe_vm/Cargo.toml
@@ -23,6 +23,7 @@ laythe_env = { path = "../laythe_env" }
 laythe_native = { path = "../laythe_native" }
 fnv = "1.0.7"
 codespan = "0.11.1"
+variant_count = "1.1.0"
 codespan-reporting = "0.11.1"
 bumpalo = { version = "3.7.0", features=["boxed", "collections"] }
 

--- a/laythe_vm/benches/compiler_benches.rs
+++ b/laythe_vm/benches/compiler_benches.rs
@@ -8,6 +8,7 @@ use laythe_core::{
 };
 use laythe_lib::create_std_lib;
 use laythe_vm::compiler::{Parser, Resolver};
+use laythe_vm::source::VM_FILE_TEST_ID;
 use laythe_vm::{compiler::Compiler, source::Source};
 use std::fs::File;
 use std::io::prelude::*;
@@ -49,15 +50,15 @@ fn compile_source(source: GcStr) {
     .to_class();
   let module = hooks.manage(Module::new(module_class, 0));
   let source = Source::new(source);
-  let (ast, line_offsets) = Parser::new(&source, 0).parse();
+  let (ast, line_offsets) = Parser::new(&source, VM_FILE_TEST_ID).parse();
   let mut ast = ast.unwrap();
 
   let gc = context.done();
-  assert!(Resolver::new(global_module, &gc, &source, 0, false)
+  assert!(Resolver::new(global_module, &gc, &source, VM_FILE_TEST_ID, false)
     .resolve(&mut ast)
     .is_ok());
 
-  let compiler = Compiler::new(module, &line_offsets, 0, false, &NO_GC, gc);
+  let compiler = Compiler::new(module, &line_offsets, VM_FILE_TEST_ID, false, &NO_GC, gc);
   compiler.compile(&ast).0.unwrap();
 }
 

--- a/laythe_vm/benches/parser_benches.rs
+++ b/laythe_vm/benches/parser_benches.rs
@@ -3,7 +3,7 @@ use laythe_core::{
   managed::GcStr,
   memory::{Allocator, NO_GC},
 };
-use laythe_vm::{compiler::Parser, source::Source};
+use laythe_vm::{compiler::Parser, source::{Source, VM_FILE_TEST_ID}};
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -30,7 +30,7 @@ fn load_source<P: AsRef<Path>>(gc: &mut Allocator, dir: P) -> GcStr {
 
 fn parse_source(source: GcStr) {
   let source = Source::new(source);
-  let parser = Parser::new(&source, 0);
+  let parser = Parser::new(&source, VM_FILE_TEST_ID);
   parser.parse().0.unwrap();
 }
 

--- a/laythe_vm/src/byte_code.rs
+++ b/laythe_vm/src/byte_code.rs
@@ -1,12 +1,40 @@
-use laythe_core::chunk::Encode;
-use std::mem;
+use codespan_reporting::diagnostic::Diagnostic;
+use laythe_core::chunk::{Encode, Line};
+use std::{fmt::Display, mem};
+use variant_count::VariantCount;
 
 #[cfg(any(test, feature = "debug"))]
 use std::convert::TryInto;
 
+use crate::source::VmFileId;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Label(u32);
+
+impl Label {
+  pub fn new(id: u32) -> Self {
+    Self(id)
+  }
+}
+
+impl Display for Label {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.0)
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CaptureIndex {
+  /// The capture is in the local function
+  Local(u8),
+
+  /// The capture points to the enclosing function
+  Enclosing(u8),
+}
+
 /// Space Lox virtual machine byte codes
 #[derive(Debug, PartialEq, Clone, Copy)]
-pub enum AlignedByteCode {
+pub enum SymbolicByteCode {
   /// Return from script or function
   Return,
 
@@ -29,10 +57,10 @@ pub enum AlignedByteCode {
   Not,
 
   /// Perform a logical and operator
-  And(u16),
+  And(Label),
 
   /// Perform a logical or operator
-  Or(u16),
+  Or(Label),
 
   /// Retrieve a constant from the constants table
   Constant(u8),
@@ -143,13 +171,22 @@ pub enum AlignedByteCode {
   SetProperty(u16),
 
   /// Jump to end of if block if false
-  JumpIfFalse(u16),
+  JumpIfFalse(Label),
 
   /// Jump conditionally to the ip
-  Jump(u16),
+  Jump(Label),
 
   /// Jump to loop beginning
-  Loop(u16),
+  Loop(Label),
+
+  /// Push an exception handler onto the fiber
+  PushHandler((u16, Label)),
+
+  /// Pop an exception handler off the fiber
+  PopHandler,
+
+  /// Are marked location
+  Label(Label),
 
   /// Call a function
   Call(u8),
@@ -206,249 +243,14 @@ pub enum AlignedByteCode {
   LessEqual,
 }
 
-impl AlignedByteCode {
-  /// Decode unaligned bytecode to aligned bytecode. Primarily for testing purposes
-  #[cfg(any(test, feature = "debug"))]
-  pub fn decode(store: &[u8], offset: usize) -> (AlignedByteCode, usize) {
-    let byte_code = ByteCode::from(store[offset]);
-
-    match byte_code {
-      ByteCode::Return => (AlignedByteCode::Return, offset + 1),
-      ByteCode::Negate => (AlignedByteCode::Negate, offset + 1),
-      ByteCode::Add => (AlignedByteCode::Add, offset + 1),
-      ByteCode::Subtract => (AlignedByteCode::Subtract, offset + 1),
-      ByteCode::Multiply => (AlignedByteCode::Multiply, offset + 1),
-      ByteCode::Divide => (AlignedByteCode::Divide, offset + 1),
-      ByteCode::And => (
-        AlignedByteCode::And(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Or => (
-        AlignedByteCode::Or(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Not => (AlignedByteCode::Not, offset + 1),
-      ByteCode::Constant => (AlignedByteCode::Constant(store[offset + 1]), offset + 2),
-      ByteCode::ConstantLong => (
-        AlignedByteCode::ConstantLong(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Nil => (AlignedByteCode::Nil, offset + 1),
-      ByteCode::True => (AlignedByteCode::True, offset + 1),
-      ByteCode::False => (AlignedByteCode::False, offset + 1),
-      ByteCode::List => (
-        AlignedByteCode::List(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Tuple => (
-        AlignedByteCode::Tuple(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Map => (
-        AlignedByteCode::Map(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Launch => (AlignedByteCode::Launch(store[offset + 1]), offset + 2),
-      ByteCode::Channel => (AlignedByteCode::Channel, offset + 1),
-      ByteCode::BufferedChannel => (AlignedByteCode::BufferedChannel, offset + 1),
-      ByteCode::Receive => (AlignedByteCode::Receive, offset + 1),
-      ByteCode::Send => (AlignedByteCode::Send, offset + 1),
-      ByteCode::Interpolate => (
-        AlignedByteCode::Interpolate(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::IterNext => (
-        AlignedByteCode::IterNext(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::IterCurrent => (
-        AlignedByteCode::IterCurrent(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Drop => (AlignedByteCode::Drop, offset + 1),
-      ByteCode::DropN => (AlignedByteCode::DropN(store[offset + 1]), offset + 2),
-      ByteCode::Dup => (AlignedByteCode::Dup, offset + 1),
-      ByteCode::Import => (
-        AlignedByteCode::Import(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::ImportSymbol => (
-        AlignedByteCode::ImportSymbol((
-          decode_u16(&store[offset + 1..offset + 3]),
-          decode_u16(&store[offset + 3..offset + 5]),
-        )),
-        offset + 5,
-      ),
-      ByteCode::Export => (
-        AlignedByteCode::Export(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::DefineGlobal => (
-        AlignedByteCode::DefineGlobal(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::GetGlobal => (
-        AlignedByteCode::GetGlobal(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::SetGlobal => (
-        AlignedByteCode::SetGlobal(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Box => (AlignedByteCode::Box(store[offset + 1]), offset + 2),
-      ByteCode::EmptyBox => (AlignedByteCode::EmptyBox, offset + 1),
-      ByteCode::FillBox => (AlignedByteCode::FillBox, offset + 1),
-      ByteCode::GetBox => (AlignedByteCode::GetBox(store[offset + 1]), offset + 2),
-      ByteCode::SetBox => (AlignedByteCode::SetBox(store[offset + 1]), offset + 2),
-      ByteCode::GetLocal => (AlignedByteCode::GetLocal(store[offset + 1]), offset + 2),
-      ByteCode::SetLocal => (AlignedByteCode::SetLocal(store[offset + 1]), offset + 2),
-      ByteCode::GetCapture => (AlignedByteCode::GetCapture(store[offset + 1]), offset + 2),
-      ByteCode::SetCapture => (AlignedByteCode::SetCapture(store[offset + 1]), offset + 2),
-      ByteCode::GetProperty => (
-        AlignedByteCode::GetProperty(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::SetProperty => (
-        AlignedByteCode::SetProperty(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::JumpIfFalse => (
-        AlignedByteCode::JumpIfFalse(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Jump => (
-        AlignedByteCode::Jump(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Loop => (
-        AlignedByteCode::Loop(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Call => (AlignedByteCode::Call(store[offset + 1]), offset + 2),
-      ByteCode::Invoke => (
-        AlignedByteCode::Invoke((
-          decode_u16(&store[offset + 1..offset + 3]),
-          store[offset + 3],
-        )),
-        offset + 4,
-      ),
-      ByteCode::SuperInvoke => (
-        AlignedByteCode::SuperInvoke((
-          decode_u16(&store[offset + 1..offset + 3]),
-          store[offset + 3],
-        )),
-        offset + 4,
-      ),
-      ByteCode::Closure => (
-        AlignedByteCode::Closure(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Method => (
-        AlignedByteCode::Method(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Field => (
-        AlignedByteCode::Field(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::StaticMethod => (
-        AlignedByteCode::StaticMethod(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Class => (
-        AlignedByteCode::Class(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Inherit => (AlignedByteCode::Inherit, offset + 1),
-      ByteCode::GetSuper => (
-        AlignedByteCode::GetSuper(decode_u16(&store[offset + 1..offset + 3])),
-        offset + 3,
-      ),
-      ByteCode::Equal => (AlignedByteCode::Equal, offset + 1),
-      ByteCode::NotEqual => (AlignedByteCode::NotEqual, offset + 1),
-      ByteCode::Greater => (AlignedByteCode::Greater, offset + 1),
-      ByteCode::GreaterEqual => (AlignedByteCode::GreaterEqual, offset + 1),
-      ByteCode::Less => (AlignedByteCode::Less, offset + 1),
-      ByteCode::LessEqual => (AlignedByteCode::LessEqual, offset + 1),
-    }
-  }
-
-  /// What effect will this instruction have on the stack
-  pub const fn stack_effect(&self) -> i32 {
-    match self {
-      AlignedByteCode::Return => 0,
-      AlignedByteCode::Negate => 0,
-      AlignedByteCode::Add => -1,
-      AlignedByteCode::Subtract => -1,
-      AlignedByteCode::Multiply => -1,
-      AlignedByteCode::Divide => -1,
-      AlignedByteCode::Not => 0,
-      AlignedByteCode::And(_) => -1,
-      AlignedByteCode::Or(_) => -1,
-      AlignedByteCode::Constant(_) => 1,
-      AlignedByteCode::ConstantLong(_) => 1,
-      AlignedByteCode::Nil => 1,
-      AlignedByteCode::True => 1,
-      AlignedByteCode::False => 1,
-      AlignedByteCode::List(cnt) => -(*cnt as i32) + 1,
-      AlignedByteCode::Tuple(cnt) => -(*cnt as i32) + 1,
-      AlignedByteCode::Map(cnt) => -(*cnt as i32 * 2) + 1,
-      AlignedByteCode::Launch(args) => -(*args as i32 + 1),
-      AlignedByteCode::Channel => 1,
-      AlignedByteCode::BufferedChannel => 0,
-      AlignedByteCode::Receive => 0,
-      AlignedByteCode::Send => 0,
-      AlignedByteCode::Interpolate(cnt) => -(*cnt as i32) + 1,
-      AlignedByteCode::IterNext(_) => 0,
-      AlignedByteCode::IterCurrent(_) => 0,
-      AlignedByteCode::Drop => -1,
-      AlignedByteCode::DropN(cnt) => -(*cnt as i32),
-      AlignedByteCode::Dup => 1,
-      AlignedByteCode::Import(_) => 1,
-      AlignedByteCode::ImportSymbol(_) => 1,
-      AlignedByteCode::Export(_) => 0,
-      AlignedByteCode::DefineGlobal(_) => -1,
-      AlignedByteCode::GetGlobal(_) => 1,
-      AlignedByteCode::SetGlobal(_) => 0,
-      AlignedByteCode::Box(_) => 0,
-      AlignedByteCode::EmptyBox => 1,
-      AlignedByteCode::FillBox => -1,
-      AlignedByteCode::GetBox(_) => 1,
-      AlignedByteCode::SetBox(_) => 0,
-      AlignedByteCode::GetLocal(_) => 1,
-      AlignedByteCode::SetLocal(_) => 0,
-      AlignedByteCode::GetCapture(_) => 1,
-      AlignedByteCode::SetCapture(_) => 0,
-      AlignedByteCode::GetProperty(_) => 0,
-      AlignedByteCode::SetProperty(_) => -1,
-      AlignedByteCode::JumpIfFalse(_) => -1,
-      AlignedByteCode::Jump(_) => 0,
-      AlignedByteCode::Loop(_) => 0,
-      AlignedByteCode::Call(args) => -(*args as i32),
-      AlignedByteCode::Invoke((_, args)) => -(*args as i32),
-      AlignedByteCode::SuperInvoke((_, args)) => -(*args as i32 + 1),
-      AlignedByteCode::Closure(_) => 1,
-      AlignedByteCode::Method(_) => -1,
-      AlignedByteCode::Field(_) => 0,
-      AlignedByteCode::StaticMethod(_) => -1,
-      AlignedByteCode::Class(_) => 1,
-      AlignedByteCode::Inherit => 0,
-      AlignedByteCode::GetSuper(_) => -1,
-      AlignedByteCode::CaptureIndex(_) => 0,
-      AlignedByteCode::Slot(_) => 0,
-      AlignedByteCode::Equal => -1,
-      AlignedByteCode::NotEqual => -1,
-      AlignedByteCode::Greater => -1,
-      AlignedByteCode::GreaterEqual => -1,
-      AlignedByteCode::Less => -1,
-      AlignedByteCode::LessEqual => -1,
-    }
-  }
-}
-
-impl Encode for AlignedByteCode {
+impl SymbolicByteCode {
   /// Encode aligned bytecode as unaligned bytecode for better storage / compactness
-  fn encode(self, code: &mut Vec<u8>) -> u32 {
+  fn encode(
+    self,
+    code: &mut Vec<u8>,
+    label_offsets: &[usize],
+    offset: usize,
+  ) -> Option<Diagnostic<VmFileId>> {
     match self {
       Self::Return => op(code, ByteCode::Return),
       Self::Negate => op(code, ByteCode::Negate),
@@ -456,8 +258,14 @@ impl Encode for AlignedByteCode {
       Self::Subtract => op(code, ByteCode::Subtract),
       Self::Multiply => op(code, ByteCode::Multiply),
       Self::Divide => op(code, ByteCode::Divide),
-      Self::And(slot) => op_short(code, ByteCode::And, slot),
-      Self::Or(slot) => op_short(code, ByteCode::Or, slot),
+      Self::And(target) => {
+        let jump = label_offsets[target.0 as usize] - offset - 3;
+        op_jump(code, ByteCode::And, jump)
+      },
+      Self::Or(target) => {
+        let jump = label_offsets[target.0 as usize] - offset - 3;
+        op_jump(code, ByteCode::Or, jump)
+      },
       Self::Not => op(code, ByteCode::Not),
       Self::Nil => op(code, ByteCode::Nil),
       Self::True => op(code, ByteCode::True),
@@ -486,8 +294,7 @@ impl Encode for AlignedByteCode {
       Self::ConstantLong(slot) => op_short(code, ByteCode::ConstantLong, slot),
       Self::Import(path) => op_short(code, ByteCode::Import, path),
       Self::ImportSymbol((path, slot)) => {
-        push_op_u16_tuple(code, ByteCode::ImportSymbol, path, slot);
-        4
+        push_op_u16_tuple(code, ByteCode::ImportSymbol, path, slot)
       },
       Self::Export(slot) => op_short(code, ByteCode::Export, slot),
       Self::DefineGlobal(slot) => op_short(code, ByteCode::DefineGlobal, slot),
@@ -504,17 +311,28 @@ impl Encode for AlignedByteCode {
       Self::SetCapture(slot) => op_byte(code, ByteCode::SetCapture, slot),
       Self::GetProperty(slot) => op_short(code, ByteCode::GetProperty, slot),
       Self::SetProperty(slot) => op_short(code, ByteCode::SetProperty, slot),
-      Self::JumpIfFalse(slot) => op_short(code, ByteCode::JumpIfFalse, slot),
-      Self::Jump(slot) => op_short(code, ByteCode::Jump, slot),
-      Self::Loop(slot) => op_short(code, ByteCode::Loop, slot),
-      Self::Call(slot) => op_byte(code, ByteCode::Call, slot),
-      Self::Invoke((slot1, slot2)) => {
-        push_op_u16_u8_tuple(code, ByteCode::Invoke, slot1, slot2);
-        4
+      Self::JumpIfFalse(target) => {
+        let jump = label_offsets[target.0 as usize] - offset - 3;
+        op_jump(code, ByteCode::JumpIfFalse, jump)
       },
+      Self::Jump(target) => {
+        let jump = label_offsets[target.0 as usize] - offset - 3;
+        op_jump(code, ByteCode::Jump, jump)
+      },
+      Self::Loop(target) => {
+        let jump = offset - label_offsets[target.0 as usize] + 3;
+        op_jump(code, ByteCode::Loop, jump)
+      },
+      Self::PushHandler((slots, target)) => {
+        let jump = label_offsets[target.0 as usize] - offset - 5;
+        push_op_u16_tuple(code, ByteCode::PushHandler, slots, (jump) as u16);
+        jump_error(jump)
+      },
+      Self::PopHandler => op(code, ByteCode::PopHandler),
+      Self::Call(slot) => op_byte(code, ByteCode::Call, slot),
+      Self::Invoke((slot1, slot2)) => push_op_u16_u8_tuple(code, ByteCode::Invoke, slot1, slot2),
       Self::SuperInvoke((slot1, slot2)) => {
-        push_op_u16_u8_tuple(code, ByteCode::SuperInvoke, slot1, slot2);
-        4
+        push_op_u16_u8_tuple(code, ByteCode::SuperInvoke, slot1, slot2)
       },
       Self::Closure(slot) => op_short(code, ByteCode::Closure, slot),
       Self::Method(slot) => op_short(code, ByteCode::Method, slot),
@@ -527,40 +345,312 @@ impl Encode for AlignedByteCode {
         let encoded: u16 = unsafe { mem::transmute(index) };
         let bytes = encoded.to_ne_bytes();
         code.extend_from_slice(&bytes);
-        3
+        None
       },
       Self::Slot(slot) => {
         let bytes = slot.to_ne_bytes();
         code.extend_from_slice(&bytes);
-        5
+        None
       },
+      Self::Label(_) => None,
+    }
+  }
+
+  /// What is the len of this instruction once encoded
+  pub const fn len(&self) -> usize {
+    match self {
+      Self::Return => 1,
+      Self::Negate => 1,
+      Self::Add => 1,
+      Self::Subtract => 1,
+      Self::Multiply => 1,
+      Self::Divide => 1,
+      Self::Not => 1,
+      Self::And(_) => 3,
+      Self::Or(_) => 3,
+      Self::Constant(_) => 2,
+      Self::ConstantLong(_) => 3,
+      Self::Nil => 1,
+      Self::True => 1,
+      Self::False => 1,
+      Self::List(_) => 3,
+      Self::Tuple(_) => 3,
+      Self::Map(_) => 3,
+      Self::Launch(_) => 2,
+      Self::Channel => 1,
+      Self::BufferedChannel => 1,
+      Self::Receive => 1,
+      Self::Send => 1,
+      Self::Interpolate(_) => 3,
+      Self::IterNext(_) => 3,
+      Self::IterCurrent(_) => 3,
+      Self::Drop => 1,
+      Self::DropN(_) => 2,
+      Self::Dup => 1,
+      Self::Import(_) => 3,
+      Self::ImportSymbol(_) => 5,
+      Self::Export(_) => 3,
+      Self::DefineGlobal(_) => 3,
+      Self::GetGlobal(_) => 3,
+      Self::SetGlobal(_) => 3,
+      Self::Box(_) => 2,
+      Self::EmptyBox => 1,
+      Self::FillBox => 1,
+      Self::GetBox(_) => 2,
+      Self::SetBox(_) => 2,
+      Self::GetLocal(_) => 2,
+      Self::SetLocal(_) => 2,
+      Self::GetCapture(_) => 2,
+      Self::SetCapture(_) => 2,
+      Self::GetProperty(_) => 3,
+      Self::SetProperty(_) => 3,
+      Self::JumpIfFalse(_) => 3,
+      Self::Jump(_) => 3,
+      Self::Loop(_) => 3,
+      Self::PushHandler(_) => 5,
+      Self::PopHandler => 1,
+      Self::Call(_) => 2,
+      Self::Invoke((_, _)) => 4,
+      Self::SuperInvoke((_, _)) => 4,
+      Self::Closure(_) => 3,
+      Self::Method(_) => 3,
+      Self::Field(_) => 3,
+      Self::StaticMethod(_) => 3,
+      Self::Class(_) => 3,
+      Self::Inherit => 1,
+      Self::GetSuper(_) => 3,
+      Self::CaptureIndex(_) => 2,
+      Self::Slot(_) => 4,
+      Self::Equal => 1,
+      Self::NotEqual => 1,
+      Self::Greater => 1,
+      Self::GreaterEqual => 1,
+      Self::Less => 1,
+      Self::LessEqual => 1,
+      Self::Label(_) => 0,
+    }
+  }
+
+  /// What effect will this instruction have on the stack
+  pub const fn stack_effect(&self) -> i32 {
+    match self {
+      Self::Return => 0,
+      Self::Negate => 0,
+      Self::Add => -1,
+      Self::Subtract => -1,
+      Self::Multiply => -1,
+      Self::Divide => -1,
+      Self::Not => 0,
+      Self::And(_) => -1,
+      Self::Or(_) => -1,
+      Self::Constant(_) => 1,
+      Self::ConstantLong(_) => 1,
+      Self::Nil => 1,
+      Self::True => 1,
+      Self::False => 1,
+      Self::List(cnt) => -(*cnt as i32) + 1,
+      Self::Tuple(cnt) => -(*cnt as i32) + 1,
+      Self::Map(cnt) => -(*cnt as i32 * 2) + 1,
+      Self::Launch(args) => -(*args as i32 + 1),
+      Self::Channel => 1,
+      Self::BufferedChannel => 0,
+      Self::Receive => 0,
+      Self::Send => 0,
+      Self::Interpolate(cnt) => -(*cnt as i32) + 1,
+      Self::IterNext(_) => 0,
+      Self::IterCurrent(_) => 0,
+      Self::Drop => -1,
+      Self::DropN(cnt) => -(*cnt as i32),
+      Self::Dup => 1,
+      Self::Import(_) => 1,
+      Self::ImportSymbol(_) => 1,
+      Self::Export(_) => 0,
+      Self::DefineGlobal(_) => -1,
+      Self::GetGlobal(_) => 1,
+      Self::SetGlobal(_) => 0,
+      Self::Box(_) => 0,
+      Self::EmptyBox => 1,
+      Self::FillBox => -1,
+      Self::GetBox(_) => 1,
+      Self::SetBox(_) => 0,
+      Self::GetLocal(_) => 1,
+      Self::SetLocal(_) => 0,
+      Self::GetCapture(_) => 1,
+      Self::SetCapture(_) => 0,
+      Self::GetProperty(_) => 0,
+      Self::SetProperty(_) => -1,
+      Self::JumpIfFalse(_) => -1,
+      Self::Jump(_) => 0,
+      Self::Loop(_) => 0,
+      Self::PushHandler(_) => 0,
+      Self::PopHandler => 0,
+      Self::Call(args) => -(*args as i32),
+      Self::Invoke((_, args)) => -(*args as i32),
+      Self::SuperInvoke((_, args)) => -(*args as i32 + 1),
+      Self::Closure(_) => 1,
+      Self::Method(_) => -1,
+      Self::Field(_) => 0,
+      Self::StaticMethod(_) => -1,
+      Self::Class(_) => 1,
+      Self::Inherit => 0,
+      Self::GetSuper(_) => -1,
+      Self::CaptureIndex(_) => 0,
+      Self::Slot(_) => 0,
+      Self::Equal => -1,
+      Self::NotEqual => -1,
+      Self::Greater => -1,
+      Self::GreaterEqual => -1,
+      Self::Less => -1,
+      Self::LessEqual => -1,
+      Self::Label(_) => 0,
     }
   }
 }
 
-impl Default for AlignedByteCode {
-  fn default() -> Self {
-    AlignedByteCode::Nil
+impl Encode for SymbolicByteCode {
+  type Error = Vec<Diagnostic<VmFileId>>;
+
+  fn encode(instructions: Vec<Self>, mut lines: Vec<Line>) -> Result<(Vec<u8>, Vec<Line>), Self::Error> {
+    let mut label_offsets: [usize; u16::MAX as usize] = [0; u16::MAX as usize];
+    let label_count = label_count(&instructions);
+
+    if label_count > u16::MAX as usize {
+      todo!("Really handle this");
+    }
+
+    compute_label_offsets(&instructions, &mut label_offsets[..label_count]);
+
+    let mut buffer = Vec::with_capacity(instructions.len());
+    let mut offset: usize = 0;
+
+    let mut lines_iter = lines.iter_mut();
+    let mut line_option = lines_iter.next();
+    let mut errors = vec![];
+
+    for (index, instruction) in instructions.iter().enumerate() {
+      if let Some(error) = instruction.encode(&mut buffer, &label_offsets[..label_count], offset) {
+        errors.push(error);
+      }
+      offset += instruction.len();
+
+      if let Some(line) = &mut line_option {
+        if index + 1 == line.offset as usize {
+          line.offset = offset as u32;
+          line_option = lines_iter.next();
+        }
+      }
+    }
+
+    if errors.is_empty() {
+      Ok((buffer, lines))
+    } else {
+      Err(errors)
+    }
   }
 }
 
-fn op(code: &mut Vec<u8>, byte_code: ByteCode) -> u32 {
+fn jump_error(jump: usize) -> Option<Diagnostic<VmFileId>> {
+  if jump > u16::MAX as usize {
+    Some(Diagnostic::error().with_message("Unable to jump so far."))
+  } else {
+    None
+  }
+}
+
+fn label_count(instructions: &[SymbolicByteCode]) -> usize {
+  let mut count = 0;
+
+  for instruction in instructions {
+    if let SymbolicByteCode::Label(_) = instruction {
+      count += 1;
+    }
+  }
+
+  count
+}
+
+fn compute_label_offsets(instructions: &[SymbolicByteCode], label_offsets: &mut [usize]) {
+  let mut offset: usize = 0;
+
+  for instruction in instructions {
+    if let SymbolicByteCode::Label(label) = instruction {
+      label_offsets[label.0 as usize] = offset;
+    }
+
+    offset += instruction.len()
+  }
+}
+
+impl Default for SymbolicByteCode {
+  fn default() -> Self {
+    SymbolicByteCode::Nil
+  }
+}
+
+fn op(code: &mut Vec<u8>, byte_code: ByteCode) -> Option<Diagnostic<VmFileId>> {
   push_op(code, byte_code);
-  1
+  None
 }
 
-fn op_byte(code: &mut Vec<u8>, byte_code: ByteCode, byte: u8) -> u32 {
+fn op_byte(code: &mut Vec<u8>, byte_code: ByteCode, byte: u8) -> Option<Diagnostic<VmFileId>> {
   push_op_u8(code, byte_code, byte);
-  2
+  None
 }
 
-fn op_short(code: &mut Vec<u8>, byte_code: ByteCode, short: u16) -> u32 {
+fn op_jump(code: &mut Vec<u8>, byte_code: ByteCode, jump: usize) -> Option<Diagnostic<VmFileId>> {
+  op_short(code, byte_code, jump as u16);
+  jump_error(jump)
+}
+
+fn op_short(code: &mut Vec<u8>, byte_code: ByteCode, short: u16) -> Option<Diagnostic<VmFileId>> {
   push_op_u16(code, byte_code, short);
-  3
+  None
 }
 
-/// Space Lox virtual machine byte codes
-#[derive(Debug, PartialEq, Clone, Copy)]
+fn push_op(code: &mut Vec<u8>, byte: ByteCode) {
+  code.push(byte.to_byte());
+}
+
+fn push_op_u8(code: &mut Vec<u8>, byte: ByteCode, param: u8) {
+  code.push(byte.to_byte());
+  code.push(param);
+}
+
+fn push_op_u16_u8_tuple(
+  code: &mut Vec<u8>,
+  byte: ByteCode,
+  param1: u16,
+  param2: u8,
+) -> Option<Diagnostic<VmFileId>> {
+  code.push(byte.to_byte());
+  let param_bytes = param1.to_ne_bytes();
+  code.extend_from_slice(&param_bytes);
+  code.push(param2);
+  None
+}
+
+fn push_op_u16(code: &mut Vec<u8>, byte: ByteCode, param: u16) {
+  let param_bytes = param.to_ne_bytes();
+  code.push(byte.to_byte());
+  code.extend_from_slice(&param_bytes);
+}
+
+fn push_op_u16_tuple(
+  code: &mut Vec<u8>,
+  byte: ByteCode,
+  param1: u16,
+  param2: u16,
+) -> Option<Diagnostic<VmFileId>> {
+  code.push(byte.to_byte());
+  let param_bytes = param1.to_ne_bytes();
+  code.extend_from_slice(&param_bytes);
+  let param_bytes = param2.to_ne_bytes();
+  code.extend_from_slice(&param_bytes);
+  None
+}
+
+/// Laythe virtual machine byte codes
+#[derive(Debug, PartialEq, Clone, Copy, VariantCount)]
 pub enum ByteCode {
   /// Return from script or function
   Return,
@@ -706,6 +796,12 @@ pub enum ByteCode {
   /// Jump to loop beginning
   Loop,
 
+  /// Push an exception handler onto the fiber
+  PushHandler,
+
+  /// Pop an exception handler off the fiber
+  PopHandler,
+
   /// Call a function
   Call,
 
@@ -760,23 +856,410 @@ impl ByteCode {
   fn to_byte(self) -> u8 {
     unsafe { mem::transmute(self) }
   }
-}
 
-impl From<u8> for ByteCode {
-  /// Get the enum bytecode for a raw byte
-  #[inline]
-  fn from(byte: u8) -> Self {
+  #[cfg(any(test, feature = "debug"))]
+  pub fn from_byte(byte: u8) -> Self {
+    if byte as usize >= ByteCode::VARIANT_COUNT {
+      panic!(
+        "Value {} is out of range {} byte code variants",
+        byte,
+        ByteCode::VARIANT_COUNT
+      );
+    }
+
     unsafe { mem::transmute(byte) }
+  }
+
+  pub unsafe fn from_byte_unchecked(byte: u8) -> Self {
+    mem::transmute(byte)
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum CaptureIndex {
-  /// The capture is in the local function
-  Local(u8),
+/// Laythe virtual machine byte codes
+#[cfg(any(test, feature = "debug"))]
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub enum AlignedByteCode {
+  /// Return from script or function
+  Return,
 
-  /// The capture points to the enclosing function
-  Enclosing(u8),
+  /// Negate a value
+  Negate,
+
+  /// Add the top two operands on the stack
+  Add,
+
+  /// Subtract the top two operands on the stack
+  Subtract,
+
+  /// Multiply the top two operands on the stack
+  Multiply,
+
+  /// Divide the top two operands on the stack
+  Divide,
+
+  /// Apply Not operator to top stack element
+  Not,
+
+  /// Perform a logical and operator
+  And(u16),
+
+  /// Perform a logical or operator
+  Or(u16),
+
+  /// Retrieve a constant from the constants table
+  Constant(u8),
+
+  /// Retrieve a constant of higher number from the constants table
+  ConstantLong(u16),
+
+  /// Nil literal
+  Nil,
+
+  /// True Literal
+  True,
+
+  /// False ByteCode
+  False,
+
+  /// Initialize list from literal
+  List(u16),
+
+  /// Initialize list from literal
+  Tuple(u16),
+
+  /// Initialize map from literal
+  Map(u16),
+
+  /// Launch a fiber
+  Launch(u8),
+
+  /// Initialize a channel
+  Channel,
+
+  /// Initialize a channel
+  BufferedChannel,
+
+  /// Receive from a channel
+  Receive,
+
+  /// Send to a channel
+  Send,
+
+  /// Combine string interpolation
+  Interpolate(u16),
+
+  /// Get the next element from an iterator
+  IterNext(u16),
+
+  /// Get the current value from an iterator
+  IterCurrent(u16),
+
+  /// Drop a value
+  Drop,
+
+  /// Drop n values
+  DropN(u8),
+
+  /// Duplicate top of the stack
+  Dup,
+
+  /// Import all symbols
+  Import(u16),
+
+  /// Import a single symbol
+  ImportSymbol((u16, u16)),
+
+  /// Export a symbol from the current module
+  Export(u16),
+
+  /// Define a global in the globals table at a index
+  DefineGlobal(u16),
+
+  /// Retrieve a global at the given index
+  GetGlobal(u16),
+
+  /// Set a global at the given index
+  SetGlobal(u16),
+
+  /// Box a local at a given index,
+  Box(u8),
+
+  /// Create a new empty box
+  EmptyBox,
+
+  /// Move top of stack into box
+  FillBox,
+
+  /// Get a box local at the given index
+  GetBox(u8),
+
+  /// Set a box local at the given index
+  SetBox(u8),
+
+  /// Get a local at the given index
+  GetLocal(u8),
+
+  /// Set a local at the given index
+  SetLocal(u8),
+
+  /// Get a box local at the given index
+  GetCapture(u8),
+
+  /// Set a box local at the given index
+  SetCapture(u8),
+
+  /// Get a property off a class instance
+  GetProperty(u16),
+
+  /// Set a property on a class instance
+  SetProperty(u16),
+
+  /// Jump to end of if block if false
+  JumpIfFalse(u16),
+
+  /// Jump conditionally to the ip
+  Jump(u16),
+
+  /// Jump to loop beginning
+  Loop(u16),
+
+  /// Push an exception handler onto the fiber
+  PushHandler((u16, u16)),
+
+  /// Pop an exception handler off the fiber
+  PopHandler,
+
+  /// Call a function
+  Call(u8),
+
+  /// Invoke a method
+  Invoke((u16, u8)),
+
+  /// Invoke a method on a super class
+  SuperInvoke((u16, u8)),
+
+  /// Create a closure
+  Closure(u16),
+
+  /// Create a method
+  Method(u16),
+
+  /// Create a field
+  Field(u16),
+
+  /// Create a static method
+  StaticMethod(u16),
+
+  /// Create a class
+  Class(u16),
+
+  /// Inherit from another class
+  Inherit,
+
+  /// Access this classes super
+  GetSuper(u16),
+
+  // An capture index for a closure
+  #[allow(dead_code)]
+  CaptureIndex(CaptureIndex),
+
+  /// A inline cache slot
+  #[allow(dead_code)]
+  Slot(u32),
+
+  /// Apply equality between the top two operands on the stack
+  Equal,
+
+  /// Check if the top two operands on the stack are not equal
+  NotEqual,
+
+  /// Apply greater between the top two operands on the stack
+  Greater,
+
+  /// Check if the 2nd from the top operand is >= the top
+  GreaterEqual,
+
+  /// Less greater between the top two operands on the stack
+  Less,
+
+  /// Check if the 2nd from the top operand is <= the top
+  LessEqual,
+}
+
+#[cfg(any(test, feature = "debug"))]
+impl AlignedByteCode {
+  /// Decode unaligned bytecode to aligned bytecode. Primarily for testing purposes
+  pub fn decode(store: &[u8], offset: usize) -> (AlignedByteCode, usize) {
+    let byte_code = ByteCode::from_byte(store[offset]);
+
+    match byte_code {
+      ByteCode::Return => (Self::Return, offset + 1),
+      ByteCode::Negate => (Self::Negate, offset + 1),
+      ByteCode::Add => (Self::Add, offset + 1),
+      ByteCode::Subtract => (Self::Subtract, offset + 1),
+      ByteCode::Multiply => (Self::Multiply, offset + 1),
+      ByteCode::Divide => (Self::Divide, offset + 1),
+      ByteCode::And => (
+        Self::And(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Or => (
+        Self::Or(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Not => (Self::Not, offset + 1),
+      ByteCode::Constant => (Self::Constant(store[offset + 1]), offset + 2),
+      ByteCode::ConstantLong => (
+        Self::ConstantLong(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Nil => (Self::Nil, offset + 1),
+      ByteCode::True => (Self::True, offset + 1),
+      ByteCode::False => (Self::False, offset + 1),
+      ByteCode::List => (
+        Self::List(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Tuple => (
+        Self::Tuple(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Map => (
+        Self::Map(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Launch => (Self::Launch(store[offset + 1]), offset + 2),
+      ByteCode::Channel => (Self::Channel, offset + 1),
+      ByteCode::BufferedChannel => (Self::BufferedChannel, offset + 1),
+      ByteCode::Receive => (Self::Receive, offset + 1),
+      ByteCode::Send => (Self::Send, offset + 1),
+      ByteCode::Interpolate => (
+        Self::Interpolate(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::IterNext => (
+        Self::IterNext(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::IterCurrent => (
+        Self::IterCurrent(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Drop => (Self::Drop, offset + 1),
+      ByteCode::DropN => (Self::DropN(store[offset + 1]), offset + 2),
+      ByteCode::Dup => (Self::Dup, offset + 1),
+      ByteCode::Import => (
+        Self::Import(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::ImportSymbol => (
+        Self::ImportSymbol((
+          decode_u16(&store[offset + 1..offset + 3]),
+          decode_u16(&store[offset + 3..offset + 5]),
+        )),
+        offset + 5,
+      ),
+      ByteCode::Export => (
+        Self::Export(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::DefineGlobal => (
+        Self::DefineGlobal(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::GetGlobal => (
+        Self::GetGlobal(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::SetGlobal => (
+        Self::SetGlobal(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Box => (Self::Box(store[offset + 1]), offset + 2),
+      ByteCode::EmptyBox => (Self::EmptyBox, offset + 1),
+      ByteCode::FillBox => (Self::FillBox, offset + 1),
+      ByteCode::GetBox => (Self::GetBox(store[offset + 1]), offset + 2),
+      ByteCode::SetBox => (Self::SetBox(store[offset + 1]), offset + 2),
+      ByteCode::GetLocal => (Self::GetLocal(store[offset + 1]), offset + 2),
+      ByteCode::SetLocal => (Self::SetLocal(store[offset + 1]), offset + 2),
+      ByteCode::GetCapture => (Self::GetCapture(store[offset + 1]), offset + 2),
+      ByteCode::SetCapture => (Self::SetCapture(store[offset + 1]), offset + 2),
+      ByteCode::GetProperty => (
+        Self::GetProperty(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::SetProperty => (
+        Self::SetProperty(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::JumpIfFalse => (
+        Self::JumpIfFalse(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Jump => (
+        Self::Jump(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Loop => (
+        Self::Loop(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::PushHandler => (
+        Self::PushHandler((
+          decode_u16(&store[offset + 1..offset + 3]),
+          decode_u16(&store[offset + 3..offset + 5]),
+        )),
+        offset + 5,
+      ),
+      ByteCode::PopHandler => (Self::PopHandler, offset + 1),
+      ByteCode::Call => (Self::Call(store[offset + 1]), offset + 2),
+      ByteCode::Invoke => (
+        Self::Invoke((
+          decode_u16(&store[offset + 1..offset + 3]),
+          store[offset + 3],
+        )),
+        offset + 4,
+      ),
+      ByteCode::SuperInvoke => (
+        Self::SuperInvoke((
+          decode_u16(&store[offset + 1..offset + 3]),
+          store[offset + 3],
+        )),
+        offset + 4,
+      ),
+      ByteCode::Closure => (
+        Self::Closure(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Method => (
+        Self::Method(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Field => (
+        Self::Field(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::StaticMethod => (
+        Self::StaticMethod(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Class => (
+        Self::Class(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Inherit => (Self::Inherit, offset + 1),
+      ByteCode::GetSuper => (
+        Self::GetSuper(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::Equal => (Self::Equal, offset + 1),
+      ByteCode::NotEqual => (Self::NotEqual, offset + 1),
+      ByteCode::Greater => (Self::Greater, offset + 1),
+      ByteCode::GreaterEqual => (Self::GreaterEqual, offset + 1),
+      ByteCode::Less => (Self::Less, offset + 1),
+      ByteCode::LessEqual => (Self::LessEqual, offset + 1),
+    }
+  }
 }
 
 #[cfg(any(test, feature = "debug"))]
@@ -791,120 +1274,106 @@ pub fn decode_u16(buffer: &[u8]) -> u16 {
   u16::from_ne_bytes(arr)
 }
 
-fn push_op(code: &mut Vec<u8>, byte: ByteCode) {
-  code.push(byte.to_byte());
-}
-
-fn push_op_u8(code: &mut Vec<u8>, byte: ByteCode, param: u8) {
-  code.push(byte.to_byte());
-  code.push(param);
-}
-
-fn push_op_u16_u8_tuple(code: &mut Vec<u8>, byte: ByteCode, param1: u16, param2: u8) {
-  code.push(byte.to_byte());
-  let param_bytes = param1.to_ne_bytes();
-  code.extend_from_slice(&param_bytes);
-  code.push(param2);
-}
-
-fn push_op_u16(code: &mut Vec<u8>, byte: ByteCode, param: u16) {
-  let param_bytes = param.to_ne_bytes();
-  code.push(byte.to_byte());
-  code.extend_from_slice(&param_bytes);
-}
-
-fn push_op_u16_tuple(code: &mut Vec<u8>, byte: ByteCode, param1: u16, param2: u16) {
-  code.push(byte.to_byte());
-  let param_bytes = param1.to_ne_bytes();
-  code.extend_from_slice(&param_bytes);
-  let param_bytes = param2.to_ne_bytes();
-  code.extend_from_slice(&param_bytes);
-}
-
 #[cfg(test)]
 mod test {
   use super::*;
 
   #[test]
-  fn encode_decode() {
-    let code: Vec<(usize, AlignedByteCode)> = vec![
-      (1, AlignedByteCode::Return),
-      (1, AlignedByteCode::Negate),
-      (1, AlignedByteCode::Add),
-      (1, AlignedByteCode::Subtract),
-      (1, AlignedByteCode::Multiply),
-      (1, AlignedByteCode::Divide),
-      (1, AlignedByteCode::Not),
-      (2, AlignedByteCode::Constant(113)),
-      (3, AlignedByteCode::ConstantLong(45863)),
-      (3, AlignedByteCode::Import(2235)),
-      (5, AlignedByteCode::ImportSymbol((2235, 113))),
-      (3, AlignedByteCode::Export(7811)),
-      (1, AlignedByteCode::Nil),
-      (1, AlignedByteCode::True),
-      (1, AlignedByteCode::False),
-      (3, AlignedByteCode::List(54782)),
-      (3, AlignedByteCode::Tuple(52782)),
-      (3, AlignedByteCode::Map(1923)),
-      (2, AlignedByteCode::Launch(197)),
-      (1, AlignedByteCode::Channel),
-      (1, AlignedByteCode::BufferedChannel),
-      (1, AlignedByteCode::Receive),
-      (1, AlignedByteCode::Send),
-      (2, AlignedByteCode::Box(66)),
-      (1, AlignedByteCode::EmptyBox),
-      (1, AlignedByteCode::FillBox),
-      (3, AlignedByteCode::Interpolate(3389)),
-      (3, AlignedByteCode::IterNext(81)),
-      (3, AlignedByteCode::IterCurrent(49882)),
-      (1, AlignedByteCode::Drop),
-      (3, AlignedByteCode::DefineGlobal(42)),
-      (3, AlignedByteCode::GetGlobal(14119)),
-      (3, AlignedByteCode::SetGlobal(2043)),
-      (3, AlignedByteCode::SetGlobal(38231)),
-      (2, AlignedByteCode::GetBox(183)),
-      (2, AlignedByteCode::SetBox(56)),
-      (2, AlignedByteCode::GetLocal(96)),
-      (2, AlignedByteCode::SetLocal(149)),
-      (2, AlignedByteCode::GetBox(11)),
-      (2, AlignedByteCode::SetBox(197)),
-      (3, AlignedByteCode::GetProperty(18273)),
-      (3, AlignedByteCode::SetProperty(253)),
-      (3, AlignedByteCode::JumpIfFalse(8941)),
-      (3, AlignedByteCode::Jump(95)),
-      (3, AlignedByteCode::Loop(34590)),
-      (2, AlignedByteCode::Call(77)),
-      (4, AlignedByteCode::Invoke((5591, 19))),
-      (4, AlignedByteCode::SuperInvoke((2105, 15))),
-      (3, AlignedByteCode::Closure(3638)),
-      (3, AlignedByteCode::Method(188)),
-      (3, AlignedByteCode::Field(6634)),
-      (3, AlignedByteCode::StaticMethod(4912)),
-      (3, AlignedByteCode::Class(64136)),
-      (1, AlignedByteCode::Inherit),
-      (3, AlignedByteCode::GetSuper(24)),
-      (1, AlignedByteCode::Equal),
-      (1, AlignedByteCode::NotEqual),
-      (1, AlignedByteCode::Greater),
-      (1, AlignedByteCode::GreaterEqual),
-      (1, AlignedByteCode::LessEqual),
+  fn encode_len() {
+    let code: Vec<(usize, SymbolicByteCode)> = vec![
+      (1, SymbolicByteCode::Return),
+      (1, SymbolicByteCode::Negate),
+      (1, SymbolicByteCode::Add),
+      (1, SymbolicByteCode::Subtract),
+      (1, SymbolicByteCode::Multiply),
+      (1, SymbolicByteCode::Divide),
+      (1, SymbolicByteCode::Not),
+      (2, SymbolicByteCode::Constant(113)),
+      (3, SymbolicByteCode::ConstantLong(45863)),
+      (3, SymbolicByteCode::Import(2235)),
+      (5, SymbolicByteCode::ImportSymbol((2235, 113))),
+      (3, SymbolicByteCode::Export(7811)),
+      (3, SymbolicByteCode::JumpIfFalse(Label::new(1))),
+      (3, SymbolicByteCode::Jump(Label::new(1))),
+      (3, SymbolicByteCode::Loop(Label::new(0))),
+      (3, SymbolicByteCode::And(Label::new(1))),
+      (3, SymbolicByteCode::Or(Label::new(1))),
+      (1, SymbolicByteCode::Nil),
+      (1, SymbolicByteCode::True),
+      (1, SymbolicByteCode::False),
+      (3, SymbolicByteCode::List(54782)),
+      (3, SymbolicByteCode::Tuple(52782)),
+      (3, SymbolicByteCode::Map(1923)),
+      (2, SymbolicByteCode::Launch(197)),
+      (1, SymbolicByteCode::Channel),
+      (1, SymbolicByteCode::BufferedChannel),
+      (1, SymbolicByteCode::Receive),
+      (1, SymbolicByteCode::Send),
+      (2, SymbolicByteCode::Box(66)),
+      (1, SymbolicByteCode::EmptyBox),
+      (1, SymbolicByteCode::FillBox),
+      (3, SymbolicByteCode::Interpolate(3389)),
+      (3, SymbolicByteCode::IterNext(81)),
+      (3, SymbolicByteCode::IterCurrent(49882)),
+      (1, SymbolicByteCode::Drop),
+      (3, SymbolicByteCode::DefineGlobal(42)),
+      (3, SymbolicByteCode::GetGlobal(14119)),
+      (3, SymbolicByteCode::SetGlobal(2043)),
+      (3, SymbolicByteCode::SetGlobal(38231)),
+      (2, SymbolicByteCode::GetBox(183)),
+      (2, SymbolicByteCode::SetBox(56)),
+      (2, SymbolicByteCode::GetLocal(96)),
+      (2, SymbolicByteCode::SetLocal(149)),
+      (2, SymbolicByteCode::GetBox(11)),
+      (2, SymbolicByteCode::SetBox(197)),
+      (3, SymbolicByteCode::GetProperty(18273)),
+      (3, SymbolicByteCode::SetProperty(253)),
+      (2, SymbolicByteCode::Call(77)),
+      (4, SymbolicByteCode::Invoke((5591, 19))),
+      (4, SymbolicByteCode::SuperInvoke((2105, 15))),
+      (3, SymbolicByteCode::Closure(3638)),
+      (3, SymbolicByteCode::Method(188)),
+      (3, SymbolicByteCode::Field(6634)),
+      (3, SymbolicByteCode::StaticMethod(4912)),
+      (3, SymbolicByteCode::Class(64136)),
+      (1, SymbolicByteCode::Inherit),
+      (3, SymbolicByteCode::GetSuper(24)),
+      (1, SymbolicByteCode::Equal),
+      (1, SymbolicByteCode::NotEqual),
+      (1, SymbolicByteCode::Greater),
+      (1, SymbolicByteCode::GreaterEqual),
+      (1, SymbolicByteCode::LessEqual),
     ];
 
-    let mut buffer: Vec<u8> = Vec::new();
     for (size1, byte_code1) in &code {
       for (size2, byte_code2) in &code {
-        byte_code1.encode(&mut buffer);
-        byte_code2.encode(&mut buffer);
+        let label_0 = SymbolicByteCode::Label(Label::new(0));
+        let label_1 = SymbolicByteCode::Label(Label::new(1));
 
-        let (decoded1, offset1) = AlignedByteCode::decode(&buffer, 0);
-        let (decoded2, offset2) = AlignedByteCode::decode(&buffer, offset1);
+        let lines = vec![Line::new(0, 2), Line::new(1, 3)];
 
-        assert_eq!(offset1, *size1);
-        assert_eq!(offset2, *size2 + offset1);
-
-        assert_eq!(*byte_code1, decoded1);
-        assert_eq!(*byte_code2, decoded2);
-        buffer.clear();
+        let (encoded, lines) =
+          Encode::encode(vec![label_0, *byte_code1, *byte_code2, label_1], lines).unwrap();
+        assert_eq!(
+          byte_code1.len(),
+          *size1,
+          "byte {:?} expected to be {} size",
+          *byte_code1,
+          *size1
+        );
+        assert_eq!(
+          byte_code2.len(),
+          *size2,
+          "byte {:?} expected to be {} size",
+          *byte_code2,
+          *size2
+        );
+        assert_eq!(lines[0].offset as usize, byte_code1.len());
+        assert_eq!(
+          lines[1].offset as usize,
+          byte_code1.len() + byte_code2.len()
+        );
+        assert_eq!(encoded.len(), byte_code1.len() + byte_code2.len());
       }
     }
   }

--- a/laythe_vm/src/byte_code.rs
+++ b/laythe_vm/src/byte_code.rs
@@ -488,7 +488,7 @@ impl Encode for AlignedByteCode {
       Self::ImportSymbol((path, slot)) => {
         push_op_u16_tuple(code, ByteCode::ImportSymbol, path, slot);
         4
-      }
+      },
       Self::Export(slot) => op_short(code, ByteCode::Export, slot),
       Self::DefineGlobal(slot) => op_short(code, ByteCode::DefineGlobal, slot),
       Self::GetGlobal(slot) => op_short(code, ByteCode::GetGlobal, slot),
@@ -511,11 +511,11 @@ impl Encode for AlignedByteCode {
       Self::Invoke((slot1, slot2)) => {
         push_op_u16_u8_tuple(code, ByteCode::Invoke, slot1, slot2);
         4
-      }
+      },
       Self::SuperInvoke((slot1, slot2)) => {
         push_op_u16_u8_tuple(code, ByteCode::SuperInvoke, slot1, slot2);
         4
-      }
+      },
       Self::Closure(slot) => op_short(code, ByteCode::Closure, slot),
       Self::Method(slot) => op_short(code, ByteCode::Method, slot),
       Self::Field(slot) => op_short(code, ByteCode::Field, slot),
@@ -528,13 +528,19 @@ impl Encode for AlignedByteCode {
         let bytes = encoded.to_ne_bytes();
         code.extend_from_slice(&bytes);
         3
-      }
+      },
       Self::Slot(slot) => {
         let bytes = slot.to_ne_bytes();
         code.extend_from_slice(&bytes);
         5
-      }
+      },
     }
+  }
+}
+
+impl Default for AlignedByteCode {
+  fn default() -> Self {
+    AlignedByteCode::Nil
   }
 }
 

--- a/laythe_vm/src/cache.rs
+++ b/laythe_vm/src/cache.rs
@@ -193,7 +193,7 @@ mod test {
   }
 
   mod inline_cache {
-    use crate::{byte_code::AlignedByteCode, cache::InlineCache};
+    use crate::{byte_code::SymbolicByteCode, cache::InlineCache};
     use laythe_core::{
       hooks::{GcHooks, NoContext},
       memory::{Allocator, NO_GC},
@@ -241,7 +241,7 @@ mod test {
       let class = hooks.manage_obj(Class::bare(class_name));
       let module = hooks.manage(Module::new(class, 0));
 
-      let fun = Fun::stub(&hooks, fun_name, module, AlignedByteCode::Nil);
+      let fun = Fun::stub(&hooks, fun_name, module, SymbolicByteCode::Nil);
       let fun = val!(hooks.manage_obj(fun));
 
       assert_eq!(inline_cache.get_invoke_cache(0, class), None);

--- a/laythe_vm/src/compiler/ir/token.rs
+++ b/laythe_vm/src/compiler/ir/token.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-
+use variant_count::VariantCount;
 use super::ast::Spanned;
 
 #[derive(Debug, Clone)]
@@ -8,7 +8,7 @@ pub enum Lexeme<'a> {
   Owned(String),
 }
 
-/// A token in the space lox language
+/// A token in the Laythe language
 #[derive(Debug, Clone)]
 pub struct Token<'a> {
   /// The token kind
@@ -58,8 +58,8 @@ impl<'a> Spanned for Token<'a> {
   }
 }
 
-/// Token kinds in the space lox language
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+/// Token kinds in the Laythe language
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, VariantCount)]
 #[repr(u8)]
 pub enum TokenKind {
   LeftParen,

--- a/laythe_vm/src/compiler/parser.rs
+++ b/laythe_vm/src/compiler/parser.rs
@@ -199,8 +199,16 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
         | TokenKind::Fun
         | TokenKind::Let
         | TokenKind::For
-        | TokenKind::If
         | TokenKind::While
+        | TokenKind::If
+        | TokenKind::Import
+        | TokenKind::Export
+        | TokenKind::Launch
+        | TokenKind::Try
+        | TokenKind::Trait
+        | TokenKind::Type
+        | TokenKind::Continue
+        | TokenKind::Break
         | TokenKind::Return => {
           break;
         },

--- a/laythe_vm/src/compiler/parser.rs
+++ b/laythe_vm/src/compiler/parser.rs
@@ -7,7 +7,7 @@ use super::{
   scanner::Scanner,
 };
 use crate::{
-  source::{LineOffsets, Source},
+  source::{LineOffsets, Source, VmFileId},
   FeResult,
 };
 use bumpalo::boxed::Box;
@@ -16,9 +16,9 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 use laythe_core::{constants::INIT, object::FunKind};
 use std::mem;
 
-type ParseResult<T, F> = Result<T, Diagnostic<F>>;
+type ParseResult<T> = Result<T, Diagnostic<VmFileId>>;
 
-fn to_fe_result<T, F>(result: ParseResult<T, F>) -> FeResult<T, F> {
+fn to_fe_result<T>(result: ParseResult<T>) -> FeResult<T> {
   match result {
     Ok(res) => Ok(res),
     Err(err) => Err(vec![err]),
@@ -38,7 +38,7 @@ const ANY_TYPE: &str = "any";
 
 /// The Laythe parser. This structure produces the Laythe
 /// AST
-pub struct Parser<'a, FileId> {
+pub struct Parser<'a> {
   /// The current token
   current: Token<'a>,
 
@@ -52,7 +52,7 @@ pub struct Parser<'a, FileId> {
   source: &'a Source,
 
   /// All errors that have been during parsing
-  errors: std::vec::Vec<Diagnostic<FileId>>,
+  errors: std::vec::Vec<Diagnostic<VmFileId>>,
 
   /// Can we currently implicitly return
   block_return: BlockReturn,
@@ -70,12 +70,12 @@ pub struct Parser<'a, FileId> {
   scanner: Scanner<'a>,
 
   /// file id
-  file_id: FileId,
+  file_id: VmFileId,
 }
 
-impl<'a, FileId: Copy> Parser<'a, FileId> {
+impl<'a> Parser<'a> {
   /// Create a new instance of the parser from a source str
-  pub fn new(source: &'a Source, file_id: FileId) -> Self {
+  pub fn new(source: &'a Source, file_id: VmFileId) -> Self {
     Self {
       scanner: Scanner::new(source),
       file_id,
@@ -98,7 +98,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   /// ```
   /// use laythe_vm::{
   ///   compiler::Parser,
-  ///   source::Source,
+  ///   source::{Source, VM_FILE_TEST_ID},
   /// };
   /// use laythe_native::stdio::StdioNative;
   /// use laythe_core::memory::{Allocator, NO_GC};
@@ -107,11 +107,11 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   /// let mut gc = Allocator::default();
   /// let source = Source::new(gc.manage_str("3 / 2 + 10;", &NO_GC));
   ///
-  /// let parser = Parser::new(&source, 0);
+  /// let parser = Parser::new(&source, VM_FILE_TEST_ID);
   /// let (ast, _) = parser.parse();
   /// assert_eq!(ast.is_ok(), true);
   /// ```
-  pub fn parse(mut self) -> (FeResult<Module<'a>, FileId>, LineOffsets) {
+  pub fn parse(mut self) -> (FeResult<Module<'a>>, LineOffsets) {
     (self.parse_inner(), self.scanner.line_offsets())
   }
 
@@ -130,7 +130,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     SymbolTable::new(self.vec())
   }
 
-  fn parse_inner(&mut self) -> FeResult<Module<'a>, FileId> {
+  fn parse_inner(&mut self) -> FeResult<Module<'a>> {
     to_fe_result(self.advance())?;
 
     // early exit if ""
@@ -156,7 +156,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
 
   /// Parse a Laythe declaration, if an error occurred at a lower level attempt
   /// synchronize to provide more error messages
-  fn decl(&mut self) -> ParseResult<Decl<'a>, FileId> {
+  fn decl(&mut self) -> ParseResult<Decl<'a>> {
     let decl = match self.current.kind() {
       TokenKind::Class => self
         .advance()
@@ -186,7 +186,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Synchronize the parser to a sentinel token
-  fn synchronize(&mut self, error: Diagnostic<FileId>) -> ParseResult<Decl<'a>, FileId> {
+  fn synchronize(&mut self, error: Diagnostic<VmFileId>) -> ParseResult<Decl<'a>> {
     self.errors.push(error);
 
     let mut tokens: Vec<Token> = self.vec();
@@ -222,7 +222,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a statement
-  fn stmt(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn stmt(&mut self) -> ParseResult<Stmt<'a>> {
     match self.current.kind() {
       TokenKind::Import => self.advance().and_then(|()| self.import()),
       TokenKind::Try => self.advance().and_then(|()| self.try_block()),
@@ -238,12 +238,12 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse an expression
-  fn expr(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn expr(&mut self) -> ParseResult<Expr<'a>> {
     self.parse_precedence(Precedence::Assignment)
   }
 
   /// Parse a class declaration
-  fn class(&mut self) -> ParseResult<Symbol<'a>, FileId> {
+  fn class(&mut self) -> ParseResult<Symbol<'a>> {
     let start = self.previous.start();
 
     self.consume(TokenKind::Identifier, "Expected class name.")?;
@@ -338,7 +338,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a function declaration
-  fn fun(&mut self) -> ParseResult<Symbol<'a>, FileId> {
+  fn fun(&mut self) -> ParseResult<Symbol<'a>> {
     let previous = mem::replace(&mut self.fun_kind, FunKind::Fun);
 
     self.consume(TokenKind::Identifier, "Expected function name.")?;
@@ -359,7 +359,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a variable declaration
-  fn let_(&mut self) -> ParseResult<Symbol<'a>, FileId> {
+  fn let_(&mut self) -> ParseResult<Symbol<'a>> {
     self.consume(TokenKind::Identifier, "Expected variable name.")?;
     let name = self.previous.clone();
     let previous_let_name = self.let_name.replace(name.clone());
@@ -387,7 +387,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a trait declaration
-  fn trait_(&mut self) -> ParseResult<Symbol<'a>, FileId> {
+  fn trait_(&mut self) -> ParseResult<Symbol<'a>> {
     self.consume(TokenKind::Identifier, "Expected trait name after 'trait'.")?;
     let name = self.previous.clone();
 
@@ -454,7 +454,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a trait declaration
-  fn type_decl(&mut self) -> ParseResult<Symbol<'a>, FileId> {
+  fn type_decl(&mut self) -> ParseResult<Symbol<'a>> {
     self.consume(TokenKind::Identifier, "Expected type name after 'type'.")?;
     let name = self.previous.clone();
 
@@ -473,7 +473,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a symbol export declaration
-  fn export_declaration(&mut self) -> ParseResult<Decl<'a>, FileId> {
+  fn export_declaration(&mut self) -> ParseResult<Decl<'a>> {
     let symbol = match self.current.kind() {
       TokenKind::Class => self.advance().and_then(|()| self.class()),
       TokenKind::Fun => self.advance().and_then(|()| self.fun()),
@@ -487,7 +487,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse an import statement
-  fn import(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn import(&mut self) -> ParseResult<Stmt<'a>> {
     if self.scope_depth > 0 {
       return self.error_current("Can only import from the module scope.");
     }
@@ -548,7 +548,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a try catch block
-  fn try_block(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn try_block(&mut self) -> ParseResult<Stmt<'a>> {
     let block = self
       .consume(TokenKind::LeftBrace, "Expected '{' after try.")
       .and_then(|()| self.block(BlockReturn::Cannot))?;
@@ -561,7 +561,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a launch statement
-  fn launch(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn launch(&mut self) -> ParseResult<Stmt<'a>> {
     let closure = self.expr()?;
 
     if let Expr::Atom(atom) = &closure {
@@ -578,7 +578,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a if statement
-  fn if_(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn if_(&mut self) -> ParseResult<Stmt<'a>> {
     // parse the condition
     let cond = self.expr()?;
     self.consume_basic(TokenKind::LeftBrace, "Expected '{' after condition.")?;
@@ -615,7 +615,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a for loop
-  fn for_(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn for_(&mut self) -> ParseResult<Stmt<'a>> {
     let table = self.table();
 
     self.loop_(|self_| {
@@ -633,7 +633,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse while statement
-  fn while_(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn while_(&mut self) -> ParseResult<Stmt<'a>> {
     self.loop_(|self_| {
       let cond = self_.expr()?;
       self_.consume(TokenKind::LeftBrace, "Expected '{' after while condition.")?;
@@ -644,7 +644,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a return statement
-  fn return_(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn return_(&mut self) -> ParseResult<Stmt<'a>> {
     if let FunKind::Script = self.fun_kind {
       return self.error("Cannot return from outside of a function or method.");
     }
@@ -666,7 +666,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     }
   }
 
-  fn continue_(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn continue_(&mut self) -> ParseResult<Stmt<'a>> {
     if self.loop_depth == 0 {
       return self.error("Cannot continue from outside of a loop.");
     }
@@ -676,7 +676,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     Ok(Stmt::Continue(self.node(continue_)))
   }
 
-  fn break_(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn break_(&mut self) -> ParseResult<Stmt<'a>> {
     if self.loop_depth == 0 {
       return self.error("Cannot break from outside of a loop.");
     }
@@ -687,7 +687,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse an expression statement
-  fn expr_stmt(&mut self) -> ParseResult<Stmt<'a>, FileId> {
+  fn expr_stmt(&mut self) -> ParseResult<Stmt<'a>> {
     let expr = self.expr()?;
     if self.match_kind(TokenKind::Semicolon)? {
       Ok(Stmt::Expr(self.node(expr)))
@@ -701,7 +701,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse an expression using a Pratt parser
-  fn parse_precedence(&mut self, precedence: Precedence) -> ParseResult<Expr<'a>, FileId> {
+  fn parse_precedence(&mut self, precedence: Precedence) -> ParseResult<Expr<'a>> {
     self.advance()?;
 
     let can_assign = precedence <= Precedence::Assignment;
@@ -733,7 +733,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Execute an prefix action
-  fn prefix(&mut self, action: Prefix, can_assign: bool) -> ParseResult<Expr<'a>, FileId> {
+  fn prefix(&mut self, action: Prefix, can_assign: bool) -> ParseResult<Expr<'a>> {
     match action {
       Prefix::Channel => self.channel(),
       Prefix::Grouping => self.grouping(),
@@ -758,7 +758,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     action: Infix,
     lhs: Expr<'a>,
     can_assign: bool,
-  ) -> ParseResult<Expr<'a>, FileId> {
+  ) -> ParseResult<Expr<'a>> {
     match action {
       Infix::And => self.and(lhs),
       Infix::Binary => self.binary(lhs),
@@ -771,7 +771,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a block statement
-  fn block(&mut self, block_return: BlockReturn) -> ParseResult<Block<'a>, FileId> {
+  fn block(&mut self, block_return: BlockReturn) -> ParseResult<Block<'a>> {
     let start = self.previous.start();
 
     self.scope_depth += 1;
@@ -815,7 +815,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
       .map(|()| Block::new(Span { start, end }, self.table(), decls))
   }
 
-  fn ternary(&mut self, cond: Expr<'a>) -> ParseResult<Expr<'a>, FileId> {
+  fn ternary(&mut self, cond: Expr<'a>) -> ParseResult<Expr<'a>> {
     let then = self.expr()?;
     self.consume_basic(TokenKind::Colon, "Expected ':' after return value.")?;
     let else_ = self.expr()?;
@@ -824,7 +824,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a binary expression
-  fn binary(&mut self, lhs: Expr<'a>) -> ParseResult<Expr<'a>, FileId> {
+  fn binary(&mut self, lhs: Expr<'a>) -> ParseResult<Expr<'a>> {
     let operator_kind = self.previous.kind();
     let precedence = get_infix(operator_kind).precedence.higher();
     let rhs = self.parse_precedence(precedence)?;
@@ -847,7 +847,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse an and expression
-  fn and(&mut self, lhs: Expr<'a>) -> ParseResult<Expr<'a>, FileId> {
+  fn and(&mut self, lhs: Expr<'a>) -> ParseResult<Expr<'a>> {
     let rhs = self.parse_precedence(Precedence::And)?;
     Ok(Expr::Binary(self.node(Binary::new(
       BinaryOp::And,
@@ -857,13 +857,13 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse an or expression
-  fn or(&mut self, lhs: Expr<'a>) -> ParseResult<Expr<'a>, FileId> {
+  fn or(&mut self, lhs: Expr<'a>) -> ParseResult<Expr<'a>> {
     let rhs = self.parse_precedence(Precedence::Or)?;
     Ok(Expr::Binary(self.node(Binary::new(BinaryOp::Or, lhs, rhs))))
   }
 
   /// Parse a unary expression
-  fn unary(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn unary(&mut self) -> ParseResult<Expr<'a>> {
     let operator_kind = self.previous.kind();
     let expr = self.parse_precedence(Precedence::Unary)?;
 
@@ -878,7 +878,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a call invocation
-  fn call(&mut self, mut lhs: Expr<'a>) -> ParseResult<Expr<'a>, FileId> {
+  fn call(&mut self, mut lhs: Expr<'a>) -> ParseResult<Expr<'a>> {
     let start = self.previous.start();
     let args = self.consume_arguments(None, TokenKind::RightParen, std::u8::MAX as usize)?;
     self.consume_basic(TokenKind::RightParen, "Expected ')' after arguments")?;
@@ -900,7 +900,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse an index on an atom
-  fn index(&mut self, mut expr: Expr<'a>, can_assign: bool) -> ParseResult<Expr<'a>, FileId> {
+  fn index(&mut self, mut expr: Expr<'a>, can_assign: bool) -> ParseResult<Expr<'a>> {
     let indexer = self.expr()?;
     self.consume_basic(TokenKind::RightBracket, "Expected ']' after index")?;
 
@@ -920,7 +920,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a property access
-  fn dot(&mut self, mut expr: Expr<'a>, can_assign: bool) -> ParseResult<Expr<'a>, FileId> {
+  fn dot(&mut self, mut expr: Expr<'a>, can_assign: bool) -> ParseResult<Expr<'a>> {
     self.consume(TokenKind::Identifier, "Expected property name after '.'.")?;
 
     if let Expr::Atom(atom) = &mut expr {
@@ -939,7 +939,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a lambda expression
-  fn lambda(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn lambda(&mut self) -> ParseResult<Expr<'a>> {
     // parse function parameters
     let call_sig = self.call_signature(TokenKind::Pipe, self.vec())?;
 
@@ -957,7 +957,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     lambda
   }
 
-  fn channel(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn channel(&mut self) -> ParseResult<Expr<'a>> {
     let start = self.previous.start();
     self.consume_basic(TokenKind::LeftParen, "Expected '(' after 'chan'")?;
 
@@ -976,7 +976,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a grouping expression
-  fn grouping(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn grouping(&mut self) -> ParseResult<Expr<'a>> {
     let start = self.previous.start();
     if self.match_kind(TokenKind::RightParen)? {
       let range = Span {
@@ -1007,7 +1007,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Compile a variable statement
-  fn variable(&mut self, can_assign: bool) -> ParseResult<Expr<'a>, FileId> {
+  fn variable(&mut self, can_assign: bool) -> ParseResult<Expr<'a>> {
     let mut expr = self.atom(Primary::Ident(self.previous.clone()));
 
     if can_assign {
@@ -1018,8 +1018,10 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Compile a variable statement
-  fn instance_access(&mut self, can_assign: bool) -> ParseResult<Expr<'a>, FileId> {
-    let mut expr = self.atom(Primary::InstanceAccess(InstanceAccess::new(self.previous.clone())));
+  fn instance_access(&mut self, can_assign: bool) -> ParseResult<Expr<'a>> {
+    let mut expr = self.atom(Primary::InstanceAccess(InstanceAccess::new(
+      self.previous.clone(),
+    )));
 
     if can_assign {
       expr = self.assign(expr)?;
@@ -1034,7 +1036,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a class' super identifer
-  fn super_(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn super_(&mut self) -> ParseResult<Expr<'a>> {
     let super_ = self.previous.clone();
     self.consume_basic(TokenKind::Dot, "Expected '.' after super.")?;
     self.consume(TokenKind::Identifier, "Expected identifier after '.'.")?;
@@ -1044,7 +1046,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a list literal
-  fn list(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn list(&mut self) -> ParseResult<Expr<'a>> {
     let start = self.previous.start();
     let items = self.consume_arguments(None, TokenKind::RightBracket, std::u16::MAX as usize)?;
     self.consume_basic(TokenKind::RightBracket, "Expected ']' after arguments")?;
@@ -1057,7 +1059,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a map literal
-  fn map(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn map(&mut self) -> ParseResult<Expr<'a>> {
     let start = self.previous.start();
     let mut entries: Vec<(Expr, Expr)> = self.vec();
 
@@ -1104,7 +1106,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a string literal
-  fn interpolation(&mut self) -> ParseResult<Expr<'a>, FileId> {
+  fn interpolation(&mut self) -> ParseResult<Expr<'a>> {
     let start = self.previous.clone();
 
     let mut segments: Vec<StringSegments> = self.vec();
@@ -1159,7 +1161,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     &mut self,
     stop_kind: TokenKind,
     type_params: Vec<'a, TypeParam<'a>>,
-  ) -> ParseResult<CallSignature<'a>, FileId> {
+  ) -> ParseResult<CallSignature<'a>> {
     let start = type_params
       .first()
       .map_or_else(|| self.previous.start(), |first| first.start());
@@ -1213,7 +1215,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     Ok(CallSignature::new(range, type_params, params, return_type))
   }
 
-  fn assign(&mut self, expr: Expr<'a>) -> ParseResult<Expr<'a>, FileId> {
+  fn assign(&mut self, expr: Expr<'a>) -> ParseResult<Expr<'a>> {
     match self.current.kind() {
       TokenKind::Equal => self
         .advance()
@@ -1245,7 +1247,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     first_value: Option<Expr<'a>>,
     stop_token: TokenKind,
     max: usize,
-  ) -> ParseResult<Vec<'a, Expr<'a>>, FileId> {
+  ) -> ParseResult<Vec<'a, Expr<'a>>> {
     let mut args = self.vec();
 
     if let Some(value) = first_value {
@@ -1268,7 +1270,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   // Parse a function body
-  fn fun_body(&mut self, block_return: BlockReturn) -> ParseResult<FunBody<'a>, FileId> {
+  fn fun_body(&mut self, block_return: BlockReturn) -> ParseResult<FunBody<'a>> {
     if self.match_kind(TokenKind::LeftBrace)? {
       let block = self.block(block_return)?;
       Ok(FunBody::Block(self.node(block)))
@@ -1285,7 +1287,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     name: Token<'a>,
     type_params: Vec<'a, TypeParam<'a>>,
     block_return: BlockReturn,
-  ) -> ParseResult<Fun<'a>, FileId> {
+  ) -> ParseResult<Fun<'a>> {
     if !self.match_kind(TokenKind::LeftParen)? {
       return self.error_current(&format!("Expected '(' after {} name.", self.fun_kind));
     }
@@ -1311,7 +1313,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
     &mut self,
     name: Token<'a>,
     is_static: bool,
-  ) -> ParseResult<(FunKind, Fun<'a>), FileId> {
+  ) -> ParseResult<(FunKind, Fun<'a>)> {
     let (fun_kind, block_return) = if is_static {
       (FunKind::StaticMethod, BlockReturn::Can)
     } else if INIT == name.str() {
@@ -1335,7 +1337,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse type parameters
-  fn type_params(&mut self) -> ParseResult<Vec<'a, TypeParam<'a>>, FileId> {
+  fn type_params(&mut self) -> ParseResult<Vec<'a, TypeParam<'a>>> {
     let mut type_params: Vec<TypeParam> = self.vec();
 
     while !self.check(TokenKind::Greater) {
@@ -1363,12 +1365,12 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a type
-  fn type_(&mut self) -> ParseResult<Type<'a>, FileId> {
+  fn type_(&mut self) -> ParseResult<Type<'a>> {
     self.parse_type_precedence(TypePrecedence::Union)
   }
 
   /// Use a pratt parser to generate a type
-  fn parse_type_precedence(&mut self, precedence: TypePrecedence) -> ParseResult<Type<'a>, FileId> {
+  fn parse_type_precedence(&mut self, precedence: TypePrecedence) -> ParseResult<Type<'a>> {
     self.advance()?;
 
     let prefix_fn = get_type_prefix(self.previous.kind()).op;
@@ -1394,7 +1396,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Execute an prefix action
-  fn type_prefix(&mut self, action: TypePrefix) -> ParseResult<Type<'a>, FileId> {
+  fn type_prefix(&mut self, action: TypePrefix) -> ParseResult<Type<'a>> {
     match action {
       TypePrefix::Fun => {
         let call_sig = self.call_signature(TokenKind::RightParen, self.vec())?;
@@ -1405,7 +1407,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Execute an infix action
-  fn type_infix(&mut self, action: TypeInfix, lhs: Type<'a>) -> ParseResult<Type<'a>, FileId> {
+  fn type_infix(&mut self, action: TypeInfix, lhs: Type<'a>) -> ParseResult<Type<'a>> {
     match action {
       TypeInfix::TypeArgs => self.type_ref(lhs),
       TypeInfix::List => self.list_type(lhs),
@@ -1415,25 +1417,25 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Create a intersection type
-  fn intersection(&mut self, lhs: Type<'a>) -> ParseResult<Type<'a>, FileId> {
+  fn intersection(&mut self, lhs: Type<'a>) -> ParseResult<Type<'a>> {
     let rhs = self.parse_type_precedence(TypePrecedence::List)?;
     Ok(Type::Intersection(self.node(Intersection::new(lhs, rhs))))
   }
 
   /// Create a union type
-  fn union(&mut self, lhs: Type<'a>) -> ParseResult<Type<'a>, FileId> {
+  fn union(&mut self, lhs: Type<'a>) -> ParseResult<Type<'a>> {
     let rhs = self.parse_type_precedence(TypePrecedence::Intersection)?;
     Ok(Type::Union(self.node(Union::new(lhs, rhs))))
   }
 
   /// Create a list type
-  fn list_type(&mut self, lhs: Type<'a>) -> ParseResult<Type<'a>, FileId> {
+  fn list_type(&mut self, lhs: Type<'a>) -> ParseResult<Type<'a>> {
     self.consume_basic(TokenKind::RightBracket, "Expected ']' after list type.")?;
     Ok(Type::List(self.node(ListType::new(lhs))))
   }
 
   /// Create a type literal
-  fn type_literal(&mut self) -> ParseResult<Type<'a>, FileId> {
+  fn type_literal(&mut self) -> ParseResult<Type<'a>> {
     let token = self.previous.clone();
     match token.kind() {
       TokenKind::Nil => Ok(Type::Primitive(Primitive::Nil(token))),
@@ -1456,7 +1458,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a class type
-  fn class_type(&mut self) -> ParseResult<ClassType<'a>, FileId> {
+  fn class_type(&mut self) -> ParseResult<ClassType<'a>> {
     let name = self.previous.clone();
 
     let type_args = if self.match_kind(TokenKind::Less)? {
@@ -1469,7 +1471,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse type ref
-  fn type_ref(&mut self, lhs: Type<'a>) -> ParseResult<Type<'a>, FileId> {
+  fn type_ref(&mut self, lhs: Type<'a>) -> ParseResult<Type<'a>> {
     match lhs {
       Type::Ref(mut type_ref) => {
         type_ref.type_args = self.type_args()?;
@@ -1483,7 +1485,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Parse a set of type args
-  fn type_args(&mut self) -> ParseResult<Vec<'a, Type<'a>>, FileId> {
+  fn type_args(&mut self) -> ParseResult<Vec<'a, Type<'a>>> {
     let args = self.consume_type_args(std::u8::MAX as usize)?;
     self.consume_basic(TokenKind::Greater, "Expected '>' after arguments")?;
 
@@ -1491,7 +1493,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   #[inline]
-  fn consume_basic(&mut self, kind: TokenKind, message: &str) -> ParseResult<(), FileId> {
+  fn consume_basic(&mut self, kind: TokenKind, message: &str) -> ParseResult<()> {
     self.consume(kind, message).map_err(|err| {
       let mut labels = err.labels.clone();
       labels.push(
@@ -1504,7 +1506,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Consume a comma separated set of arguments for calls and lists
-  fn consume_type_args(&mut self, max: usize) -> ParseResult<Vec<'a, Type<'a>>, FileId> {
+  fn consume_type_args(&mut self, max: usize) -> ParseResult<Vec<'a, Type<'a>>> {
     let mut args = self.vec();
 
     while !self.check(TokenKind::Greater) {
@@ -1525,7 +1527,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   /// Does the provided token kind match if so advance the
   /// token index
   #[inline]
-  fn match_kind(&mut self, kind: TokenKind) -> ParseResult<bool, FileId> {
+  fn match_kind(&mut self, kind: TokenKind) -> ParseResult<bool> {
     if !self.check(kind) {
       return Ok(false);
     }
@@ -1541,7 +1543,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
 
   /// Advance the parser a token forward
   #[inline]
-  fn advance(&mut self) -> ParseResult<(), FileId> {
+  fn advance(&mut self) -> ParseResult<()> {
     self.previous = mem::replace(&mut self.current, self.scanner.scan_token());
 
     if self.current.kind() != TokenKind::Error {
@@ -1554,7 +1556,7 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
 
   /// Consume a token and advance the current token index
   #[inline]
-  fn consume(&mut self, kind: TokenKind, message: &str) -> ParseResult<(), FileId> {
+  fn consume(&mut self, kind: TokenKind, message: &str) -> ParseResult<()> {
     if self.current.kind() == kind {
       return self.advance();
     }
@@ -1563,17 +1565,17 @@ impl<'a, FileId: Copy> Parser<'a, FileId> {
   }
 
   /// Indicate an error occurred at he current index
-  fn error_current<T>(&mut self, message: &str) -> ParseResult<T, FileId> {
+  fn error_current<T>(&mut self, message: &str) -> ParseResult<T> {
     self.error_at(self.current.clone(), message)
   }
 
   /// Indicate an error occurred at the previous index
-  fn error<T>(&mut self, message: &str) -> ParseResult<T, FileId> {
+  fn error<T>(&mut self, message: &str) -> ParseResult<T> {
     self.error_at(self.previous.clone(), message)
   }
 
   /// Print an error to the console for a user to address
-  fn error_at<T>(&mut self, token: Token<'a>, message: &str) -> ParseResult<T, FileId> {
+  fn error_at<T>(&mut self, token: Token<'a>, message: &str) -> ParseResult<T> {
     let error = Diagnostic::error()
       .with_message(message)
       .with_labels(vec![Label::primary(self.file_id, token.span())]);
@@ -1681,10 +1683,8 @@ enum TypeInfix {
   Union,
 }
 
-const TOKEN_VARIANTS: usize = 68;
-
 /// The rules for infix and prefix operators
-const PREFIX_TABLE: [Rule<Prefix, Precedence>; TOKEN_VARIANTS] = [
+const PREFIX_TABLE: [Rule<Prefix, Precedence>; TokenKind::VARIANT_COUNT] = [
   Rule::new(Some(Prefix::Grouping), Precedence::Call),
   // LEFT_PAREN
   Rule::new(None, Precedence::None),
@@ -1824,7 +1824,7 @@ const PREFIX_TABLE: [Rule<Prefix, Precedence>; TOKEN_VARIANTS] = [
 ];
 
 /// The rules for infix and prefix operators
-const INFIX_TABLE: [Rule<Infix, Precedence>; TOKEN_VARIANTS] = [
+const INFIX_TABLE: [Rule<Infix, Precedence>; TokenKind::VARIANT_COUNT] = [
   Rule::new(Some(Infix::Call), Precedence::Call),
   // LEFT_PAREN
   Rule::new(None, Precedence::None),
@@ -1964,7 +1964,7 @@ const INFIX_TABLE: [Rule<Infix, Precedence>; TOKEN_VARIANTS] = [
 ];
 
 /// The rules for infix and prefix operators
-const TYPE_PREFIX_TABLE: [Rule<TypePrefix, TypePrecedence>; TOKEN_VARIANTS] = [
+const TYPE_PREFIX_TABLE: [Rule<TypePrefix, TypePrecedence>; TokenKind::VARIANT_COUNT] = [
   Rule::new(Some(TypePrefix::Fun), TypePrecedence::Primary),
   // LEFT_PAREN
   Rule::new(None, TypePrecedence::None),
@@ -2104,7 +2104,7 @@ const TYPE_PREFIX_TABLE: [Rule<TypePrefix, TypePrecedence>; TOKEN_VARIANTS] = [
 ];
 
 /// The rules for infix and prefix operators
-const TYPE_INFIX_TABLE: [Rule<TypeInfix, TypePrecedence>; TOKEN_VARIANTS] = [
+const TYPE_INFIX_TABLE: [Rule<TypeInfix, TypePrecedence>; TokenKind::VARIANT_COUNT] = [
   Rule::new(None, TypePrecedence::None),
   // LEFT_PAREN
   Rule::new(None, TypePrecedence::None),
@@ -2265,7 +2265,9 @@ const fn get_type_infix(kind: TokenKind) -> &'static Rule<TypeInfix, TypePrecede
 
 #[cfg(test)]
 mod test {
-  use super::super::ir::AstPrint;
+  use crate::source::VM_FILE_TEST_ID;
+
+use super::super::ir::AstPrint;
   use super::*;
   use laythe_core::memory::{Allocator, NO_GC};
 
@@ -2274,7 +2276,7 @@ mod test {
     let source = gc.manage_str(src, &NO_GC);
     let source = Source::new(source);
 
-    let (ast, _) = Parser::new(&source, 0).parse();
+    let (ast, _) = Parser::new(&source, VM_FILE_TEST_ID).parse();
     assert!(ast.is_ok(), "{}", src);
     let ast = ast.unwrap();
 
@@ -2284,7 +2286,7 @@ mod test {
     let reproduced = gc.manage_str(printer.str(), &NO_GC);
     let reproduced = Source::new(reproduced);
 
-    let (ast2, _) = Parser::new(&reproduced, 0).parse();
+    let (ast2, _) = Parser::new(&reproduced, VM_FILE_TEST_ID).parse();
     assert!(
       ast2.is_ok(),
       "expected:\n{}, \ngenerated: \n{}",

--- a/laythe_vm/src/debug.rs
+++ b/laythe_vm/src/debug.rs
@@ -1,10 +1,364 @@
+use crate::byte_code::{decode_u16, decode_u32, AlignedByteCode, CaptureIndex};
 use laythe_core::{chunk::Chunk, if_let_obj, object::ObjectKind, to_obj_kind, value::Value};
 use laythe_env::stdio::Stdio;
 use std::{io, io::Write, mem};
 
-use crate::byte_code::{decode_u16, decode_u32, AlignedByteCode, CaptureIndex};
+#[cfg(feature = "debug")]
+use laythe_core::chunk::ChunkBuilder;
+
+#[cfg(feature = "debug")]
+use crate::byte_code::{Label, SymbolicByteCode};
+
+#[cfg(feature = "debug")]
+pub fn print_symbolic_code(
+  stdio: &mut Stdio,
+  chunk_builder: &ChunkBuilder<SymbolicByteCode>,
+  name: &str,
+) -> io::Result<()> {
+  let stdout = stdio.stdout();
+  writeln!(stdout)?;
+  writeln!(stdout, "{0}", name)?;
+
+  let mut offset: usize = 0;
+  let mut last_index: usize = 0;
+
+  while offset < chunk_builder.instructions().len() {
+    let show_line = chunk_builder.get_line(offset) == chunk_builder.get_line(last_index);
+    let temp = print_byte_code(stdio, chunk_builder, offset, show_line);
+    last_index = offset;
+    offset = temp?;
+  }
+
+  Ok(())
+}
+
+/// Write an instruction to console
+#[cfg(feature = "debug")]
+pub fn print_byte_code(
+  stdio: &mut Stdio,
+  chunk: &ChunkBuilder<SymbolicByteCode>,
+  offset: usize,
+  show_line: bool,
+) -> io::Result<usize> {
+  let stdout = stdio.stdout();
+  let instruction = chunk.instructions()[offset];
+  let offset = offset + 1;
+
+  if let SymbolicByteCode::Label(label) = instruction {
+    return label_instruction(stdio.stdout(), label, offset);
+  }
+
+  write!(stdout, "  {:0>4} ", offset)?;
+
+  if offset != 0 && show_line {
+    write!(stdout, "   | ")?;
+  } else {
+    write!(stdout, "{:>4} ", chunk.get_line(offset))?;
+  }
+
+  match instruction {
+    SymbolicByteCode::Return => simple_instruction(stdio.stdout(), "Return", offset),
+    SymbolicByteCode::Negate => simple_instruction(stdio.stdout(), "Negate", offset),
+    SymbolicByteCode::Add => simple_instruction(stdio.stdout(), "Add", offset),
+    SymbolicByteCode::Subtract => simple_instruction(stdio.stdout(), "Subtract", offset),
+    SymbolicByteCode::Multiply => simple_instruction(stdio.stdout(), "Multiply", offset),
+    SymbolicByteCode::Divide => simple_instruction(stdio.stdout(), "Divide", offset),
+    SymbolicByteCode::And(jump) => symbolic_jump_instruction(stdio.stdout(), "And", jump, offset),
+    SymbolicByteCode::Or(jump) => symbolic_jump_instruction(stdio.stdout(), "Or", jump, offset),
+    SymbolicByteCode::Not => simple_instruction(stdio.stdout(), "Not", offset),
+    SymbolicByteCode::Nil => simple_instruction(stdio.stdout(), "Nil", offset),
+    SymbolicByteCode::True => simple_instruction(stdio.stdout(), "True", offset),
+    SymbolicByteCode::False => simple_instruction(stdio.stdout(), "False", offset),
+    SymbolicByteCode::List(arg_count) => {
+      short_instruction(stdio.stdout(), "List", arg_count, offset)
+    },
+    SymbolicByteCode::Tuple(arg_count) => {
+      short_instruction(stdio.stdout(), "Tuple", arg_count, offset)
+    },
+    SymbolicByteCode::Map(arg_count) => short_instruction(stdio.stdout(), "Map", arg_count, offset),
+    SymbolicByteCode::Launch(arg_count) => {
+      byte_instruction(stdio.stdout(), "Launch", arg_count, offset)
+    },
+    SymbolicByteCode::Channel => simple_instruction(stdio.stdout(), "Channel", offset),
+    SymbolicByteCode::BufferedChannel => {
+      simple_instruction(stdio.stdout(), "BufferedChannel", offset)
+    },
+    SymbolicByteCode::Receive => simple_instruction(stdio.stdout(), "Receive", offset),
+    SymbolicByteCode::Send => simple_instruction(stdio.stdout(), "Send", offset),
+    SymbolicByteCode::Interpolate(arg_count) => {
+      short_instruction(stdio.stdout(), "Interpolate", arg_count, offset)
+    },
+    SymbolicByteCode::IterNext(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "IterNext", slot, chunk, offset)
+    },
+    SymbolicByteCode::IterCurrent(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "IterCurrent", slot, chunk, offset)
+    },
+    SymbolicByteCode::Box(slot) => byte_instruction(stdio.stdout(), "Box", slot, offset),
+    SymbolicByteCode::EmptyBox => simple_instruction(stdio.stdout(), "EmptyBox", offset),
+    SymbolicByteCode::FillBox => simple_instruction(stdio.stdout(), "FillBox", offset),
+    SymbolicByteCode::Drop => simple_instruction(stdio.stdout(), "Drop", offset),
+    SymbolicByteCode::DropN(count) => byte_instruction(stdio.stdout(), "DropN", count, offset),
+    SymbolicByteCode::Dup => simple_instruction(stdio.stdout(), "Dup", offset),
+    SymbolicByteCode::Call(arg_count) => {
+      byte_instruction(stdio.stdout(), "Call", arg_count, offset)
+    },
+    SymbolicByteCode::Import(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "Import", slot, chunk, offset)
+    },
+    SymbolicByteCode::ImportSymbol((path, slot)) => symbolic_constant_pair_instruction(
+      stdio.stdout(),
+      "ImportSymbol",
+      (path, slot),
+      (
+        chunk.get_constant(path as usize),
+        chunk.get_constant(slot as usize),
+      ),
+      offset,
+    ),
+    SymbolicByteCode::Export(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "Export", slot, chunk, offset)
+    },
+    SymbolicByteCode::Invoke((slot, arg_count)) => {
+      symbolic_invoke_instruction(stdio.stdout(), "Invoke", slot, arg_count, chunk, offset)
+    },
+    SymbolicByteCode::SuperInvoke((slot, arg_count)) => symbolic_invoke_instruction(
+      stdio.stdout(),
+      "SuperInvoke",
+      slot,
+      arg_count,
+      chunk,
+      offset,
+    ),
+    SymbolicByteCode::Class(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "Class", slot, chunk, offset)
+    },
+    SymbolicByteCode::Inherit => simple_instruction(stdio.stdout(), "Inherit", offset),
+    SymbolicByteCode::GetSuper(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "GetSuper", slot, chunk, offset)
+    },
+    SymbolicByteCode::Closure(constant) => {
+      symbolic_closure_instruction(stdio, "Closure", chunk, constant, offset)
+    },
+    SymbolicByteCode::Method(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "Method", slot, chunk, offset)
+    },
+    SymbolicByteCode::Field(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "Field", slot, chunk, offset)
+    },
+    SymbolicByteCode::StaticMethod(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "StaticMethod", slot, chunk, offset)
+    },
+    SymbolicByteCode::CaptureIndex(_) => {
+      simple_instruction(stdio.stdout(), "!=== CaptureIndex - Invalid ===!", offset)
+    },
+    SymbolicByteCode::Slot(_) => {
+      simple_instruction(stdio.stdout(), "!=== Slot - Invalid ===!", offset)
+    },
+    SymbolicByteCode::DefineGlobal(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "DefineGlobal", slot, chunk, offset)
+    },
+    SymbolicByteCode::GetGlobal(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "GetGlobal", slot, chunk, offset)
+    },
+    SymbolicByteCode::SetGlobal(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "SetGlobal", slot, chunk, offset)
+    },
+    SymbolicByteCode::GetLocal(slot) => byte_instruction(stdio.stdout(), "GetLocal", slot, offset),
+    SymbolicByteCode::SetLocal(slot) => byte_instruction(stdio.stdout(), "SetLocal", slot, offset),
+    SymbolicByteCode::GetBox(slot) => byte_instruction(stdio.stdout(), "GetBox", slot, offset),
+    SymbolicByteCode::SetBox(slot) => byte_instruction(stdio.stdout(), "SetBox", slot, offset),
+    SymbolicByteCode::GetCapture(slot) => {
+      byte_instruction(stdio.stdout(), "GetCapture", slot, offset)
+    },
+    SymbolicByteCode::SetCapture(slot) => {
+      byte_instruction(stdio.stdout(), "SetCapture", slot, offset)
+    },
+    SymbolicByteCode::SetProperty(slot) => {
+      symbolic_constant_instruction_with_slot(stdio.stdout(), "SetProperty", chunk, slot, offset)
+    },
+    SymbolicByteCode::GetProperty(slot) => {
+      symbolic_constant_instruction_with_slot(stdio.stdout(), "GetProperty", chunk, slot, offset)
+    },
+    SymbolicByteCode::Jump(jump) => symbolic_jump_instruction(stdio.stdout(), "Jump", jump, offset),
+    SymbolicByteCode::JumpIfFalse(jump) => {
+      symbolic_jump_instruction(stdio.stdout(), "JumpIfFalse", jump, offset)
+    },
+    SymbolicByteCode::Loop(jump) => symbolic_jump_instruction(stdio.stdout(), "Loop", jump, offset),
+    SymbolicByteCode::PushHandler((slots, jump)) => {
+      symbolic_push_handler_instruction(stdio.stdout(), "PushHandler", slots, jump, offset)
+    },
+    SymbolicByteCode::PopHandler => simple_instruction(stdio.stdout(), "PopHandler", offset),
+    SymbolicByteCode::Equal => simple_instruction(stdio.stdout(), "Equal", offset),
+    SymbolicByteCode::NotEqual => simple_instruction(stdio.stdout(), "NotEqual", offset),
+    SymbolicByteCode::Greater => simple_instruction(stdio.stdout(), "Greater", offset),
+    SymbolicByteCode::GreaterEqual => simple_instruction(stdio.stdout(), "GreaterEqual", offset),
+    SymbolicByteCode::Less => simple_instruction(stdio.stdout(), "Less", offset),
+    SymbolicByteCode::LessEqual => simple_instruction(stdio.stdout(), "LessEqual", offset),
+    SymbolicByteCode::Constant(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "Constant", slot as u16, chunk, offset)
+    },
+    SymbolicByteCode::ConstantLong(slot) => {
+      symbolic_constant_instruction(stdio.stdout(), "ConstantLong", slot, chunk, offset)
+    },
+    SymbolicByteCode::Label(_) => unreachable!(),
+  }
+}
+
+#[cfg(feature = "debug")]
+fn label_instruction(stdout: &mut dyn Write, label: Label, offset: usize) -> io::Result<usize> {
+  writeln!(stdout, "L{}:", label)?;
+  Ok(offset)
+}
+
+#[cfg(feature = "debug")]
+fn symbolic_jump_instruction(
+  stdout: &mut dyn Write,
+  name: &str,
+  label: Label,
+  offset: usize,
+) -> io::Result<usize> {
+  writeln!(stdout, "{:13} L{}:", name, label)?;
+  Ok(offset)
+}
+
+/// print a constant
+#[cfg(feature = "debug")]
+fn symbolic_constant_instruction(
+  stdout: &mut dyn Write,
+  name: &str,
+  slot: u16,
+  chunk: &ChunkBuilder<SymbolicByteCode>,
+  offset: usize,
+) -> io::Result<usize> {
+  write!(stdout, "{:13} {:5} ", name, slot)?;
+  writeln!(stdout, "{}", &chunk.get_constant(slot as usize))?;
+  Ok(offset)
+}
+
+/// print a constant
+#[cfg(feature = "debug")]
+fn symbolic_constant_pair_instruction(
+  stdout: &mut dyn Write,
+  name: &str,
+  slots: (u16, u16),
+  constants: (Value, Value),
+  offset: usize,
+) -> io::Result<usize> {
+  write!(stdout, "{:13} {:5} {:5}", name, slots.0, slots.1)?;
+  writeln!(stdout, "{} {}", &constants.0, &constants.1)?;
+  Ok(offset)
+}
+
+/// print a constant with a slot
+#[cfg(feature = "debug")]
+fn symbolic_constant_instruction_with_slot(
+  stdout: &mut dyn Write,
+  name: &str,
+  chunk: &ChunkBuilder<SymbolicByteCode>,
+  constant: u16,
+  offset: usize,
+) -> io::Result<usize> {
+  write!(stdout, "{:13} {:5} ", name, constant)?;
+  write!(stdout, "{}", &chunk.get_constant(constant as usize))?;
+
+  if let SymbolicByteCode::Slot(cache_slot) = chunk.instructions()[offset] {
+    writeln!(stdout, " cache slot {}", &cache_slot)?;
+  } else {
+    panic!("Unexpected SymbolicByteCode following invoke")
+  }
+
+  Ok(offset + 1)
+}
+
+/// print a closure
+#[cfg(feature = "debug")]
+fn symbolic_closure_instruction(
+  stdio: &mut Stdio,
+  name: &str,
+  chunk: &ChunkBuilder<SymbolicByteCode>,
+  constant: u16,
+  offset: usize,
+) -> io::Result<usize> {
+  let stdout = stdio.stdout();
+
+  write!(stdout, "{:13} {:5} ", name, constant)?;
+  writeln!(stdout, "{}", &chunk.get_constant(constant as usize))?;
+
+  let value = chunk.get_constant(constant as usize);
+
+  let capture_count = if_let_obj!(ObjectKind::Fun(fun) = (value) {
+    fun.capture_count()
+  } else {
+    let stderr = stdio.stderr();
+
+    writeln!(
+      stderr,
+      "!=== Compilation failure found {} instead of function ===!",
+      value.value_type()
+    )?;
+    panic!();
+  });
+
+  let mut current_offset = offset;
+  for _ in 0..capture_count {
+    if let SymbolicByteCode::CaptureIndex(capture_index) = chunk.instructions()[current_offset] {
+      match capture_index {
+        CaptureIndex::Local(local) => writeln!(
+          stdout,
+          "  {:0>4}      |                  local {}",
+          current_offset, local
+        ),
+        CaptureIndex::Enclosing(capture) => writeln!(
+          stdout,
+          "  {:0>4}      |                  capture {}",
+          current_offset, capture
+        ),
+      }?;
+
+      current_offset += 1;
+    }
+  }
+
+  Ok(current_offset)
+}
+
+#[cfg(feature = "debug")]
+fn symbolic_invoke_instruction(
+  stdout: &mut dyn Write,
+  name: &str,
+  slot: u16,
+  arg_count: u8,
+  chunk: &ChunkBuilder<SymbolicByteCode>,
+  offset: usize,
+) -> io::Result<usize> {
+  write!(stdout, "{:13} {:5} ({} args) ", name, slot, arg_count)?;
+  write!(stdout, "{}", &chunk.get_constant(slot as usize))?;
+
+  if let SymbolicByteCode::Slot(cache_slot) = chunk.instructions()[offset] {
+    writeln!(stdout, " cache slot {}", &cache_slot)?;
+  } else {
+    panic!("Unexpected SymbolicByteCode following invoke")
+  }
+
+  Ok(offset + 1)
+}
+
+/// push handler instruction
+#[cfg(feature = "debug")]
+fn symbolic_push_handler_instruction(
+  stdout: &mut dyn Write,
+  name: &str,
+  slots: u16,
+  label: Label,
+  offset: usize,
+) -> io::Result<usize> {
+  writeln!(stdout, "{:13} L{}: {:5}", name, slots, label)?;
+  Ok(offset)
+}
 
 /// Write a chunk to console
+#[cfg(test)]
 pub fn disassemble_chunk(stdio: &mut Stdio, chunk: &Chunk, name: &str) -> io::Result<()> {
   let stdout = stdio.stdout();
   writeln!(stdout)?;
@@ -55,29 +409,29 @@ pub fn disassemble_instruction(
     AlignedByteCode::False => simple_instruction(stdio.stdout(), "False", offset),
     AlignedByteCode::List(arg_count) => {
       short_instruction(stdio.stdout(), "List", arg_count, offset)
-    }
+    },
     AlignedByteCode::Tuple(arg_count) => {
       short_instruction(stdio.stdout(), "Tuple", arg_count, offset)
-    }
+    },
     AlignedByteCode::Map(arg_count) => short_instruction(stdio.stdout(), "Map", arg_count, offset),
     AlignedByteCode::Launch(arg_count) => {
       byte_instruction(stdio.stdout(), "Launch", arg_count, offset)
-    }
+    },
     AlignedByteCode::Channel => simple_instruction(stdio.stdout(), "Channel", offset),
     AlignedByteCode::BufferedChannel => {
       simple_instruction(stdio.stdout(), "BufferedChannel", offset)
-    }
+    },
     AlignedByteCode::Receive => simple_instruction(stdio.stdout(), "Receive", offset),
     AlignedByteCode::Send => simple_instruction(stdio.stdout(), "Send", offset),
     AlignedByteCode::Interpolate(arg_count) => {
       short_instruction(stdio.stdout(), "Interpolate", arg_count, offset)
-    }
+    },
     AlignedByteCode::IterNext(constant) => {
       constant_instruction(stdio.stdout(), "IterNext", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::IterCurrent(constant) => {
       constant_instruction(stdio.stdout(), "IterCurrent", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::Box(slot) => byte_instruction(stdio.stdout(), "Box", slot, offset),
     AlignedByteCode::EmptyBox => simple_instruction(stdio.stdout(), "EmptyBox", offset),
     AlignedByteCode::FillBox => simple_instruction(stdio.stdout(), "FillBox", offset),
@@ -87,16 +441,16 @@ pub fn disassemble_instruction(
     AlignedByteCode::Call(arg_count) => byte_instruction(stdio.stdout(), "Call", arg_count, offset),
     AlignedByteCode::Import(path) => {
       constant_instruction(stdio.stdout(), "Import", chunk, path, offset)
-    }
+    },
     AlignedByteCode::ImportSymbol((path, slot)) => {
-      constant_pair_instruction(stdio.stdout(), "ImportSymbol", chunk, (path, slot), offset)
-    }
+      import_symbol_instruction(stdio.stdout(), "ImportSymbol", chunk, (path, slot), offset)
+    },
     AlignedByteCode::Export(constant) => {
       constant_instruction(stdio.stdout(), "Export", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::Invoke((constant, arg_count)) => {
       invoke_instruction(stdio.stdout(), "Invoke", chunk, constant, arg_count, offset)
-    }
+    },
     AlignedByteCode::SuperInvoke((constant, arg_count)) => invoke_instruction(
       stdio.stdout(),
       "SuperInvoke",
@@ -107,59 +461,57 @@ pub fn disassemble_instruction(
     ),
     AlignedByteCode::Class(constant) => {
       constant_instruction(stdio.stdout(), "Class", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::Inherit => simple_instruction(stdio.stdout(), "Inherit", offset),
     AlignedByteCode::GetSuper(constant) => {
       constant_instruction(stdio.stdout(), "GetSuper", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::Closure(constant) => {
       closure_instruction(stdio, "Closure", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::Method(constant) => {
       constant_instruction(stdio.stdout(), "Method", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::Field(constant) => {
       constant_instruction(stdio.stdout(), "Field", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::StaticMethod(constant) => {
       constant_instruction(stdio.stdout(), "StaticMethod", chunk, constant, offset)
-    }
-    AlignedByteCode::CaptureIndex(_) => {
-      simple_instruction(stdio.stdout(), "!=== CaptureIndex - Invalid ===!", offset)
-    }
-    AlignedByteCode::Slot(_) => {
-      simple_instruction(stdio.stdout(), "!=== Slot - Invalid ===!", offset)
-    }
+    },
     AlignedByteCode::DefineGlobal(constant) => {
       constant_instruction(stdio.stdout(), "DefineGlobal", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::GetGlobal(constant) => {
       constant_instruction(stdio.stdout(), "GetGlobal", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::SetGlobal(constant) => {
       constant_instruction(stdio.stdout(), "SetGlobal", chunk, constant, offset)
-    }
+    },
     AlignedByteCode::GetLocal(slot) => byte_instruction(stdio.stdout(), "GetLocal", slot, offset),
     AlignedByteCode::SetLocal(slot) => byte_instruction(stdio.stdout(), "SetLocal", slot, offset),
     AlignedByteCode::GetBox(slot) => byte_instruction(stdio.stdout(), "GetBox", slot, offset),
     AlignedByteCode::SetBox(slot) => byte_instruction(stdio.stdout(), "SetBox", slot, offset),
     AlignedByteCode::GetCapture(slot) => {
       byte_instruction(stdio.stdout(), "GetCapture", slot, offset)
-    }
+    },
     AlignedByteCode::SetCapture(slot) => {
       byte_instruction(stdio.stdout(), "SetCapture", slot, offset)
-    }
+    },
     AlignedByteCode::SetProperty(slot) => {
       constant_instruction_with_slot(stdio.stdout(), "SetProperty", chunk, slot, offset)
-    }
+    },
     AlignedByteCode::GetProperty(slot) => {
       constant_instruction_with_slot(stdio.stdout(), "GetProperty", chunk, slot, offset)
-    }
+    },
     AlignedByteCode::Jump(jump) => jump_instruction(stdio.stdout(), "Jump", 1, jump, offset),
     AlignedByteCode::JumpIfFalse(jump) => {
       jump_instruction(stdio.stdout(), "JumpIfFalse", 1, jump, offset)
-    }
+    },
     AlignedByteCode::Loop(jump) => jump_instruction(stdio.stdout(), "Loop", -1, jump, offset),
+    AlignedByteCode::PushHandler((slots, jump)) => {
+      push_handler_instruction(stdio.stdout(), "PushHandler", slots, jump, offset)
+    },
+    AlignedByteCode::PopHandler => simple_instruction(stdio.stdout(), "PopHandler", offset),
     AlignedByteCode::Equal => simple_instruction(stdio.stdout(), "Equal", offset),
     AlignedByteCode::NotEqual => simple_instruction(stdio.stdout(), "NotEqual", offset),
     AlignedByteCode::Greater => simple_instruction(stdio.stdout(), "Greater", offset),
@@ -168,10 +520,12 @@ pub fn disassemble_instruction(
     AlignedByteCode::LessEqual => simple_instruction(stdio.stdout(), "LessEqual", offset),
     AlignedByteCode::Constant(constant) => {
       constant_instruction(stdio.stdout(), "Constant", chunk, constant as u16, offset)
-    }
+    },
     AlignedByteCode::ConstantLong(constant) => {
       constant_instruction(stdio.stdout(), "ConstantLong", chunk, constant, offset)
-    }
+    },
+    AlignedByteCode::CaptureIndex(_) => panic!("Unexpected AlignedByteCode CaptureIndex"),
+    AlignedByteCode::Slot(_) => panic!("Unexpected AlignedByteCode Slot"),
   }
 }
 
@@ -193,7 +547,7 @@ fn jump_instruction(
   Ok(offset)
 }
 
-/// print a constant
+// /// print a constant
 fn constant_instruction(
   stdout: &mut dyn Write,
   name: &str,
@@ -206,8 +560,27 @@ fn constant_instruction(
   Ok(offset)
 }
 
+/// push handler instruction
+fn push_handler_instruction(
+  stdout: &mut dyn Write,
+  name: &str,
+  slots: u16,
+  jump: u16,
+  offset: usize,
+) -> io::Result<usize> {
+  writeln!(
+    stdout,
+    "{:13} {:5} {:5} -> {}",
+    name,
+    slots,
+    offset - 5,
+    offset + jump as usize
+  )?;
+  Ok(offset)
+}
+
 /// print a constant
-fn constant_pair_instruction(
+fn import_symbol_instruction(
   stdout: &mut dyn Write,
   name: &str,
   chunk: &Chunk,

--- a/laythe_vm/src/lib.rs
+++ b/laythe_vm/src/lib.rs
@@ -7,9 +7,10 @@ mod constants;
 pub mod source;
 pub mod vm;
 use codespan_reporting::diagnostic::Diagnostic;
+use source::VmFileId;
 
 #[cfg(any(test, feature = "debug"))]
 mod debug;
 
 /// The result of a compilation
-pub type FeResult<T, F> = Result<T, Vec<Diagnostic<F>>>;
+pub type FeResult<T> = Result<T, Vec<Diagnostic<VmFileId>>>;

--- a/laythe_vm/src/source/files.rs
+++ b/laythe_vm/src/source/files.rs
@@ -138,6 +138,8 @@ impl Trace for VmFile {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VmFileId(usize);
 
+pub const VM_FILE_TEST_ID: VmFileId = VmFileId(usize::MAX);
+
 /// A file database managed by the virtual machine
 #[derive(Default)]
 pub struct VmFiles {

--- a/laythe_vm/src/source/mod.rs
+++ b/laythe_vm/src/source/mod.rs
@@ -1,5 +1,5 @@
 mod files;
-pub use files::{LineError, LineOffsets, VmFileId, VmFiles};
+pub use files::{LineError, LineOffsets, VmFileId, VmFiles, VM_FILE_TEST_ID};
 
 use bumpalo::{boxed::Box, collections::Vec, Bump};
 use laythe_core::managed::{GcStr, Trace};

--- a/laythe_vm/src/vm/debug.rs
+++ b/laythe_vm/src/vm/debug.rs
@@ -13,7 +13,7 @@ impl Vm {
 
     let start = self.current_fun.chunk().instructions().as_ptr();
     let offset = ip.offset_from(start) as usize;
-    disassemble_instruction(&mut stdio, &self.current_fun.chunk(), offset, false)
+    disassemble_instruction(&mut stdio, self.current_fun.chunk(), offset, false)
   }
 
   /// Print debugging information for the current hook

--- a/laythe_vm/src/vm/error.rs
+++ b/laythe_vm/src/vm/error.rs
@@ -47,8 +47,8 @@ impl Vm {
     self.store_ip();
 
     let bottom_frame = match mode {
-      ExecuteMode::Normal => 0,
-      ExecuteMode::CallFunction(depth) => depth,
+      ExecuteMode::Normal => None,
+      ExecuteMode::CallFunction(depth) => Some(depth),
     };
 
     match self.fiber.stack_unwind(bottom_frame) {

--- a/laythe_vm/src/vm/mod.rs
+++ b/laythe_vm/src/vm/mod.rs
@@ -9,7 +9,7 @@ mod ops;
 mod source_loader;
 
 use crate::{
-  byte_code::{AlignedByteCode, ByteCode},
+  byte_code::{SymbolicByteCode, ByteCode},
   cache::InlineCache,
   constants::REPL_MODULE,
   source::{Source, VmFileId, VmFiles},
@@ -148,7 +148,7 @@ impl Vm {
       &hooks,
       hooks.manage_str(PLACEHOLDER_NAME),
       global,
-      AlignedByteCode::Nil,
+      SymbolicByteCode::Nil,
     );
 
     let current_fun = hooks.manage_obj(current_fun);
@@ -317,7 +317,7 @@ impl Vm {
     unsafe {
       loop {
         // get the current instruction
-        let op_code: ByteCode = ByteCode::from(self.read_byte());
+        let op_code: ByteCode = ByteCode::from_byte_unchecked(self.read_byte());
 
         #[cfg(feature = "debug")]
         {
@@ -344,6 +344,8 @@ impl Vm {
           ByteCode::JumpIfFalse => self.op_jump_if_false(),
           ByteCode::Jump => self.op_jump(),
           ByteCode::Loop => self.op_loop(),
+          ByteCode::PushHandler => self.op_push_handler(),
+          ByteCode::PopHandler => self.op_pop_handler(),
           ByteCode::DefineGlobal => self.op_define_global(),
           ByteCode::Box => self.op_box(),
           ByteCode::EmptyBox => self.op_empty_box(),

--- a/laythe_vm/src/vm/source_loader.rs
+++ b/laythe_vm/src/vm/source_loader.rs
@@ -38,7 +38,7 @@ impl Vm {
     module: Gc<Module>,
     source: &Source,
     file_id: VmFileId,
-  ) -> FeResult<GcObj<Fun>, VmFileId> {
+  ) -> FeResult<GcObj<Fun>> {
     let (ast, line_offsets) = Parser::new(source, file_id).parse();
     self
       .files


### PR DESCRIPTION
## Problem
Currently we have a peephole optimizer like functionality living in the main code gen pass. We'd like to continue to add more peephole-like optimization but the complexity added to the main codegen pass (Compiler) isn't a good path forward.

## Solution
Create a new intermediate representation `SymbolicByteCode` which presents an Assembly like view into what the bytecode will become. The primary abstraction is we've introduced `Label`'s as a means to indicate a location in the code without an explicit byte offset.

With this we can move `DropN` and `Invoke` to be part of the transformation from SymbolicByteCode down into regular byte code instead of in the codegen pass. 

Because of the shifts to labels this allow ended up requiring a rework of the exception system. Now more of the exception code is actually present in the byte code. More specifically this PR introduces a new pair of byte codes

* PushHandler
* PopHandler

Now the bare bones example of 
```laythe
try { } catch { }
```

gets compile to 

```
script.lay
  0001    | PushHandler   L1: 0
  0002    | PopHandler   
  0003    | Jump          L1:
L0:
  0005    | PopHandler   
L1:
  0007    | Nil          
  0008    | Return   
```

Having the exception code allows the label replacement code now work seamlessly with exception. In this was we also have more opportunities to eventually optimize exception code. 

As an immediate consequence to this change we take a small runtime hit push and popping the handlers, but the actually exception handling should be extremely fast now, effective checking if an option is `Some`.