### PR TITLE
Peephole optimizer

### DIFF
--- a/laythe_core/src/lib.rs
+++ b/laythe_core/src/lib.rs
@@ -26,7 +26,7 @@ pub type LyHashSet<K> = HashSet<K, FnvBuildHasher>;
 
 use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
-use managed::Instance;
+use managed::{Instance};
 
 #[macro_export]
 macro_rules! impl_trace {

--- a/laythe_core/src/object/channel.rs
+++ b/laythe_core/src/object/channel.rs
@@ -462,7 +462,7 @@ mod test {
       let context = NoContext::default();
       let hooks = GcHooks::new(&context);
 
-      let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+      let fiber = FiberBuilder::default().build(&hooks).unwrap();
       let mut queue = ChannelQueue::with_capacity(5);
 
       assert_eq!(queue.len(), 0);
@@ -480,7 +480,7 @@ mod test {
       let context = NoContext::default();
       let hooks = GcHooks::new(&context);
 
-      let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+      let fiber = FiberBuilder::default().build(&hooks).unwrap();
       let mut queue = ChannelQueue::with_capacity(5);
 
       assert_eq!(queue.capacity(), 5);
@@ -505,7 +505,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::sync();
 
         let r = queue.send(fiber, val!(1.0));
@@ -518,8 +518,8 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
-        let fiber_waiter = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
+        let fiber_waiter = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::sync();
 
         queue.receive(fiber_waiter);
@@ -534,7 +534,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::sync();
 
         queue.send(fiber, val!(1.0));
@@ -548,9 +548,9 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
-        let fiber_waiter1 = FiberBuilder::<u8>::default().build(&hooks).unwrap();
-        let fiber_waiter2 = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
+        let fiber_waiter1 = FiberBuilder::default().build(&hooks).unwrap();
+        let fiber_waiter2 = FiberBuilder::default().build(&hooks).unwrap();
 
         let mut queue = ChannelQueue::sync();
         queue.receive(fiber_waiter1);
@@ -585,7 +585,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::sync();
 
         assert_eq!(queue.close(), CloseResult::Ok);
@@ -600,7 +600,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::sync();
 
         let r = queue.receive(fiber);
@@ -613,7 +613,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::sync();
 
         let r = queue.receive(fiber);
@@ -626,8 +626,8 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber1 = FiberBuilder::<u8>::default().build(&hooks).unwrap();
-        let fiber2 = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber1 = FiberBuilder::default().build(&hooks).unwrap();
+        let fiber2 = FiberBuilder::default().build(&hooks).unwrap();
 
         let mut queue = ChannelQueue::with_capacity(1);
         queue.send(fiber2, val!(1.0));
@@ -642,7 +642,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::sync();
 
         queue.send(fiber, val!(10.0));
@@ -658,7 +658,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::sync();
 
         assert_eq!(queue.close(), CloseResult::Ok);
@@ -677,7 +677,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::with_capacity(3);
 
         let r = queue.send(fiber, val!(1.0));
@@ -690,7 +690,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::with_capacity(1);
 
         queue.send(fiber, val!(1.0));
@@ -704,8 +704,8 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
-        let fiber_waiter1 = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
+        let fiber_waiter1 = FiberBuilder::default().build(&hooks).unwrap();
 
         let mut queue = ChannelQueue::with_capacity(1);
         queue.receive(fiber_waiter1);
@@ -721,7 +721,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::with_capacity(1);
 
         assert_eq!(queue.close(), CloseResult::Ok);
@@ -736,7 +736,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::with_capacity(3);
 
         let r = queue.receive(fiber);
@@ -749,8 +749,8 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
-        let fiber_waiter = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
+        let fiber_waiter = FiberBuilder::default().build(&hooks).unwrap();
 
         let mut queue = ChannelQueue::with_capacity(1);
         queue.send(fiber_waiter, val!(1.0));
@@ -767,7 +767,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::with_capacity(3);
 
         queue.send(fiber, val!(1.0));
@@ -782,7 +782,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::with_capacity(3);
 
         queue.send(fiber, val!(10.0));
@@ -798,7 +798,7 @@ mod test {
         let context = NoContext::default();
         let hooks = GcHooks::new(&context);
 
-        let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+        let fiber = FiberBuilder::default().build(&hooks).unwrap();
         let mut queue = ChannelQueue::with_capacity(1);
 
         assert_eq!(queue.close(), CloseResult::Ok);
@@ -853,7 +853,7 @@ mod test {
       let context = NoContext::default();
       let hooks = GcHooks::new(&context);
 
-      let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+      let fiber = FiberBuilder::default().build(&hooks).unwrap();
       let mut channel = Channel::with_capacity(&hooks, 5);
 
       assert_eq!(channel.len(), 0);
@@ -896,7 +896,7 @@ mod test {
       let context = NoContext::default();
       let hooks = GcHooks::new(&context);
 
-      let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+      let fiber = FiberBuilder::default().build(&hooks).unwrap();
       let mut channel = Channel::sync(&hooks).read_only().unwrap();
 
       let r = channel.send(fiber, val!(10.0));
@@ -910,7 +910,7 @@ mod test {
       let context = NoContext::default();
       let hooks = GcHooks::new(&context);
 
-      let fiber = FiberBuilder::<u8>::default().build(&hooks).unwrap();
+      let fiber = FiberBuilder::default().build(&hooks).unwrap();
       let mut channel = Channel::sync(&hooks).write_only().unwrap();
 
       let r = channel.receive(fiber);

--- a/laythe_core/src/object/closure.rs
+++ b/laythe_core/src/object/closure.rs
@@ -21,6 +21,7 @@ impl Closure {
   /// use laythe_core::module::Module;
   /// use laythe_core::captures::Captures;
   /// use laythe_core::hooks::{NoContext, GcHooks};
+  /// use laythe_core::chunk::Chunk;
   /// use std::path::PathBuf;
   ///
   /// let mut context = NoContext::default();
@@ -30,8 +31,9 @@ impl Closure {
   ///   hooks.manage_obj(Class::bare(hooks.manage_str("module"))),
   ///   0,
   /// ));
-  /// let mut builder = FunBuilder::<u8>::new(hooks.manage_str("example"), module, Arity::default());
-  /// let managed_fun = hooks.manage_obj(builder.build(&hooks).unwrap());
+  /// let mut builder = FunBuilder::new(hooks.manage_str("example"), module, Arity::default());
+  /// let chunk = Chunk::stub(&hooks);
+  /// let managed_fun = hooks.manage_obj(builder.build(chunk));
   ///
   /// let captures = Captures::new(&hooks, &[]);
   /// let closure = Closure::new(managed_fun, captures);

--- a/laythe_core/src/object/fiber/mod.rs
+++ b/laythe_core/src/object/fiber/mod.rs
@@ -734,6 +734,7 @@ unsafe impl Sync for Fiber {}
 mod test {
   use super::*;
   use crate::{
+    chunk::Chunk,
     hooks::{GcHooks, NoContext},
     object::FunBuilder,
     signature::Arity,
@@ -745,7 +746,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let fiber = FiberBuilder::<u8>::default().build(&hooks);
+    let fiber = FiberBuilder::default().build(&hooks);
     assert!(fiber.is_ok())
   }
 
@@ -754,7 +755,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -778,7 +779,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(1)
       .build(&hooks)
       .expect("Expected to build");
@@ -794,7 +795,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -818,7 +819,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -834,7 +835,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -858,7 +859,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -874,7 +875,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -897,7 +898,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -912,7 +913,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -938,7 +939,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let fiber = FiberBuilder::<u8>::default()
+    let fiber = FiberBuilder::default()
       .max_slots(1)
       .build(&hooks)
       .expect("Expected to build");
@@ -953,7 +954,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -980,7 +981,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(0)
       .build(&hooks)
       .expect("Expected to build");
@@ -998,15 +999,13 @@ mod test {
     let module = test_module(&hooks, "test module");
 
     let mut builder = FunBuilder::new(hooks.manage_str("test"), module, Arity::default());
-    builder.write_instruction(0, 0);
-    builder.write_instruction(0, 0);
-    builder.write_instruction(0, 0);
     builder.update_max_slots(3);
 
     let captures = Captures::new(&hooks, &[]);
-    let fun = hooks.manage_obj(builder.build(&hooks).unwrap());
+    let fun =
+      hooks.manage_obj(builder.build(Chunk::stub_with_instructions(&hooks, &[0, 0, 0])));
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .instructions(vec![1, 2, 3])
       .build(&hooks)
@@ -1038,7 +1037,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(3)
       .instructions(vec![1])
       .build(&hooks)
@@ -1053,7 +1052,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(1)
       .instructions(vec![1, 2, 3])
       .build(&hooks)
@@ -1067,7 +1066,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .instructions(vec![1, 2, 3])
       .build(&hooks)
@@ -1086,7 +1085,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .instructions(vec![1, 2, 3])
       .build(&hooks)
@@ -1100,7 +1099,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .build(&hooks)
       .expect("Expected to build");
 
@@ -1117,7 +1116,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .build(&hooks)
       .expect("Expected to build");
 
@@ -1137,7 +1136,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .build(&hooks)
       .expect("Expected to build");
 
@@ -1153,15 +1152,13 @@ mod test {
 
     let module = test_module(&hooks, "test module");
 
-    let mut builder = FunBuilder::new(hooks.manage_str("test"), module, Arity::default());
-    builder.write_instruction(0, 0);
-    builder.write_instruction(0, 0);
-    builder.write_instruction(0, 0);
+    let builder = FunBuilder::new(hooks.manage_str("test"), module, Arity::default());
 
-    let fun = hooks.manage_obj(builder.build(&hooks).unwrap());
+    let fun =
+      hooks.manage_obj(builder.build(Chunk::stub_with_instructions(&hooks, &[0, 0, 0])));
     let captures = Captures::new(&hooks, &[]);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(3)
       .build(&hooks)
       .expect("Expected to build");
@@ -1190,11 +1187,11 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let parent = FiberBuilder::<u8>::default()
+    let parent = FiberBuilder::default()
       .build(&hooks)
       .expect("Expected to build");
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .parent(parent)
       .build(&hooks)
       .expect("Expected to build");
@@ -1209,7 +1206,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(0)
       .build(&hooks)
       .expect("Expected to build");
@@ -1226,7 +1223,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(0)
       .instructions(vec![1, 2, 3])
       .build(&hooks)
@@ -1242,7 +1239,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -1280,7 +1277,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -1313,7 +1310,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -1339,7 +1336,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let fiber = FiberBuilder::<u8>::default()
+    let fiber = FiberBuilder::default()
       .max_slots(0)
       .build(&hooks)
       .expect("Expected to build");
@@ -1357,7 +1354,7 @@ mod test {
     let fun = test_fun(&hooks, "next", "next module");
     let captures = Captures::new(&hooks, &[]);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(3)
       .build(&hooks)
       .expect("Expected to build");
@@ -1388,7 +1385,7 @@ mod test {
     let fun = test_fun(&hooks, "next", "next module");
     let captures = Captures::new(&hooks, &[]);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(4)
       .build(&hooks)
       .expect("Expected to build");
@@ -1422,7 +1419,7 @@ mod test {
 
     let captures = Captures::new(&hooks, &[]);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(6)
       .build(&hooks)
       .expect("Expected to build");
@@ -1453,17 +1450,17 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fun1 = test_fun_builder::<u8>(&hooks, "first", "first module");
+    let mut fun1 = test_fun_builder(&hooks, "first", "first module");
     fun1.update_max_slots(4);
-    let fun1 = hooks.manage_obj(fun1.build(&hooks).unwrap());
+    let fun1 = hooks.manage_obj(fun1.build(Chunk::stub(&hooks)));
 
-    let mut fun2 = test_fun_builder::<u8>(&hooks, "second", "second module");
+    let mut fun2 = test_fun_builder(&hooks, "second", "second module");
     fun2.update_max_slots(3);
-    let fun2 = hooks.manage_obj(fun2.build(&hooks).unwrap());
+    let fun2 = hooks.manage_obj(fun2.build(Chunk::stub(&hooks)));
 
     let captures = Captures::new(&hooks, &[]);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(6)
       .build(&hooks)
       .expect("Expected to build");
@@ -1499,7 +1496,7 @@ mod test {
     let context = NoContext::default();
     let hooks = GcHooks::new(&context);
 
-    let mut fiber = FiberBuilder::<u8>::default()
+    let mut fiber = FiberBuilder::default()
       .max_slots(2)
       .build(&hooks)
       .expect("Expected to build");

--- a/laythe_core/src/utils.rs
+++ b/laythe_core/src/utils.rs
@@ -39,7 +39,7 @@ pub fn ptr_len<T>(start: *const T, end: *const T) -> usize {
   byte_len / mem::size_of::<T>()
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct IdEmitter(usize);
 
 impl IdEmitter {

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -911,7 +911,7 @@ mod test {
     let name = test_string(hooks);
     let module = test_module(hooks);
 
-    hooks.manage_obj(Fun::stub(hooks, name, module, 0))
+    hooks.manage_obj(Fun::stub(hooks, name, module))
   }
 
   fn test_closure(hooks: &GcHooks) -> GcObj<Closure> {

--- a/laythe_lib/src/global/primitives/channel.rs
+++ b/laythe_lib/src/global/primitives/channel.rs
@@ -163,7 +163,7 @@ mod test {
       let channel_len = ChannelLen::native(&hooks.as_gc());
       let mut channel = hooks.manage_obj(Channel::with_capacity(&hooks.as_gc(), 1));
 
-      let fiber = FiberBuilder::<u8>::default()
+      let fiber = FiberBuilder::default()
         .instructions(vec![0])
         .build(&hooks.as_gc())
         .unwrap();

--- a/laythe_lib/src/global/primitives/closure.rs
+++ b/laythe_lib/src/global/primitives/closure.rs
@@ -127,7 +127,7 @@ mod test {
   mod size {
     use super::*;
     use crate::support::{test_fun_builder, MockedContext};
-    use laythe_core::{captures::Captures, object::Closure};
+    use laythe_core::{captures::Captures, chunk::Chunk, object::Closure};
 
     #[test]
     fn new() {
@@ -150,16 +150,17 @@ mod test {
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
       let closure = hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
+        hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc()))),
         captures,
       ));
 
       let result = closure_name.call(&mut hooks, Some(val!(closure)), &[]);
       assert_eq!(result.unwrap().to_num(), 4.0);
 
-      let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
+      let builder =
+        test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
       let closure = hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
+        hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc()))),
         captures,
       ));
 
@@ -168,7 +169,7 @@ mod test {
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
       let closure = hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
+        hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc()))),
         captures,
       ));
 
@@ -180,7 +181,7 @@ mod test {
   mod call {
     use super::*;
     use crate::support::{test_fun_builder, MockedContext};
-    use laythe_core::{captures::Captures, object::Closure};
+    use laythe_core::{captures::Captures, chunk::Chunk, object::Closure};
 
     #[test]
     fn new() {
@@ -207,7 +208,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let closure = hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
+        hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc()))),
         captures,
       ));
 

--- a/laythe_lib/src/global/primitives/fiber.rs
+++ b/laythe_lib/src/global/primitives/fiber.rs
@@ -80,7 +80,7 @@ mod test {
 
       let fiber_str = FiberStr::native(&hooks.as_gc());
 
-      let fiber = FiberBuilder::<u8>::default()
+      let fiber = FiberBuilder::default()
         .instructions(vec![0])
         .build(&hooks.as_gc())
         .unwrap();

--- a/laythe_lib/src/global/primitives/fun.rs
+++ b/laythe_lib/src/global/primitives/fun.rs
@@ -119,6 +119,8 @@ mod test {
   }
 
   mod size {
+    use laythe_core::chunk::Chunk;
+
     use super::*;
     use crate::support::{test_fun_builder, MockedContext};
 
@@ -140,19 +142,19 @@ mod test {
       let fun_name = FunLen::native(&hooks.as_gc());
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(4));
-      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap());
+      let fun = hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc())));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 4.0);
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Default(2, 2));
-      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap());
+      let fun = hooks.manage_obj(builder.build( Chunk::stub(&hooks.as_gc())));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 2.0);
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Variadic(5));
-      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap());
+      let fun = hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc())));
 
       let result = fun_name.call(&mut hooks, Some(val!(fun)), &[]);
       assert_eq!(result.unwrap().to_num(), 5.0);
@@ -160,6 +162,8 @@ mod test {
   }
 
   mod call {
+    use laythe_core::chunk::Chunk;
+
     use super::*;
     use crate::support::{test_fun_builder, MockedContext};
 
@@ -186,7 +190,7 @@ mod test {
 
       let builder = test_fun_builder::<u8>(&hooks.as_gc(), "example", "module", Arity::Fixed(1));
 
-      let fun = hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap());
+      let fun = hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc())));
 
       let args = &[val!(hooks.manage_str("input".to_string()))];
       let result1 = fun_call.call(&mut hooks, Some(val!(fun)), args);

--- a/laythe_lib/src/global/primitives/iter.rs
+++ b/laythe_lib/src/global/primitives/iter.rs
@@ -1276,7 +1276,7 @@ mod test {
   mod map {
     use super::*;
     use crate::support::test_fun_builder;
-    use laythe_core::{captures::Captures, object::Closure};
+    use laythe_core::{captures::Captures, object::Closure, chunk::Chunk};
 
     #[test]
     fn new() {
@@ -1306,7 +1306,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
+        hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc()))),
         captures
       )));
 
@@ -1327,7 +1327,7 @@ mod test {
     use crate::support::{test_fun_builder, MockedContext};
     use laythe_core::{
       captures::Captures,
-      object::{Closure, Enumerator},
+      object::{Closure, Enumerator}, chunk::Chunk,
     };
 
     #[test]
@@ -1358,7 +1358,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
+        hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc()))),
         captures
       )));
 
@@ -1381,7 +1381,7 @@ mod test {
     use crate::support::{test_fun_builder, MockedContext};
     use laythe_core::{
       captures::Captures,
-      object::{Closure, Enumerator},
+      object::{Closure, Enumerator}, chunk::Chunk,
     };
 
     #[test]
@@ -1417,7 +1417,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
+        hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc()))),
         captures
       )));
 
@@ -1471,7 +1471,7 @@ mod test {
     use crate::support::{test_fun_builder, MockedContext};
     use laythe_core::{
       captures::Captures,
-      object::{Closure, Enumerator},
+      object::{Closure, Enumerator}, chunk::Chunk,
     };
 
     #[test]
@@ -1503,7 +1503,7 @@ mod test {
       let captures = Captures::new(&hooks.as_gc(), &[]);
 
       let fun = val!(hooks.manage_obj(Closure::new(
-        hooks.manage_obj(builder.build(&hooks.as_gc()).unwrap()),
+        hooks.manage_obj(builder.build(Chunk::stub(&hooks.as_gc()))),
         captures
       )));
 

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -148,7 +148,7 @@ mod test {
     utils::IdEmitter,
     val,
     value::{Value, VALUE_NIL},
-    Call, LyError,
+    Call, LyError, chunk::Chunk,
   };
   use laythe_env::{
     io::Io,
@@ -437,9 +437,9 @@ mod test {
   pub fn test_fun(hooks: &GcHooks, name: &str, module_name: &str) -> GcObj<Fun> {
     let module = test_module(hooks, module_name);
 
-    let builder = FunBuilder::<u8>::new(hooks.manage_str(name), module, Arity::default());
+    let builder = FunBuilder::new(hooks.manage_str(name), module, Arity::default());
 
-    hooks.manage_obj(builder.build(&hooks).unwrap())
+    hooks.manage_obj(builder.build(Chunk::stub(&hooks)))
   }
 
   pub fn test_fun_builder<T: Default>(
@@ -447,7 +447,7 @@ mod test {
     name: &str,
     module_name: &str,
     arity: Arity,
-  ) -> FunBuilder<T> {
+  ) -> FunBuilder {
     let module = test_module(&hooks, module_name);
     FunBuilder::new(hooks.manage_str(name), module, arity)
   }

--- a/laythe_vm/src/cache.rs
+++ b/laythe_vm/src/cache.rs
@@ -4,7 +4,7 @@ use std::vec;
 use laythe_core::{managed::GcObj, object::Class, utils::IdEmitter, value::Value};
 
 /// The cache for property access and setting
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct PropertyCache {
   /// The cached class
   class: GcObj<Class>,
@@ -14,7 +14,7 @@ struct PropertyCache {
 }
 
 /// The cache for invoking a method
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct InvokeCache {
   /// The cached class
   class: GcObj<Class>,
@@ -26,6 +26,7 @@ struct InvokeCache {
 /// The inline cache for a module in Laythe
 /// This cache is meant to reduce the total
 /// number of hash lookups need in the vm
+#[derive(Debug)]
 pub struct InlineCache {
   /// A set of property access caches. There
   /// is one for each location a property is
@@ -59,7 +60,7 @@ impl InlineCache {
         } else {
           None
         }
-      }
+      },
       None => None,
     }
   }
@@ -97,7 +98,7 @@ impl InlineCache {
         } else {
           None
         }
-      }
+      },
       None => None,
     }
   }
@@ -124,7 +125,7 @@ impl InlineCache {
   }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 /// An id emitter used for inline caching. This struct
 /// simply emits new ideas to use in AlignedByteCode::Slot
 /// to give each cachable instruction an id
@@ -193,7 +194,7 @@ mod test {
   }
 
   mod inline_cache {
-    use crate::{byte_code::SymbolicByteCode, cache::InlineCache};
+    use crate::cache::InlineCache;
     use laythe_core::{
       hooks::{GcHooks, NoContext},
       memory::{Allocator, NO_GC},
@@ -241,7 +242,7 @@ mod test {
       let class = hooks.manage_obj(Class::bare(class_name));
       let module = hooks.manage(Module::new(class, 0));
 
-      let fun = Fun::stub(&hooks, fun_name, module, SymbolicByteCode::Nil);
+      let fun = Fun::stub(&hooks, fun_name, module);
       let fun = val!(hooks.manage_obj(fun));
 
       assert_eq!(inline_cache.get_invoke_cache(0, class), None);

--- a/laythe_vm/src/chunk_builder.rs
+++ b/laythe_vm/src/chunk_builder.rs
@@ -1,0 +1,167 @@
+use laythe_core::chunk::Line;
+use laythe_core::managed::DebugWrap;
+use laythe_core::{managed::DebugHeap, managed::Trace, value::Value};
+
+use crate::byte_code::SymbolicByteCode;
+
+/// Represents a chunk of code
+/// A mutable builder for a final immutable chunk
+#[derive(Default)]
+pub struct ChunkBuilder {
+  /// instruction in this code chunk
+  instructions: Vec<SymbolicByteCode>,
+
+  /// constants in this code chunk
+  constants: Vec<Value>,
+
+  /// debug line information
+  lines: Vec<Line>,
+}
+
+impl ChunkBuilder {
+  /// instruction in this code chunk
+  #[cfg(feature = "debug")]
+  pub fn instructions(&self) -> &[SymbolicByteCode] {
+    &self.instructions
+  }
+
+  /// Write an instruction to this chunk
+  pub fn write_instruction(&mut self, instruction: SymbolicByteCode, line: u32) {
+    self.instructions.push(instruction);
+    let len = self.instructions.len() as u32;
+
+    match self.lines.last_mut() {
+      Some(last_line) => {
+        if last_line.line == line {
+          last_line.offset = len;
+        } else {
+          self.lines.push(Line::new(line, len));
+        }
+      },
+      None => self.lines.push(Line::new(line, len)),
+    }
+  }
+
+  /// Retrieve a constant in the constants table at
+  /// the provided offset
+  #[cfg(feature = "debug")]
+  pub fn get_constant(&self, offset: usize) -> Value {
+    self.constants[offset]
+  }
+
+  /// Add a constant to this chunk
+  pub fn add_constant(&mut self, value: Value) -> usize {
+    self.constants.push(value);
+    self.constants.len() - 1
+  }
+
+  /// Takes the ownership of the internal pieces of this
+  /// chunk builder
+  pub fn take(self) -> (Vec<SymbolicByteCode>, Vec<Value>, Vec<Line>) {
+    (self.instructions, self.constants, self.lines)
+  }
+
+  /// Get the line number at a token offset
+  #[cfg(feature = "debug")]
+  pub fn get_line(&self, offset: usize) -> u32 {
+    use std::cmp;
+
+    let result = self
+      .lines
+      .binary_search_by_key(&(offset), |line| line.offset as usize);
+
+    match result {
+      Ok(index) => self.lines[index].line,
+      Err(index) => self.lines[cmp::min(index, self.lines.len() - 1)].line,
+    }
+  }
+}
+
+impl Trace for ChunkBuilder {
+  fn trace(&self) {
+    self.constants.iter().for_each(|constant| constant.trace());
+  }
+
+  fn trace_debug(&self, log: &mut dyn std::io::Write) {
+    self
+      .constants
+      .iter()
+      .for_each(|constant| constant.trace_debug(log));
+  }
+}
+
+impl DebugHeap for ChunkBuilder {
+  fn fmt_heap(&self, f: &mut std::fmt::Formatter, depth: usize) -> std::fmt::Result {
+    f.debug_struct("ChunkBuilder")
+      .field("instructions", &self.instructions)
+      .field("constants", &DebugWrap(&&*self.constants, depth))
+      .field("lines", &self.lines)
+      .finish()
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[cfg(test)]
+  mod line {
+    use super::*;
+
+    #[test]
+    fn line_new() {
+      let line = Line::new(10, 5);
+      assert_eq!(line.line, 10);
+      assert_eq!(line.offset, 5);
+    }
+  }
+
+  #[cfg(test)]
+  mod chunk_builder {
+    use super::*;
+    use laythe_core::value::VALUE_NIL;
+
+    #[test]
+    fn default() {
+      let chunk = ChunkBuilder::default();
+      assert_eq!(chunk.instructions.len(), 00);
+      assert_eq!(chunk.constants.len(), 0);
+    }
+
+    #[test]
+    fn write_instruction() {
+      let mut chunk = ChunkBuilder::default();
+      chunk.write_instruction(SymbolicByteCode::Add, 0);
+
+      assert_eq!(chunk.instructions.len(), 1);
+    }
+
+    #[test]
+    fn add_constant() {
+      let mut chunk = ChunkBuilder::default();
+      let index = chunk.add_constant(VALUE_NIL);
+
+      assert_eq!(index, 0);
+      assert!(chunk.constants[0].is_nil());
+    }
+
+    #[test]
+    fn take() {
+      let mut chunk = ChunkBuilder::default();
+      chunk.add_constant(VALUE_NIL);
+
+      chunk.write_instruction(SymbolicByteCode::Nil, 0);
+
+      let (instructions, constants, lines) = chunk.take();
+
+      assert_eq!(instructions.len(), 1);
+      assert_eq!(constants.len(), 1);
+      assert_eq!(lines.len(), 1);
+
+      assert_eq!(instructions[0], SymbolicByteCode::Nil);
+      assert_eq!(constants[0], VALUE_NIL);
+      assert_eq!(lines[0].line, 0);
+      assert_eq!(lines[0].offset, 1);
+    }
+  }
+}

--- a/laythe_vm/src/compiler/peephole.rs
+++ b/laythe_vm/src/compiler/peephole.rs
@@ -1,0 +1,38 @@
+use crate::byte_code::SymbolicByteCode;
+
+pub fn peephole(mut instructions: Vec<SymbolicByteCode>) -> Vec<SymbolicByteCode> {
+  let mut reader: usize = 0;
+  let mut writer: usize = 0;
+
+  while reader < instructions.len() {
+    match &instructions[reader..] {
+      [SymbolicByteCode::Drop, SymbolicByteCode::Drop, ..]  => drop(&mut instructions, &mut reader, &mut writer),
+      _ => {
+        instructions[writer] = instructions[reader];
+        reader += 1;
+        writer += 1;
+      },
+    }
+  }
+
+  instructions.truncate(writer);
+  instructions
+}
+
+pub fn drop(instructions: &mut [SymbolicByteCode], reader: &mut usize, writer: &mut usize) {
+  let mut drop_count: u8 = 1;
+  let mut local_reader = *reader;
+
+  while instructions[local_reader + 1] == SymbolicByteCode::Drop {
+    local_reader += 1;
+    drop_count += 1;
+  }
+
+  instructions[*writer] = if drop_count == 1 {
+    SymbolicByteCode::Drop
+  } else {
+    SymbolicByteCode::DropN(drop_count)
+  };
+  *writer += 1;
+  *reader = local_reader + 1;
+}

--- a/laythe_vm/src/compiler/peephole.rs
+++ b/laythe_vm/src/compiler/peephole.rs
@@ -1,12 +1,102 @@
-use crate::byte_code::SymbolicByteCode;
+use std::{cell::RefCell, rc::Rc};
 
-pub fn peephole(mut instructions: Vec<SymbolicByteCode>) -> Vec<SymbolicByteCode> {
+use crate::{
+  byte_code::{compute_label_offsets, label_count, SymbolicByteCode},
+  cache::CacheIdEmitter,
+  chunk_builder::ChunkBuilder,
+  source::VmFileId,
+};
+use codespan_reporting::diagnostic::Diagnostic;
+use laythe_core::{
+  chunk::Chunk,
+  hooks::GcHooks,
+  object::{Fun, FunBuilder},
+};
+
+pub fn peephole_compile(
+  hooks: &GcHooks,
+  fun_builder: FunBuilder,
+  chunk_builder: ChunkBuilder,
+  cache_id_emitter: Rc<RefCell<CacheIdEmitter>>,
+) -> Result<Fun, Vec<Diagnostic<VmFileId>>> {
+  let (instructions, constants, mut lines) = chunk_builder.take();
+
+  let instructions = peephole_optimize(instructions);
+
+  let mut label_offsets: [usize; u16::MAX as usize] = [0; u16::MAX as usize];
+  let label_count = label_count(&instructions);
+
+  if label_count > u16::MAX as usize {
+    todo!("Really handle this");
+  }
+
+  compute_label_offsets(&instructions, &mut label_offsets[..label_count]);
+
+  let mut buffer = Vec::with_capacity(instructions.len());
+  let mut offset: usize = 0;
+
+  let mut lines_iter = lines.iter_mut();
+  let mut line_option = lines_iter.next();
+  let mut errors = vec![];
+
+  for (index, instruction) in instructions.iter().enumerate() {
+    if let Some(error) = instruction.encode(
+      &mut buffer,
+      &label_offsets[..label_count],
+      Rc::clone(&cache_id_emitter),
+      offset,
+    ) {
+      errors.push(error);
+    }
+    offset += instruction.len();
+
+    if let Some(line) = &mut line_option {
+      if index + 1 == line.offset as usize {
+        line.offset = offset as u32;
+        line_option = lines_iter.next();
+      }
+    }
+  }
+
+  if errors.is_empty() {
+    let instructions = hooks.manage(&*buffer);
+    hooks.push_root(instructions);
+    let constants = hooks.manage(&*constants);
+    hooks.push_root(constants);
+    let lines = hooks.manage(&*lines);
+
+    Ok(fun_builder.build(Chunk::new(instructions, constants, lines)))
+  } else {
+    Err(errors)
+  }
+}
+
+fn peephole_optimize(mut instructions: Vec<SymbolicByteCode>) -> Vec<SymbolicByteCode> {
   let mut reader: usize = 0;
   let mut writer: usize = 0;
 
   while reader < instructions.len() {
     match &instructions[reader..] {
-      [SymbolicByteCode::Drop, SymbolicByteCode::Drop, ..]  => drop(&mut instructions, &mut reader, &mut writer),
+      [SymbolicByteCode::Drop, SymbolicByteCode::Drop, ..] => {
+        drop(&mut instructions, &mut reader, &mut writer)
+      },
+      [SymbolicByteCode::GetProperty(slot), SymbolicByteCode::PropertySlot, SymbolicByteCode::Call(args), ..] =>
+      {
+        let slot = *slot;
+        let args = *args;
+
+        invoke(&mut instructions, &mut reader, &mut writer, slot, args)
+      },
+      [SymbolicByteCode::GetSuper(slot), SymbolicByteCode::PropertySlot, SymbolicByteCode::Call(args), ..] =>
+      {
+        let slot = *slot;
+        let args = *args;
+
+        invoke_super(&mut instructions, &mut reader, &mut writer, slot, args)
+      },
+      [SymbolicByteCode::ArgumentDelimiter, ..] => {
+        reader += 1;
+      },
       _ => {
         instructions[writer] = instructions[reader];
         reader += 1;
@@ -35,4 +125,32 @@ pub fn drop(instructions: &mut [SymbolicByteCode], reader: &mut usize, writer: &
   };
   *writer += 1;
   *reader = local_reader + 1;
+}
+
+pub fn invoke(
+  instructions: &mut [SymbolicByteCode],
+  reader: &mut usize,
+  writer: &mut usize,
+  slot: u16,
+  args: u8,
+) {
+  instructions[*writer] = SymbolicByteCode::Invoke((slot, args));
+  instructions[*writer + 1] = SymbolicByteCode::InvokeSlot;
+
+  *writer += 2;
+  *reader += 3;
+}
+
+pub fn invoke_super(
+  instructions: &mut [SymbolicByteCode],
+  reader: &mut usize,
+  writer: &mut usize,
+  slot: u16,
+  args: u8,
+) {
+  instructions[*writer] = SymbolicByteCode::SuperInvoke((slot, args));
+  instructions[*writer + 1] = SymbolicByteCode::InvokeSlot;
+
+  *writer += 2;
+  *reader += 3;
 }

--- a/laythe_vm/src/lib.rs
+++ b/laythe_vm/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod byte_code;
 mod cache;
+mod chunk_builder;
 pub mod compiler;
 mod constants;
 pub mod source;

--- a/laythe_vm/src/vm/mod.rs
+++ b/laythe_vm/src/vm/mod.rs
@@ -9,7 +9,7 @@ mod ops;
 mod source_loader;
 
 use crate::{
-  byte_code::{SymbolicByteCode, ByteCode},
+  byte_code::{ByteCode},
   cache::InlineCache,
   constants::REPL_MODULE,
   source::{Source, VmFileId, VmFiles},
@@ -144,12 +144,7 @@ impl Vm {
     let std_lib = create_std_lib(&hooks, &mut emitter).expect("Standard library creation failed");
     let global = std_lib.root_module();
 
-    let current_fun = Fun::stub(
-      &hooks,
-      hooks.manage_str(PLACEHOLDER_NAME),
-      global,
-      SymbolicByteCode::Nil,
-    );
+    let current_fun = Fun::stub(&hooks, hooks.manage_str(PLACEHOLDER_NAME), global);
 
     let current_fun = hooks.manage_obj(current_fun);
     let capture_stub = Captures::new(&hooks, &[]);

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -1,6 +1,6 @@
 use super::{source_loader::ImportResult, Signal, Vm};
 use crate::{
-  byte_code::{CaptureIndex, SymbolicByteCode},
+  byte_code::{CaptureIndex},
   constants::MAX_FRAME_SIZE,
 };
 use laythe_core::hooks::GcContext;
@@ -1317,7 +1317,6 @@ impl Vm {
             &GcHooks::new(self),
             meta.name,
             self.global,
-            SymbolicByteCode::Nil,
           ))
         });
         stub.set_name(meta.name);


### PR DESCRIPTION
## Problem
As I've continued to work on this project it became clear I was doing some thing peephole'ish but embedded in the main code gen compiler. As I've added more features to the language keeping the same handful peephole optimizations has become increasing complicated and not pretty.

With this PR I break out a separate peephole optimization pass. At a high level this does two primary things.
* New home to lower `SymbolicByteCode` to `ByteCode`
* Runs the small handful of optimization pass

While not directly related to the end result this PR also moves the `ChunkBuilder` to the `laythe_vm` crate. Overall this makes thing a _lot_ better. We could remove several generic parameters and make stubbing functions in some ways simpler. 

## Next Steps
This PR is essentially just a refactor at this point with likely a compilation performance loss. Ideally I'd like to follow this PR with two things

* Run this code through the profiler to negate some of the perf loss
* Add new peephole optimizations that are now easier in the current framework