### PR TITLE
Return nil on stdin readline when EOF

### DIFF
--- a/laythe_core/src/captures.rs
+++ b/laythe_core/src/captures.rs
@@ -8,7 +8,7 @@ use crate::{
   value::Value,
 };
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct Captures(Tuple);
 
 impl Captures {

--- a/laythe_core/src/chunk.rs
+++ b/laythe_core/src/chunk.rs
@@ -14,7 +14,7 @@ pub trait Encode: Sized {
 }
 
 /// Represent tokens on a line
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Line {
   /// Line number
   pub line: u32,
@@ -36,7 +36,7 @@ impl_debug_heap!(u8);
 impl_trace!(Line);
 impl_debug_heap!(Line);
 /// An immutable chunk of code
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Chunk {
   /// instruction in this code chunk
   instructions: Array<u8>,

--- a/laythe_core/src/lib.rs
+++ b/laythe_core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod value;
 pub type Call = LyResult<value::Value>;
 pub type LyResult<T> = Result<T, LyError>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum LyError {
   Err(Instance),
   Exit(u16),
@@ -26,7 +26,7 @@ pub type LyHashSet<K> = HashSet<K, FnvBuildHasher>;
 
 use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
-use managed::{Instance};
+use managed::Instance;
 
 #[macro_export]
 macro_rules! impl_trace {

--- a/laythe_core/src/managed/gc.rs
+++ b/laythe_core/src/managed/gc.rs
@@ -76,7 +76,7 @@ impl<T: 'static + Trace + DebugHeap> Trace for Gc<T> {
     log
       .write_fmt(format_args!(
         "{:p} mark {:?}\n",
-        &*self.obj(),
+        self.obj(),
         DebugWrap(self, 1)
       ))
       .expect("unable to write to stdout");
@@ -142,8 +142,8 @@ impl<T: 'static> DerefMut for Gc<T> {
 impl<T> PartialEq for Gc<T> {
   #[inline]
   fn eq(&self, other: &Gc<T>) -> bool {
-    let left_inner: &T = &*self;
-    let right_inner: &T = &*other;
+    let left_inner: &T = self;
+    let right_inner: &T = other;
 
     ptr::eq(left_inner, right_inner)
   }
@@ -174,14 +174,14 @@ impl<T> Ord for Gc<T> {
 
 impl<T: fmt::Display> fmt::Display for Gc<T> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    let inner: &T = &*self;
+    let inner: &T = self;
     write!(f, "{}", inner)
   }
 }
 
 impl<T: fmt::Debug> fmt::Debug for Gc<T> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    let inner: &T = &*self;
+    let inner: &T = self;
 
     f.debug_struct("Gc").field("ptr", inner).finish()
   }

--- a/laythe_core/src/managed/gc_array.rs
+++ b/laythe_core/src/managed/gc_array.rs
@@ -277,6 +277,7 @@ impl<T, H> PartialEq<GcArray<T, H>> for GcArray<T, H> {
     ptr::eq(self.as_alloc_ptr(), other.as_alloc_ptr())
   }
 }
+impl<T, H> Eq for GcArray<T, H> {}
 
 impl Display for GcArray<Value, ObjHeader> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/laythe_core/src/managed/gc_obj.rs
+++ b/laythe_core/src/managed/gc_obj.rs
@@ -179,7 +179,7 @@ impl<T: 'static + Object> Trace for GcObj<T> {
     log
       .write_fmt(format_args!(
         "{:p} mark {:?}\n",
-        &*self.header(),
+        self.header(),
         DebugWrap(self, 1)
       ))
       .expect("unable to write to stdout");
@@ -246,8 +246,8 @@ impl<T: 'static + Object> DerefMut for GcObj<T> {
 impl<T: 'static + Object> PartialEq for GcObj<T> {
   #[inline]
   fn eq(&self, other: &GcObj<T>) -> bool {
-    let left_inner: &T = &*self;
-    let right_inner: &T = &*other;
+    let left_inner: &T = self;
+    let right_inner: &T = other;
 
     ptr::eq(left_inner, right_inner)
   }
@@ -278,14 +278,14 @@ impl<T: 'static + Object> Ord for GcObj<T> {
 
 impl<T: 'static + Object + fmt::Display> fmt::Display for GcObj<T> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    let inner: &T = &*self;
+    let inner: &T = self;
     write!(f, "{}", inner)
   }
 }
 
 impl<T: 'static + Object + fmt::Debug> fmt::Debug for GcObj<T> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    let inner: &T = &*self;
+    let inner: &T = self;
 
     f.debug_struct("GcObj").field("ptr", inner).finish()
   }

--- a/laythe_core/src/memory.rs
+++ b/laythe_core/src/memory.rs
@@ -50,7 +50,7 @@ pub struct Allocator {
 
 const GC_HEAP_GROW_FACTOR: usize = 2;
 
-impl<'a> Allocator {
+impl Allocator {
   /// Create a new manged heap for laythe for objects.
   ///
   /// # Examples
@@ -682,7 +682,7 @@ fn debug_free_obj(obj: &GcObjectHandle, free: bool) {
   }
 }
 
-impl<'a> Default for Allocator {
+impl Default for Allocator {
   fn default() -> Self {
     Allocator::new(Stdio::default())
   }

--- a/laythe_core/src/module/error.rs
+++ b/laythe_core/src/module/error.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt::Display};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ImportError {
   PackageDoesNotMatch,
   ModuleDoesNotExist,
@@ -37,7 +37,7 @@ impl Error for ImportError {
   }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ModuleInsertError {
   ModuleAlreadyExists,
 }
@@ -64,7 +64,7 @@ impl Error for ModuleInsertError {
   }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SymbolInsertError {
   SymbolAlreadyExists,
 }
@@ -91,7 +91,7 @@ impl Error for SymbolInsertError {
   }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SymbolExportError {
   SymbolDoesNotExist,
   SymbolAlreadyExported,

--- a/laythe_core/src/module/mod.rs
+++ b/laythe_core/src/module/mod.rs
@@ -117,7 +117,7 @@ impl Module {
   }
 
   /// Attempt to import a module from the provided path
-  pub fn import(&self, hooks: &GcHooks, path: &[GcStr]) -> ImportResult<Gc<Module>> {
+  pub fn import(&self, path: &[GcStr]) -> ImportResult<Gc<Module>> {
     if path.is_empty() {
       Err(ImportError::MalformedPath)
     } else {
@@ -126,7 +126,7 @@ impl Module {
           if path.len() == 1 {
             Ok(*module)
           } else {
-            module.import(hooks, &path[1..])
+            module.import(&path[1..])
           }
         },
         None => Err(ImportError::ModuleDoesNotExist),

--- a/laythe_core/src/module/package.rs
+++ b/laythe_core/src/module/package.rs
@@ -1,8 +1,5 @@
 use super::{error::ImportResult, import::Import, ImportError, Module};
-use crate::{
-  hooks::GcHooks,
-  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcStr, Trace},
-};
+use crate::managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcStr, Trace};
 use std::{fmt, io::Write};
 
 #[derive(Clone)]
@@ -32,13 +29,13 @@ impl Package {
   }
 
   /// Attempt to import a module from the provided import object
-  pub fn import(&self, hooks: &GcHooks, import: Gc<Import>) -> ImportResult<Gc<Module>> {
+  pub fn import(&self, import: Gc<Import>) -> ImportResult<Gc<Module>> {
     if import.package() == self.name {
       let path = import.path();
       if path.is_empty() {
         Ok(self.root_module)
       } else {
-        self.root_module.import(hooks, import.path())
+        self.root_module.import(import.path())
       }
     } else {
       Err(ImportError::PackageDoesNotMatch)

--- a/laythe_core/src/object/channel.rs
+++ b/laythe_core/src/object/channel.rs
@@ -28,7 +28,7 @@ enum ChannelQueueKind {
   Buffered,
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum SendResult {
   Ok,
   NoSendAccess,
@@ -37,7 +37,7 @@ pub enum SendResult {
   Closed,
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ReceiveResult {
   Ok(Value),
   NoReceiveAccess,
@@ -46,7 +46,7 @@ pub enum ReceiveResult {
   Closed,
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum CloseResult {
   Ok,
   AlreadyClosed,

--- a/laythe_core/src/object/channel.rs
+++ b/laythe_core/src/object/channel.rs
@@ -371,7 +371,7 @@ impl Channel {
 
 impl fmt::Display for Channel {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "<Channel {:p}>", &*self)
+    write!(f, "<Channel {:p}>", self)
   }
 }
 

--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -9,7 +9,7 @@ use std::{fmt, io::Write};
 
 use super::ObjectKind;
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Class {
   name: GcStr,
   init: Option<Value>,

--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -121,7 +121,7 @@ impl Class {
 
     self.methods.reserve(super_class.methods.len());
     super_class.methods.iter().for_each(|(key, value)| {
-      if self.methods.get(&*key).is_none() {
+      if self.methods.get(key).is_none() {
         self.methods.insert(*key, *value);
       }
     });
@@ -180,7 +180,7 @@ impl Class {
 
 impl fmt::Display for Class {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "<class {} {:p}>", self.name(), &*self)
+    write!(f, "<class {} {:p}>", self.name(), self)
   }
 }
 

--- a/laythe_core/src/object/closure.rs
+++ b/laythe_core/src/object/closure.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use std::{fmt, io::Write};
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Closure {
   fun: GcObj<Fun>,
   captures: Captures,

--- a/laythe_core/src/object/enumerator.rs
+++ b/laythe_core/src/object/enumerator.rs
@@ -57,7 +57,7 @@ impl Enumerator {
 
 impl fmt::Display for Enumerator {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "<iter {} {:p}>", self.name(), &*self)
+    write!(f, "<iter {} {:p}>", self.name(), self)
   }
 }
 

--- a/laythe_core/src/object/fiber/call_frame.rs
+++ b/laythe_core/src/object/fiber/call_frame.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A call frame in the Laythe interpreter
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CallFrame {
   /// The function defining this call frame
   fun: GcObj<Fun>,

--- a/laythe_core/src/object/fiber/exception_handler.rs
+++ b/laythe_core/src/object/fiber/exception_handler.rs
@@ -1,5 +1,5 @@
 /// An exception handler in Laythe
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ExceptionHandler {
   /// The ip offset from the start call frame
   offset: usize,

--- a/laythe_core/src/object/fiber/mod.rs
+++ b/laythe_core/src/object/fiber/mod.rs
@@ -15,7 +15,7 @@ use std::{fmt, io::Write, mem, ptr, usize};
 
 const INITIAL_FRAME_SIZE: usize = 4;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum FiberState {
   Running,
   Pending,
@@ -30,7 +30,7 @@ pub enum FiberError {
 
 pub type FiberResult<T> = Result<T, FiberError>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum UnwindResult<'a> {
   Handled(&'a mut CallFrame),
   Unhandled,
@@ -1002,8 +1002,7 @@ mod test {
     builder.update_max_slots(3);
 
     let captures = Captures::new(&hooks, &[]);
-    let fun =
-      hooks.manage_obj(builder.build(Chunk::stub_with_instructions(&hooks, &[0, 0, 0])));
+    let fun = hooks.manage_obj(builder.build(Chunk::stub_with_instructions(&hooks, &[0, 0, 0])));
 
     let mut fiber = FiberBuilder::default()
       .max_slots(4)
@@ -1154,8 +1153,7 @@ mod test {
 
     let builder = FunBuilder::new(hooks.manage_str("test"), module, Arity::default());
 
-    let fun =
-      hooks.manage_obj(builder.build(Chunk::stub_with_instructions(&hooks, &[0, 0, 0])));
+    let fun = hooks.manage_obj(builder.build(Chunk::stub_with_instructions(&hooks, &[0, 0, 0])));
     let captures = Captures::new(&hooks, &[]);
 
     let mut fiber = FiberBuilder::default()

--- a/laythe_core/src/object/fiber/mod.rs
+++ b/laythe_core/src/object/fiber/mod.rs
@@ -382,7 +382,7 @@ impl Fiber {
       }
     }
 
-    std::slice::from_raw_parts(start, len as usize)
+    std::slice::from_raw_parts(start, len)
   }
 
   /// Retrieve the current error on this fiber

--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -203,7 +203,7 @@ impl Fun {
 
 impl fmt::Display for Fun {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "<fn {} {:p}>", self.name, &*self)
+    write!(f, "<fn {} {:p}>", self.name, self)
   }
 }
 

--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::ObjectKind;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum FunKind {
   Fun,
   Method,

--- a/laythe_core/src/object/instance.rs
+++ b/laythe_core/src/object/instance.rs
@@ -20,7 +20,7 @@ impl Instance {
 
   #[inline]
   pub fn fields(&self) -> &[Value] {
-    &*self
+    self
   }
 
   #[inline]
@@ -45,6 +45,6 @@ impl Instance {
 
 impl fmt::Display for Instance {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "<{} {:p}>", &*self.class().name(), &*self)
+    write!(f, "<{} {:p}>", &*self.class().name(), self)
   }
 }

--- a/laythe_core/src/object/ly_box.rs
+++ b/laythe_core/src/object/ly_box.rs
@@ -27,7 +27,7 @@ impl Default for LyBox {
 
 impl Display for LyBox {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "<*{} {:p}>", self.value, &*self)
+    write!(f, "<*{} {:p}>", self.value, self)
   }
 }
 

--- a/laythe_core/src/object/ly_box.rs
+++ b/laythe_core/src/object/ly_box.rs
@@ -8,7 +8,7 @@ use std::{fmt, io::Write};
 
 use super::ObjectKind;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct LyBox {
   pub value: Value,
 }

--- a/laythe_core/src/object/method.rs
+++ b/laythe_core/src/object/method.rs
@@ -9,7 +9,7 @@ use std::{
 
 use super::ObjectKind;
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Method {
   receiver: Value,
   method: Value,

--- a/laythe_core/src/object/native.rs
+++ b/laythe_core/src/object/native.rs
@@ -129,7 +129,7 @@ impl Native {
 
 impl fmt::Display for Native {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "<{} native {:p}>", &*self.meta().name, &*self)
+    write!(f, "<{} native {:p}>", &*self.meta().name, self)
   }
 }
 

--- a/laythe_core/src/signature.rs
+++ b/laythe_core/src/signature.rs
@@ -6,14 +6,14 @@ use crate::{
 };
 use std::{fmt::Display, io::Write};
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Arity {
   Fixed(u8),
   Variadic(u8),
   Default(u8, u8),
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ArityError {
   Fixed(u8),
   Variadic(u8),
@@ -117,7 +117,7 @@ impl Trace for Parameter {
 }
 
 /// Indicating the type of the parameter passed in
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ParameterKind {
   Any,
   Bool,
@@ -214,7 +214,7 @@ pub enum Environment {
   Normal,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SignatureError {
   LengthFixed(u8),
   LengthVariadic(u8),

--- a/laythe_env/src/stdio.rs
+++ b/laythe_env/src/stdio.rs
@@ -10,7 +10,7 @@ pub struct Stdio {
 impl Default for Stdio {
   fn default() -> Self {
     Self {
-      stdio: Box::new(StdioMock::default()),
+      stdio: Box::<StdioMock>::default(),
     }
   }
 }
@@ -61,7 +61,7 @@ pub struct IoStdioMock();
 
 impl IoImpl<Stdio> for IoStdioMock {
   fn make(&self) -> Stdio {
-    Stdio::new(Box::new(StdioMock::default()))
+    Stdio::new(Box::<StdioMock>::default())
   }
 }
 
@@ -262,11 +262,11 @@ pub mod support {
     pub fn log_stdio(&self) {
       eprintln!(
         "{}",
-        str::from_utf8(&*self.stdout.0).expect("Could not unwrap stdout")
+        str::from_utf8(&self.stdout.0).expect("Could not unwrap stdout")
       );
       eprintln!(
         "{}",
-        str::from_utf8(&*self.stderr.0).expect("Could not unwrap stderr")
+        str::from_utf8(&self.stderr.0).expect("Could not unwrap stderr")
       );
     }
   }
@@ -297,7 +297,7 @@ pub mod support {
     }
     fn read_line(&self, buffer: &mut String) -> std::io::Result<usize> {
       unsafe {
-        let line = match (&*self.lines).get(*self.line_index) {
+        let line = match (*self.lines).get(*self.line_index) {
           Some(line) => line.clone(),
           None => panic!("Not enough test lines"),
         };

--- a/laythe_env/src/stdio.rs
+++ b/laythe_env/src/stdio.rs
@@ -7,6 +7,7 @@ pub struct Stdio {
   stdio: Box<dyn StdioImpl>,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for Stdio {
   fn default() -> Self {
     Self {

--- a/laythe_lib/src/global/primitives/channel.rs
+++ b/laythe_lib/src/global/primitives/channel.rs
@@ -27,8 +27,7 @@ const CHANNEL_CAPACITY: NativeMetaBuilder = NativeMetaBuilder::method("capacity"
 
 pub fn declare_channel_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
   let channel_class = class_inheritance(hooks, module, CHANNEL_CLASS_NAME)?;
-  export_and_insert(module, channel_class.name(), val!(channel_class))
-    .map_err(StdError::from)
+  export_and_insert(module, channel_class.name(), val!(channel_class)).map_err(StdError::from)
 }
 
 pub fn define_channel_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
@@ -66,7 +65,7 @@ impl LyNative for ChannelStr {
     let class = hooks.get_class(this).to_obj().to_class();
     let channel = this.to_obj().to_channel();
 
-    Call::Ok(val!(hooks.manage_str(&format!(
+    Call::Ok(val!(hooks.manage_str(format!(
       "<{} {:p}>",
       &*class.name(),
       &*channel

--- a/laythe_lib/src/global/primitives/class.rs
+++ b/laythe_lib/src/global/primitives/class.rs
@@ -61,7 +61,7 @@ impl LyNative for ClassStr {
   fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
     let class = this.unwrap().to_obj().to_class();
 
-    Call::Ok(val!(hooks.manage_str(&format!(
+    Call::Ok(val!(hooks.manage_str(format!(
       "<class {} {:p}>",
       &*class.name(),
       &*class

--- a/laythe_lib/src/global/primitives/fiber.rs
+++ b/laythe_lib/src/global/primitives/fiber.rs
@@ -44,7 +44,7 @@ impl LyNative for FiberStr {
     let class = hooks.get_class(this).to_obj().to_class();
     let fiber = this.to_obj().to_fiber();
 
-    Call::Ok(val!(hooks.manage_str(&format!(
+    Call::Ok(val!(hooks.manage_str(format!(
       "<{} {:p}>",
       &*class.name(),
       &*fiber

--- a/laythe_lib/src/global/primitives/list.rs
+++ b/laythe_lib/src/global/primitives/list.rs
@@ -235,7 +235,7 @@ impl LyNative for ListStr {
           .and_then(|method| hooks.call_method(item, method, &[]))?;
 
         if_let_obj!(ObjectKind::String(string) = (result) {
-          buf.push_str(&*string);
+          buf.push_str(&string);
           buf.push_str(", ");
         } else {
           // if error throw away temporary strings
@@ -258,7 +258,7 @@ impl LyNative for ListStr {
           .and_then(|method| hooks.call_method(*last, method, &[]))?;
 
         if_let_obj!(ObjectKind::String(string) = (result) {
-          buf.push_str(&*string);
+          buf.push_str(&string);
         } else {
           // if error throw away temporary strings
           return hooks.call(

--- a/laythe_lib/src/global/primitives/map.rs
+++ b/laythe_lib/src/global/primitives/map.rs
@@ -194,7 +194,7 @@ fn format_map_entry(
     .and_then(|method| hooks.call_method(item, method, &[]))?;
 
   if_let_obj!(ObjectKind::String(string) = (result) {
-    buffer.push_str(&*string);
+    buffer.push_str(&string);
     Call::Ok(VALUE_NIL)
   } else {
     // if error throw away temporary strings

--- a/laythe_lib/src/global/primitives/object.rs
+++ b/laythe_lib/src/global/primitives/object.rs
@@ -116,7 +116,7 @@ impl LyNative for ObjectStr {
       }),
     };
 
-    Call::Ok(val!(hooks.manage_str(&string)))
+    Call::Ok(val!(hooks.manage_str(string)))
   }
 }
 

--- a/laythe_lib/src/global/primitives/tuple.rs
+++ b/laythe_lib/src/global/primitives/tuple.rs
@@ -165,7 +165,7 @@ impl LyNative for TupleStr {
           .and_then(|method| hooks.call_method(item, method, &[]))?;
 
         if_let_obj!(ObjectKind::String(string) = (result) {
-          buf.push_str(&*string);
+          buf.push_str(&string);
           buf.push_str(", ");
         } else {
           // if error throw away temporary strings
@@ -188,7 +188,7 @@ impl LyNative for TupleStr {
           .and_then(|method| hooks.call_method(*last, method, &[]))?;
 
         if_let_obj!(ObjectKind::String(string) = (result) {
-          buf.push_str(&*string);
+          buf.push_str(&string);
         } else {
           // if error throw away temporary strings
           return hooks.call(

--- a/laythe_lib/src/io/stdio/stdin.rs
+++ b/laythe_lib/src/io/stdio/stdin.rs
@@ -13,7 +13,7 @@ use laythe_core::{
   object::{LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::Arity,
   val,
-  value::Value,
+  value::{Value, VALUE_NIL},
   Call, LyError,
 };
 use std::io::Write;
@@ -86,12 +86,13 @@ impl LyNative for StdinReadLine {
     let mut buf = String::new();
 
     match stdio.read_line(&mut buf) {
+      Ok(0) => Call::Ok(VALUE_NIL),
       Ok(_) => {
         if buf.ends_with('\n') {
           buf.pop();
         }
         Call::Ok(val!(hooks.manage_str(buf)))
-      }
+      },
       Err(err) => self.call_error(hooks, err.to_string()),
     }
   }

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -20,7 +20,7 @@ pub fn default_class_inheritance(
   let name = hooks.manage_str(class_name);
 
   let import = Import::from_str(hooks, STD)?;
-  let module = package.import(hooks, import)?;
+  let module = package.import(import)?;
   let object_class = match module.get_exported_symbol(hooks.manage_str(OBJECT_CLASS_NAME)) {
     Some(class) => class,
     None => return Err(StdError::SymbolNotFound),
@@ -46,7 +46,7 @@ pub fn default_error_inheritance(
   let error_name = hooks.manage_str(ERROR_CLASS_NAME);
 
   let import = Import::from_str(hooks, STD)?;
-  let module = package.import(hooks, import)?;
+  let module = package.import(import)?;
   let object_class = match module.get_exported_symbol(hooks.manage_str(error_name)) {
     Some(class) => class,
     None => return Err(StdError::SymbolNotFound),
@@ -71,7 +71,7 @@ pub fn load_class_from_package(
 ) -> StdResult<GcObj<Class>> {
   let name = hooks.manage_str(name);
   let import = Import::from_str(hooks, path)?;
-  let module = package.import(hooks, import)?;
+  let module = package.import(import)?;
   let symbol = match module.get_exported_symbol(hooks.manage_str(name)) {
     Some(class) => class,
     None => return Err(StdError::SymbolNotFound),
@@ -136,6 +136,7 @@ mod test {
     create_std_lib, native,
   };
   use laythe_core::{
+    chunk::Chunk,
     hooks::{GcContext, GcHooks, HookContext, Hooks, ValueContext},
     managed::{DebugHeap, GcObj, GcObject, GcStr, Trace, TraceRoot},
     match_obj,
@@ -148,7 +149,7 @@ mod test {
     utils::IdEmitter,
     val,
     value::{Value, VALUE_NIL},
-    Call, LyError, chunk::Chunk,
+    Call, LyError,
   };
   use laythe_env::{
     io::Io,

--- a/laythe_native/src/stdio.rs
+++ b/laythe_native/src/stdio.rs
@@ -11,7 +11,7 @@ pub struct IoStdioNative();
 
 impl IoImpl<Stdio> for IoStdioNative {
   fn make(&self) -> Stdio {
-    Stdio::new(Box::new(StdioNative::default()))
+    Stdio::new(Box::<StdioNative>::default())
   }
 }
 

--- a/laythe_vm/src/byte_code.rs
+++ b/laythe_vm/src/byte_code.rs
@@ -8,7 +8,7 @@ use std::convert::TryInto;
 
 use crate::{cache::CacheIdEmitter, source::VmFileId};
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Label(u32);
 
 impl Label {
@@ -27,7 +27,7 @@ impl Display for Label {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CaptureIndex {
   /// The capture is in the local function
   Local(u8),
@@ -37,7 +37,7 @@ pub enum CaptureIndex {
 }
 
 /// Space Lox virtual machine byte codes
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SymbolicByteCode {
   /// Return from script or function
   Return,
@@ -605,7 +605,7 @@ fn push_op_u16_tuple(
 }
 
 /// Laythe virtual machine byte codes
-#[derive(Debug, PartialEq, Clone, Copy, VariantCount)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, VariantCount)]
 pub enum ByteCode {
   /// Return from script or function
   Return,

--- a/laythe_vm/src/compiler/ir/ast.rs
+++ b/laythe_vm/src/compiler/ir/ast.rs
@@ -109,7 +109,7 @@ pub trait Spanned {
 
 /// Representing the start and end of a node. Typically this would
 /// be a multi line control flow or a function declaration
-#[derive(Default, PartialEq, Debug, Copy, Clone)]
+#[derive(Default, PartialEq, Eq, Debug, Copy, Clone)]
 pub struct Span {
   pub start: u32,
   pub end: u32,

--- a/laythe_vm/src/compiler/ir/symbol_table.rs
+++ b/laythe_vm/src/compiler/ir/symbol_table.rs
@@ -3,7 +3,7 @@ use bumpalo::collections::vec::Vec;
 
 /// Provides the state of a given
 /// symbol
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SymbolState {
   Uninitialized,
   Initialized,
@@ -19,7 +19,7 @@ impl Default for SymbolState {
 
 /// Was the local successfully added
 /// to this table
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum AddSymbolResult {
   Ok,
   DuplicateSymbol(Symbol),
@@ -27,7 +27,7 @@ pub enum AddSymbolResult {
 
 /// A symbol representing a named
 /// entity inside a Laythe program
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct Symbol {
   /// name of the local
   name: String,

--- a/laythe_vm/src/compiler/ir/token.rs
+++ b/laythe_vm/src/compiler/ir/token.rs
@@ -1,6 +1,6 @@
+use super::ast::Spanned;
 use std::fmt;
 use variant_count::VariantCount;
-use super::ast::Spanned;
 
 #[derive(Debug, Clone)]
 pub enum Lexeme<'a> {
@@ -38,7 +38,7 @@ impl<'a> Token<'a> {
   pub fn str(&'a self) -> &'a str {
     match &self.lexeme {
       Lexeme::Slice(slice) => slice,
-      Lexeme::Owned(string) => &*string,
+      Lexeme::Owned(string) => string,
     }
   }
 

--- a/laythe_vm/src/compiler/resolver.rs
+++ b/laythe_vm/src/compiler/resolver.rs
@@ -3,7 +3,10 @@ use super::ir::{
   symbol_table::{self, AddSymbolResult, SymbolState, SymbolTable},
   token::{Lexeme, Token, TokenKind},
 };
-use crate::{source::{Source, VmFileId}, FeResult};
+use crate::{
+  source::{Source, VmFileId},
+  FeResult,
+};
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use laythe_core::{
   constants::OBJECT,
@@ -237,10 +240,8 @@ impl<'a, 'src> Resolver<'a, 'src> {
       "Variable with this name already declared in this scope.",
       vec![
         Label::primary(self.file_id, duplicate.span()).with_message("Declared a second time here"),
-        Label::secondary(self.file_id, existing.span()).with_message(&format!(
-          "{} was originally declared here",
-          &duplicate.str()
-        )),
+        Label::secondary(self.file_id, existing.span())
+          .with_message(format!("{} was originally declared here", &duplicate.str())),
       ],
     )
   }
@@ -966,24 +967,15 @@ mod test {
     std_lib.root_module()
   }
 
-  fn test_repl_resolve(
-    src: &str,
-    test_assert: impl FnOnce(&ast::Module, FeResult<()>),
-  ) {
+  fn test_repl_resolve(src: &str, test_assert: impl FnOnce(&ast::Module, FeResult<()>)) {
     test_resolve(src, true, false, test_assert)
   }
 
-  fn test_file_std_resolve(
-    src: &str,
-    test_assert: impl FnOnce(&ast::Module, FeResult<()>),
-  ) {
+  fn test_file_std_resolve(src: &str, test_assert: impl FnOnce(&ast::Module, FeResult<()>)) {
     test_resolve(src, false, true, test_assert)
   }
 
-  fn test_file_resolve(
-    src: &str,
-    test_assert: impl FnOnce(&ast::Module, FeResult<()>),
-  ) {
+  fn test_file_resolve(src: &str, test_assert: impl FnOnce(&ast::Module, FeResult<()>)) {
     test_resolve(src, false, false, test_assert)
   }
 

--- a/laythe_vm/src/source/files.rs
+++ b/laythe_vm/src/source/files.rs
@@ -17,7 +17,7 @@ pub struct LineOffsets {
   len: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum LineError {
   OffsetOutOfBounds,
   LineOutOfBounds,
@@ -135,7 +135,7 @@ impl Trace for VmFile {
 }
 
 /// A unique id to a `VmFile`
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct VmFileId(usize);
 
 pub const VM_FILE_TEST_ID: VmFileId = VmFileId(usize::MAX);

--- a/laythe_vm/src/source/files.rs
+++ b/laythe_vm/src/source/files.rs
@@ -282,7 +282,7 @@ impl<'a> files::Files<'a> for VmFiles {
     let line_offset = vm_file.line_offsets();
 
     match line_offset.line_range(line_index) {
-      Ok(range) => Ok((range.start as usize)..(range.end as usize)),
+      Ok(range) => Ok((range.start)..(range.end)),
       Err(_) => Err(files::Error::LineTooLarge {
         given: line_index,
         max: vm_file.source.len(),

--- a/laythe_vm/src/source/mod.rs
+++ b/laythe_vm/src/source/mod.rs
@@ -37,7 +37,7 @@ impl Deref for Source {
 
 impl AsRef<str> for Source {
   fn as_ref(&self) -> &str {
-    &*self
+    self
   }
 }
 

--- a/laythe_vm/src/vm/mod.rs
+++ b/laythe_vm/src/vm/mod.rs
@@ -9,7 +9,7 @@ mod ops;
 mod source_loader;
 
 use crate::{
-  byte_code::{ByteCode},
+  byte_code::ByteCode,
   cache::InlineCache,
   constants::REPL_MODULE,
   source::{Source, VmFileId, VmFiles},
@@ -205,6 +205,9 @@ impl Vm {
       stdio.stdout().flush().expect("Could not write to stdout");
 
       match stdio.read_line(&mut buffer) {
+        Ok(0) => {
+          return (0, VmExit::Ok);
+        },
         Ok(_) => {
           let source_content = self.manage_str(buffer);
           self.push_root(source_content);

--- a/laythe_vm/src/vm/mod.rs
+++ b/laythe_vm/src/vm/mod.rs
@@ -47,7 +47,7 @@ enum Signal {
   RuntimeError,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecuteResult {
   Ok(Value),
   Exit(u16),
@@ -55,14 +55,14 @@ pub enum ExecuteResult {
   CompileError,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VmExit {
   Ok,
   RuntimeError,
   CompileError,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecuteMode {
   Normal,
   CallFunction(usize),

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -2,7 +2,7 @@ use super::{source_loader::ImportResult, Signal, Vm};
 use crate::{byte_code::CaptureIndex, constants::MAX_FRAME_SIZE};
 use laythe_core::{
   captures::Captures,
-  hooks::{GcHooks, Hooks, GcContext},
+  hooks::{GcContext, GcHooks, Hooks},
   if_let_obj,
   managed::{Array, Gc, GcObj, GcStr},
   match_obj,
@@ -75,7 +75,7 @@ impl Vm {
   /// create a map from a map literal
   pub(super) unsafe fn op_map(&mut self) -> Signal {
     let arg_count = self.read_short() as usize;
-    let mut map = self.manage_obj(Map::with_capacity(arg_count as usize));
+    let mut map = self.manage_obj(Map::with_capacity(arg_count));
 
     for i in 0..arg_count {
       let key = self.fiber.peek(i * 2 + 1);
@@ -262,7 +262,7 @@ impl Vm {
   /// create a map from a map literal
   pub(super) unsafe fn op_interpolate(&mut self) -> Signal {
     let arg_count = self.read_short() as usize;
-    let args = self.fiber.stack_slice(arg_count as usize);
+    let args = self.fiber.stack_slice(arg_count);
 
     let mut length: usize = 0;
     for arg in args {
@@ -939,8 +939,8 @@ impl Vm {
       let right = right.to_obj().to_str();
 
       let mut buffer = String::with_capacity(left.len() + right.len());
-      buffer.push_str(&*left);
-      buffer.push_str(&*right);
+      buffer.push_str(&left);
+      buffer.push_str(&right);
 
       let string = self.manage_str(buffer);
       self.fiber.push(val!(string));

--- a/laythe_vm/src/vm/source_loader.rs
+++ b/laythe_vm/src/vm/source_loader.rs
@@ -104,7 +104,7 @@ impl Vm {
     let package = self.packages.get(&import.package()).cloned();
 
     match package {
-      Some(existing_package) => match existing_package.import(&GcHooks::new(self), import) {
+      Some(existing_package) => match existing_package.import(import) {
         Ok(module) => ImportResult::Loaded(module),
         Err(err) => match err {
           ImportError::ModuleDoesNotExist => self.load_missing_module(existing_package, import),


### PR DESCRIPTION
## Summary
I'm reading through crafting interpreters again and realized I don't have any way of detecting an EOF with my current stdin impl. Now stdin.readline will return nil of only an EOF is read.