### PR TITLE
Fix issue with catch blocks

### DIFF
--- a/laythe_vm/src/compiler/mod.rs
+++ b/laythe_vm/src/compiler/mod.rs
@@ -1491,11 +1491,10 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
     self.emit_byte(SymbolicByteCode::Jump(end_label), try_.block.end());
     self.emit_byte(SymbolicByteCode::Label(catch_label), try_.catch.start());
 
+    self.emit_byte(SymbolicByteCode::PopHandler, try_.catch.end());
     self.scope(try_.catch.end(), &try_.catch.symbols, |self_| {
       self_.block(&try_.catch);
     });
-
-    self.emit_byte(SymbolicByteCode::PopHandler, try_.catch.end());
 
     self.emit_byte(SymbolicByteCode::Label(end_label), try_.catch.end());
   }
@@ -2580,11 +2579,11 @@ mod test {
         AlignedByteCode::DropN(2),
         AlignedByteCode::PopHandler,
         AlignedByteCode::Jump(9),
+        AlignedByteCode::PopHandler,
         AlignedByteCode::GetGlobal(3),
         AlignedByteCode::Constant(4),
         AlignedByteCode::Call(1),
         AlignedByteCode::Drop,
-        AlignedByteCode::PopHandler,
         AlignedByteCode::Nil,
         AlignedByteCode::Return,
       ],
@@ -2627,18 +2626,18 @@ mod test {
         AlignedByteCode::Drop,
         AlignedByteCode::PopHandler,
         AlignedByteCode::Jump(9),
+        AlignedByteCode::PopHandler,
         AlignedByteCode::GetGlobal(3),
         AlignedByteCode::Constant(4),
         AlignedByteCode::Call(1),
         AlignedByteCode::Drop,
         AlignedByteCode::PopHandler,
-        AlignedByteCode::PopHandler,
         AlignedByteCode::Jump(9),
+        AlignedByteCode::PopHandler,
         AlignedByteCode::GetGlobal(3),
         AlignedByteCode::Constant(5),
         AlignedByteCode::Call(1),
         AlignedByteCode::Drop,
-        AlignedByteCode::PopHandler,
         AlignedByteCode::Nil,
         AlignedByteCode::Return,
       ],


### PR DESCRIPTION
## Summary
While working on round 2 of crafting interpreters I noticed that catch block compiled wrong. Specifically here we popped the handler at the end of the block instead of the beginning. This exposed an issue when the code had a return in the catch block that would skip popping the block off.