### PR TITLE
Fix native subclassing

### DIFF
--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -130,7 +130,7 @@ impl Class {
 
     self.fields.reserve(super_class.fields.len());
     super_class.fields.iter().for_each(|(field, index)| {
-      self.fields.insert(*field, *index as u16);
+      self.fields.insert(*field, *index);
     });
 
     debug_assert!(self

--- a/laythe_core/src/object/class.rs
+++ b/laythe_core/src/object/class.rs
@@ -92,18 +92,20 @@ impl Class {
     self
   }
 
-  pub fn add_field(&mut self, name: GcStr) -> Option<u16> {
-    let len = self.fields.len();
+  pub fn add_field(&mut self, name: GcStr) {
+    if !self.fields.contains_key(&name) {
+      let len = self.fields.len();
 
-    self.fields.insert(name, len as u16)
+      self.fields.insert(name, len as u16);
+    }
   }
 
-  pub fn add_method(&mut self, name: GcStr, method: Value) -> Option<Value> {
+  pub fn add_method(&mut self, name: GcStr, method: Value) {
     if &*name == INIT {
       self.init = Some(method)
     }
 
-    self.methods.insert(name, method)
+    self.methods.insert(name, method);
   }
 
   pub fn get_method(&self, name: &GcStr) -> Option<Value> {
@@ -127,11 +129,8 @@ impl Class {
     });
 
     self.fields.reserve(super_class.fields.len());
-    super_class.fields.iter().for_each(|(field, _index)| {
-      if self.fields.get(field).is_none() {
-        let len = self.fields.len();
-        self.fields.insert(*field, len as u16);
-      }
+    super_class.fields.iter().for_each(|(field, index)| {
+      self.fields.insert(*field, *index as u16);
     });
 
     debug_assert!(self

--- a/laythe_lib/src/global/primitives/error.rs
+++ b/laythe_lib/src/global/primitives/error.rs
@@ -15,7 +15,7 @@ use super::error_inheritance;
 
 pub const ERROR_CLASS_NAME: &str = "Error";
 const ERROR_FIELD_MESSAGE: &str = "message";
-const ERROR_FIELD_STACK: &str = "stack";
+const ERROR_FIELD_BACK_TRACE: &str = "backTrace";
 const ERROR_FIELD_INNER: &str = "inner";
 
 pub const TYPE_ERROR_NAME: &str = "TypeError";
@@ -41,7 +41,7 @@ pub fn create_error_class(hooks: &GcHooks, object: GcObj<Class>) -> GcObj<Class>
   let mut class = Class::with_inheritance(hooks, hooks.manage_str(ERROR_CLASS_NAME), object);
 
   class.add_field(hooks.manage_str(ERROR_FIELD_MESSAGE));
-  class.add_field(hooks.manage_str(ERROR_FIELD_STACK));
+  class.add_field(hooks.manage_str(ERROR_FIELD_BACK_TRACE));
   class.add_field(hooks.manage_str(ERROR_FIELD_INNER));
 
   class.add_method(
@@ -142,7 +142,7 @@ mod test {
       let error_init = ErrorInit::native(&hooks.as_gc());
       let mut test_class = hooks.manage_obj(Class::bare(hooks.manage_str("test")));
       test_class.add_field(hooks.manage_str(ERROR_FIELD_MESSAGE));
-      test_class.add_field(hooks.manage_str(ERROR_FIELD_STACK));
+      test_class.add_field(hooks.manage_str(ERROR_FIELD_BACK_TRACE));
       test_class.add_field(hooks.manage_str(ERROR_FIELD_INNER));
 
       let instance = hooks.manage_instance(test_class);

--- a/laythe_vm/fixture/std_lib/global/error/construct.lay
+++ b/laythe_vm/fixture/std_lib/global/error/construct.lay
@@ -1,0 +1,11 @@
+let error1 = Error("broken");
+let error2 = Error("broken again", error1);
+
+assertEq(error1.message, "broken");
+assertEq(error1.inner, nil);
+assertEq(error1.backTrace.cls(), List);
+assertEq(error1.backTrace.len(), 0);
+
+assertEq(error2.message, "broken again");
+assertEq(error2.inner, error1);
+assertEq(error1.backTrace.len(), 0);

--- a/laythe_vm/fixture/std_lib/global/error/sub_class.lay
+++ b/laythe_vm/fixture/std_lib/global/error/sub_class.lay
@@ -1,0 +1,18 @@
+class CustomError : Error {}
+class CustomWithInitError : Error {
+  init(message, inner) {
+    super.init(message, inner);
+  }
+}
+
+let error1 = CustomError("broken");
+assertEq(error1.message, "broken");
+assertEq(error1.inner, nil);
+assertEq(error1.backTrace.cls(), List);
+assertEq(error1.backTrace.len(), 0);
+
+let error2 = CustomWithInitError("broken again", error1);
+assertEq(error2.message, "broken again");
+assertEq(error2.inner, error1);
+assertEq(error2.backTrace.cls(), List);
+assertEq(error2.backTrace.len(), 0);

--- a/laythe_vm/tests/global.rs
+++ b/laythe_vm/tests/global.rs
@@ -81,6 +81,23 @@ fn closure() -> Result<(), std::io::Error> {
 }
 
 #[test]
+fn error() -> Result<(), std::io::Error> {
+  test_files(
+    &vec![
+      "std_lib/global/error/construct.lay",
+      "std_lib/global/error/sub_class.lay",
+    ],
+    VmExit::Ok,
+  )?;
+
+  test_files(
+    &vec![
+    ],
+    VmExit::RuntimeError,
+  )
+}
+
+#[test]
 fn fun() -> Result<(), std::io::Error> {
   test_files(
     &vec![


### PR DESCRIPTION
## Problem
Today we can't really subclass a native generated class. These problems are seen when we subclass a user generated class. Overall there were two problems

1. Adding a field assumed that something else did a dedup and we would always insert a new value
2. We didn't keep the same field order for the subclass as parent class. This likely wasn't a problem because we would cache miss the inline cache then do a lookup again

## Solution

Now we don't make the assumption on fields and we keep the same field order as our parent class.
