### PR TITLE
Fix native function stack resize issue

### DIFF
--- a/laythe_vm/src/byte_code.rs
+++ b/laythe_vm/src/byte_code.rs
@@ -37,7 +37,7 @@ pub enum CaptureIndex {
 }
 
 /// Space Lox virtual machine byte codes
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum SymbolicByteCode {
   /// Return from script or function
   Return,
@@ -73,6 +73,7 @@ pub enum SymbolicByteCode {
   ConstantLong(u16),
 
   /// Nil literal
+  #[default]
   Nil,
 
   /// True Literal
@@ -533,12 +534,6 @@ fn jump_error(jump: usize) -> Option<Diagnostic<VmFileId>> {
     Some(Diagnostic::error().with_message("Unable to jump so far."))
   } else {
     None
-  }
-}
-
-impl Default for SymbolicByteCode {
-  fn default() -> Self {
-    SymbolicByteCode::Nil
   }
 }
 

--- a/laythe_vm/src/compiler/ir/symbol_table.rs
+++ b/laythe_vm/src/compiler/ir/symbol_table.rs
@@ -3,18 +3,13 @@ use bumpalo::collections::vec::Vec;
 
 /// Provides the state of a given
 /// symbol
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum SymbolState {
+  #[default]
   Uninitialized,
   Initialized,
   GlobalInitialized,
   Captured,
-}
-
-impl Default for SymbolState {
-  fn default() -> Self {
-    SymbolState::Uninitialized
-  }
 }
 
 /// Was the local successfully added

--- a/laythe_vm/src/compiler/scanner.rs
+++ b/laythe_vm/src/compiler/scanner.rs
@@ -645,12 +645,12 @@ fn make_token_owned<'a>(kind: TokenKind, lexeme: String, start: usize, end: usiz
 
 /// Is the str slice a digit. Assumes single char
 fn is_digit(c: char) -> bool {
-  ('0'..='9').contains(&c)
+  c.is_ascii_digit()
 }
 
 /// Is the str slice a digit. Assumes single char
 fn is_alpha(c: char) -> bool {
-  ('A'..='Z').contains(&c) || ('a'..='z').contains(&c) || c == '_'
+  c.is_ascii_uppercase() || c.is_ascii_lowercase() || c == '_'
 }
 
 /// A loose estimate for how many characters are in a typical line

--- a/laythe_vm/src/vm/hooks.rs
+++ b/laythe_vm/src/vm/hooks.rs
@@ -41,7 +41,7 @@ impl Vm {
     #[cfg(feature = "debug")]
     {
       self
-        .print_hook_state("fun_method", &format!("{}:{}", this, method))
+        .print_hook_state("run_method", &format!("{}:{}", this, method))
         .expect("Unable to print hook state");
     }
 

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -1318,7 +1318,10 @@ impl Vm {
 
         self.push_frame(stub, self.capture_stub, arg_count);
 
-        let result = native.call(&mut Hooks::new(self), this, args);
+        // Because the stack can resize we need to store the values in a separate
+        // vec
+        let args = args.to_vec();
+        let result = native.call(&mut Hooks::new(self), this, &args);
         self.native_fun_stubs.push(stub);
 
         match result {


### PR DESCRIPTION
## Problem
I'm not sure what changed but somehow an issues which had so far eluding testing started appearing locally. The issue was found in https://github.com/Laythe-lang/Laythe/blob/fix-native-function-stack-resize-issue/laythe_vm/fixture/std_lib/global/method/call.lay. Here we call the native method `.call` on a method

Prior to calling this method we put args in a slice using `fiber.stack_slice`. Normally this is fine but in this case the invocation of `.call` was causing the running fiber to resize. In that case our pointer to the stack became invalidated as it pointed to empty memory.

## Solution
Longer term we likely want some kind of managed pointer into the stack that can be moved along with the stack itself on resize. For now we simply copy the args into a vec which sits on the rust stack. This ensures the args aren't removed during the invocation.