### PR TITLE
logical operator as && and ||

### DIFF
--- a/laythe_vm/fixture/compiler/arm_compiler.lay
+++ b/laythe_vm/fixture/compiler/arm_compiler.lay
@@ -48,7 +48,7 @@ class Num {
 
   equals(other: Ast) -> bool {
     other.cls() == Num
-      and @value == other.value
+      && @value == other.value
   }
 }
 
@@ -68,7 +68,7 @@ class Id {
 
   equals(other: Ast) -> bool {
     other.cls() == Id
-      and @value.equals(other.value)
+      && @value.equals(other.value)
   }
 }
 
@@ -86,7 +86,7 @@ class Not {
 
   equals(other: Ast) -> bool {
     other.cls() == Not
-      and @term == other.term
+      && @term == other.term
   }
 }
 
@@ -105,8 +105,8 @@ class Infix {
 
   equals(other: Ast) -> bool {
     other.cls() == @cls()
-      and @left.equals(other.left)
-      and @right.equals(other.right)
+      && @left.equals(other.left)
+      && @right.equals(other.right)
   }
 }
 
@@ -169,7 +169,7 @@ class Call {
     } else if count == 1 {
       @args[0].emit(env);
       emit('  bl ${@callee}');
-    } else if count >= 2 and count <= 4 {
+    } else if count >= 2 && count <= 4 {
       emit('  sub sp, sp, #16');
       let i = 0;
       for arg in @args {
@@ -188,9 +188,9 @@ class Call {
 
   equals(other: Ast) -> bool {
     other.cls() == Call
-      and @callee == other.callee
-      and @args.len() == other.len()
-      and @args.iter()
+      && @callee == other.callee
+      && @args.len() == other.len()
+      && @args.iter()
         .zip(other.args.iter())
         .all(|both| both[0].equals(both[1]))
   }
@@ -209,7 +209,7 @@ class Return {
 
   equals(other: Ast) -> bool {
     other.cls() == Return
-      and @term.equals(other.term)
+      && @term.equals(other.term)
   }
 }
 
@@ -226,8 +226,8 @@ class Block {
 
   equals(other: Ast) -> bool {
     other.cls() == Block
-      and @stmts.len() == other.stmts.len()
-      and @stmts.iter()
+      && @stmts.len() == other.stmts.len()
+      && @stmts.iter()
         .zip(other.stmts.iter())
         .all(|both| both[0].equals(both[1]))
   }
@@ -273,9 +273,9 @@ class If {
 
   equals(other: Ast) -> bool {
     other.cls() == If
-      and @cond.equals(other.cond)
-      and @then.equals(other.then)
-      and @else_.equals(other.else_)
+      && @cond.equals(other.cond)
+      && @then.equals(other.then)
+      && @else_.equals(other.else_)
   }
 }
 
@@ -330,11 +330,11 @@ class Function {
 
   equals(other: Ast) -> bool {
     other.cls() == Function
-      and @name == other.name
-      and @parameters.iter()
+      && @name == other.name
+      && @parameters.iter()
         .zip(other.parameters.iter())
         .all(|both| both[0] == both[1])
-      and @body.equals(other.body)
+      && @body.equals(other.body)
   }
 }
 
@@ -353,8 +353,8 @@ class Var {
 
   equals(other: Ast) -> bool {
     other.cls() == Var
-      and @name == other.name
-      and @value.equals(other.value)
+      && @name == other.name
+      && @value.equals(other.value)
   }
 }
 
@@ -376,8 +376,8 @@ class Assign {
 
   equals(other: Ast) -> bool {
     other.cls() == Assign
-      and @name == other.name
-      and @value.equals(other.value)
+      && @name == other.name
+      && @value.equals(other.value)
   }
 }
 
@@ -402,8 +402,8 @@ class While {
 
   equals(other: Ast) -> bool {
     other.cls() == While
-      and @cond.equals(other.cond)
-      and @body.equals(other.body)
+      && @cond.equals(other.cond)
+      && @body.equals(other.body)
   }
 }
 

--- a/laythe_vm/fixture/demo/gameOfLife.lay
+++ b/laythe_vm/fixture/demo/gameOfLife.lay
@@ -66,7 +66,7 @@ class Universe {
     let count = 0;
     for deltaRow in [@height - 1, 0, 1] {
       for deltaCol in [@width - 1, 0, 1] {
-        if deltaRow != 0 or deltaCol != 0 {
+        if deltaRow != 0 || deltaCol != 0 {
           let neighborRow = rem(row + deltaRow, @height);
           let neighborCol = rem(col + deltaCol, @width);
 
@@ -102,7 +102,7 @@ class Universe {
 
         let nextCell = cell;
         if cell.isAlive() {
-          if liveNeighbors < 2 or liveNeighbors > 3 {
+          if liveNeighbors < 2 || liveNeighbors > 3 {
             nextCell = Cell.dead();
           } else {
             nextCell = Cell.alive();

--- a/laythe_vm/fixture/language/logical_operator/and.lay
+++ b/laythe_vm/fixture/language/logical_operator/and.lay
@@ -1,19 +1,19 @@
 // Note: These tests implicitly depend on ints being truthy.
 
 // Return the first non-true argument.
-assertEq(false and 1, false); // expect: false
-assertEq(true and 1, 1); // expect: 1
-assertEq(1 and 2 and false, false); // expect: false
+assertEq(false && 1, false); // expect: false
+assertEq(true && 1, 1); // expect: 1
+assertEq(1 && 2 && false, false); // expect: false
 
 // Return the last argument if all are true.
-assertEq(1 and true, true); // expect: true
-assertEq(1 and 2 and 3, 3); // expect: 3
+assertEq(1 && true, true); // expect: true
+assertEq(1 && 2 && 3, 3); // expect: 3
 
 // Short-circuit at the first false argument.
 let a = "before";
 let b = "before";
-(a = true) and
-    (b = false) and
+(a = true) &&
+    (b = false) &&
     (a = "bad");
 assertEq(a, true); // expect: true
 assertEq(b, false); // expect: false

--- a/laythe_vm/fixture/language/logical_operator/and_truth.lay
+++ b/laythe_vm/fixture/language/logical_operator/and_truth.lay
@@ -1,8 +1,8 @@
 // False and nil are false.
-assertEq(false and "bad", false); // expect: false
-assertEq(nil and "bad", nil); // expect: nil
+assertEq(false && "bad", false); // expect: false
+assertEq(nil && "bad", nil); // expect: nil
 
 // Everything else is true.
-assertEq(true and "ok", "ok"); // expect: ok
-assertEq(0 and "ok", "ok"); // expect: ok
-assertEq("" and "ok", "ok"); // expect: ok
+assertEq(true && "ok", "ok"); // expect: ok
+assertEq(0 && "ok", "ok"); // expect: ok
+assertEq("" && "ok", "ok"); // expect: ok

--- a/laythe_vm/fixture/language/logical_operator/or.lay
+++ b/laythe_vm/fixture/language/logical_operator/or.lay
@@ -1,19 +1,19 @@
 // Note: These tests implicitly depend on ints being truthy.
 
 // Return the first true argument.
-assertEq(1 or true, 1); // expect: 1
-assertEq(false or 1, 1); // expect: 1
-assertEq(false or false or true, true); // expect: true
+assertEq(1 || true, 1); // expect: 1
+assertEq(false || 1, 1); // expect: 1
+assertEq(false || false || true, true); // expect: true
 
 // Return the last argument if all are false.
-assertEq(false or false, false); // expect: false
-assertEq(false or false or false, false); // expect: false
+assertEq(false || false, false); // expect: false
+assertEq(false || false || false, false); // expect: false
 
 // Short-circuit at the first true argument.
 let a = "before";
 let b = "before";
-(a = false) or
-    (b = true) or
+(a = false) ||
+    (b = true) ||
     (a = "bad");
 assertEq(a, false); // expect: false
 assertEq(b, true); // expect: true

--- a/laythe_vm/fixture/language/logical_operator/or_truth.lay
+++ b/laythe_vm/fixture/language/logical_operator/or_truth.lay
@@ -1,8 +1,8 @@
 // False and nil are false.
-assertEq(false or "ok", "ok"); // expect: ok
-assertEq(nil or "ok", "ok"); // expect: ok
+assertEq(false || "ok", "ok"); // expect: ok
+assertEq(nil || "ok", "ok"); // expect: ok
 
 // Everything else is true.
-assertEq(true or "ok", true); // expect: true
-assertEq(0 or "ok", 0); // expect: 0
-assertEq("s" or "ok", "s"); // expect: s
+assertEq(true || "ok", true); // expect: true
+assertEq(0 || "ok", 0); // expect: 0
+assertEq("s" || "ok", "s"); // expect: s

--- a/laythe_vm/fixture/language/scanning/keywords.lay
+++ b/laythe_vm/fixture/language/scanning/keywords.lay
@@ -1,6 +1,5 @@
-and class else false for fn if nil or return super self true let while
+class else false for fn if nil  return super self true let while
 
-// expect: AND and null
 // expect: CLASS class null
 // expect: ELSE else null
 // expect: FALSE false null
@@ -8,7 +7,6 @@ and class else false for fn if nil or return super self true let while
 // expect: fn fn null
 // expect: IF if null
 // expect: NIL nil null
-// expect: OR or null
 // expect: RETURN return null
 // expect: SUPER super null
 // expect: self self null

--- a/laythe_vm/fixture/lox_interpreter/lox.lay
+++ b/laythe_vm/fixture/lox_interpreter/lox.lay
@@ -116,7 +116,7 @@ fn tokenTypeStr(kind) {
   return nil;
 }
 
-// Convert a keyword string to its token kind constant, or return nil
+// Convert a keyword string to its token kind constant, || return nil
 // if it's not a keyword.
 fn keywordType(name) {
   if name == "and" { return AND; }
@@ -139,11 +139,11 @@ fn keywordType(name) {
 }
 
 fn isNameStart(ch) {
-  return ch == '_' or (ch >= 'a' and ch <= 'z') or (ch >= 'A' and ch <= 'Z');
+  return ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
 }
 
 fn isDigit(ch) {
-  return ch >= '0' and ch <= '9';
+  return ch >= '0' && ch <= '9';
 }
 
 class Scanner {
@@ -218,7 +218,7 @@ class Scanner {
         self.advance();
 
         // TODO escape sequence
-        while self.ch and self.ch != '\n' {
+        while self.ch && self.ch != '\n' {
           self.advance();
         }
         if self.ch == '\n' {
@@ -227,18 +227,18 @@ class Scanner {
         self.advance();
       }
       // TODO escape sequence
-      else if ch == ' ' or ch == '\t' or ch == '\r' {
+      else if ch == ' ' || ch == '\t' || ch == '\r' {
         // Ignore whitespace: space, tab, and carriage return
       }
       else if ch == '\n' {
         // Newline
-        self.line = self.line + 1;  
+        self.line = self.line + 1;
       }
       else if ch == '"' {
         // Strings (start and end with double quote)
         let line = self.line;
         let value = "";
-        while self.ch and self.ch != '"' {
+        while self.ch && self.ch != '"' {
           if self.ch == '\n' {
             self.line = self.line + 1;
           }
@@ -280,7 +280,7 @@ class Scanner {
       else if isNameStart(ch) {
         // Identifiers and keywords
         let name = ch;
-        while isNameStart(self.ch) or isDigit(self.ch) {
+        while isNameStart(self.ch) || isDigit(self.ch) {
           name = name + self.ch;
           self.advance();
         }
@@ -500,7 +500,7 @@ class Get {
     self.object = object;
     self.name = name;
   }
-  
+
   str() {
     return "${self.object}.${self.name}";
   }
@@ -591,7 +591,7 @@ class Logical {
     if self.operator == AND {
       return left and self.right.evaluate(interpreter);
     } else {
-      return left or self.right.evaluate(interpreter);
+      return left || self.right.evaluate(interpreter);
     }
   }
 }
@@ -698,7 +698,7 @@ class Variable {
   }
 
   resolve(resolver) {
-    if resolver.scopes.len() != 0 and resolver.scopes[resolver.scopes.len() - 1].get(self.name) == false {
+    if resolver.scopes.len() != 0 && resolver.scopes[resolver.scopes.len() - 1].get(self.name) == false {
       resolver.error("Error at '${self.name}': Cannot read local variable in its own initializer.");
     }
 
@@ -1124,7 +1124,7 @@ class LoxClass {
     if method {
       return method.bind(instance);
     }
-    
+
     if self.superclass {
       return self.superclass.findMethod(instance, name);
     }
@@ -1265,7 +1265,7 @@ class Parser {
     self.hasSuperClass = superclass != nil;
     self.consume(LEFT_BRACE, "Expect '{' before class body.");
     let methods = [];
-    while self.token.kind != EOF and self.token.kind != RIGHT_BRACE {
+    while self.token.kind != EOF && self.token.kind != RIGHT_BRACE {
       methods.push(self.function("method"));
     }
     self.consume(RIGHT_BRACE, "Expect '}' after class body.");
@@ -1413,7 +1413,7 @@ class Parser {
     self.consume(LEFT_BRACE, "Expect '{' before " + kind + " body.");
 
     self.functionDepth = self.functionDepth + 1;
-    self.inInitializer = kind == "method" and name.value == "init";
+    self.inInitializer = kind == "method" && name.value == "init";
     let body = self.block();
     self.functionDepth = self.functionDepth - 1;
     self.inInitializer = false;
@@ -1423,7 +1423,7 @@ class Parser {
 
   block() {
     let statements = [];
-    while self.token.kind != EOF and self.token.kind != RIGHT_BRACE {
+    while self.token.kind != EOF && self.token.kind != RIGHT_BRACE {
       statements.push(self.declaration());
     }
     self.consume(RIGHT_BRACE, "Expect '}' after block.");
@@ -1466,7 +1466,7 @@ class Parser {
 
   equality() {
     let expr = self.comparison();
-    while self.token.kind == BANG_EQUAL or self.token.kind == EQUAL_EQUAL {
+    while self.token.kind == BANG_EQUAL || self.token.kind == EQUAL_EQUAL {
       let operator = self.token.kind;
       self.next();
       let right = self.comparison();
@@ -1477,8 +1477,8 @@ class Parser {
 
   comparison() {
     let expr = self.addition();
-    while (self.token.kind == GREATER or self.token.kind == GREATER_EQUAL or
-           self.token.kind == LESS or self.token.kind == LESS_EQUAL) {
+    while (self.token.kind == GREATER || self.token.kind == GREATER_EQUAL or
+           self.token.kind == LESS || self.token.kind == LESS_EQUAL) {
       let operator = self.token.kind;
       self.next();
       let right = self.addition();
@@ -1489,7 +1489,7 @@ class Parser {
 
   addition() {
     let expr = self.multiplication();
-    while self.token.kind == MINUS or self.token.kind == PLUS {
+    while self.token.kind == MINUS || self.token.kind == PLUS {
       let operator = self.token.kind;
       self.next();
       let right = self.multiplication();
@@ -1500,7 +1500,7 @@ class Parser {
 
   multiplication() {
     let expr = self.unary();
-    while self.token.kind == SLASH or self.token.kind == STAR {
+    while self.token.kind == SLASH || self.token.kind == STAR {
       let operator = self.token.kind;
       self.next();
       let right = self.unary();
@@ -1510,7 +1510,7 @@ class Parser {
   }
 
   unary() {
-    if self.token.kind == BANG or self.token.kind == MINUS {
+    if self.token.kind == BANG || self.token.kind == MINUS {
       let operator = self.token.kind;
       self.next();
       let right = self.unary();

--- a/laythe_vm/fixture/std_lib/math/utils/rand.lay
+++ b/laythe_vm/fixture/std_lib/math/utils/rand.lay
@@ -2,5 +2,5 @@ import std.math;
 
 for _ in 10.times() {
   let rand = math.rand();
-  assert(rand >= 0 and rand < 1);
+  assert(rand >= 0 && rand < 1);
 }

--- a/laythe_vm/src/compiler/ir/ast_printer.rs
+++ b/laythe_vm/src/compiler/ir/ast_printer.rs
@@ -454,8 +454,8 @@ impl<'a> Visitor<'a> for AstPrint {
       BinaryOp::GtEq => self.buffer.push_str(">="),
       BinaryOp::Eq => self.buffer.push_str("=="),
       BinaryOp::Ne => self.buffer.push_str("!="),
-      BinaryOp::And => self.buffer.push_str("and"),
-      BinaryOp::Or => self.buffer.push_str("or"),
+      BinaryOp::And => self.buffer.push_str("&&"),
+      BinaryOp::Or => self.buffer.push_str("||"),
     }
     self.buffer.push(' ');
     self.visit_expr(&binary.rhs);

--- a/laythe_vm/src/compiler/mod.rs
+++ b/laythe_vm/src/compiler/mod.rs
@@ -1797,7 +1797,7 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
   fn binary(&mut self, binary: &'a ast::Binary<'src>) {
     self.expr(&binary.lhs);
 
-    // emit for rhs if we're not an "and" or "or"
+    // emit for rhs if we're not an "&&" or "||"
     match &binary.op {
       ast::BinaryOp::And | ast::BinaryOp::Or => (),
       _ => self.expr(&binary.rhs),
@@ -4243,7 +4243,7 @@ mod test {
 
   #[test]
   fn and_operator() {
-    let example = "true and false;";
+    let example = "true && false;";
     let context = NoContext::default();
     let fun = test_compile(example, &context);
 
@@ -4263,7 +4263,7 @@ mod test {
 
   #[test]
   fn or_operator() {
-    let example = "false or true;";
+    let example = "false || true;";
     let context = NoContext::default();
     let fun = test_compile(example, &context);
 

--- a/laythe_vm/src/compiler/scanner.rs
+++ b/laythe_vm/src/compiler/scanner.rs
@@ -125,7 +125,13 @@ impl<'a> Scanner<'a> {
           self.make_token_source(TokenKind::Minus)
         }
       },
-      '&' => self.make_token_source(TokenKind::Amp),
+      '&' => {
+        if self.match_char('&') {
+          self.make_token_source(TokenKind::And)
+        } else {
+          self.make_token_source(TokenKind::Amp)
+        }
+      }
       '+' => {
         if self.match_char('=') {
           self.make_token_source(TokenKind::PlusEqual)
@@ -133,7 +139,13 @@ impl<'a> Scanner<'a> {
           self.make_token_source(TokenKind::Plus)
         }
       },
-      '|' => self.make_token_source(TokenKind::Pipe),
+      '|' => {
+        if self.match_char('|') {
+          self.make_token_source(TokenKind::Or)
+        } else {
+          self.make_token_source(TokenKind::Pipe)
+        }
+      }
       '/' => {
         if self.match_char('=') {
           self.make_token_source(TokenKind::SlashEqual)
@@ -439,14 +451,7 @@ impl<'a> Scanner<'a> {
 
     match chars.next() {
       Some(c1) => match c1 {
-        'a' => match chars.next() {
-          Some(c2) => match c2 {
-            'n' => self.check_keyword(2, "d", TokenKind::And),
-            's' => self.check_keyword_len(2, TokenKind::As),
-            _ => TokenKind::Identifier,
-          },
-          None => TokenKind::Identifier,
-        },
+        'a' => self.check_keyword(1, "s", TokenKind::As),
         'b' => self.check_keyword(1, "reak", TokenKind::Break),
         'c' => match chars.next() {
           Some(c2) => match c2 {
@@ -493,7 +498,6 @@ impl<'a> Scanner<'a> {
           None => TokenKind::Identifier,
         },
         'n' => self.check_keyword(1, "il", TokenKind::Nil),
-        'o' => self.check_keyword(1, "r", TokenKind::Or),
         'r' => match chars.next() {
           Some(c2) => match c2 {
             'e' => self.check_keyword(2, "turn", TokenKind::Return),
@@ -803,7 +807,7 @@ mod test {
     );
     map.insert(
       TokenKind::And,
-      TokenGen::ALpha(Box::new(|| "and".to_string())),
+      TokenGen::ALpha(Box::new(|| "&&".to_string())),
     );
     map.insert(
       TokenKind::Break,
@@ -871,7 +875,7 @@ mod test {
     );
     map.insert(
       TokenKind::Or,
-      TokenGen::ALpha(Box::new(|| "or".to_string())),
+      TokenGen::ALpha(Box::new(|| "||".to_string())),
     );
     map.insert(
       TokenKind::Launch,


### PR DESCRIPTION
## Summary
Pretty much the title. Previously `and` and `or` where keywords and have now been replace by `&&` and `||`. This is mostly to later enable `&&=` and `||=`