### PR TITLE
Typed exceptions part 1

### DIFF
--- a/laythe_vm/fixture/language/exception/multiple_catches.lay
+++ b/laythe_vm/fixture/language/exception/multiple_catches.lay
@@ -1,0 +1,7 @@
+try {
+
+} catch e: Error {
+
+} catch e {
+  
+}

--- a/laythe_vm/fixture/language/exception/nested_break.lay
+++ b/laythe_vm/fixture/language/exception/nested_break.lay
@@ -8,7 +8,7 @@ fn notThrower() {
       let c = a / b * a * a;
       c / a * b;
       break;
-    } catch {
+    } catch e {
       assert(false);
     }
   }
@@ -19,7 +19,7 @@ let caught = false;
 try {
   notThrower();
   raise Error("boom");
-} catch {
+} catch e: Error {
   caught = true;
 }
 

--- a/laythe_vm/fixture/language/exception/nested_continue.lay
+++ b/laythe_vm/fixture/language/exception/nested_continue.lay
@@ -8,7 +8,7 @@ fn notThrower() {
       let c = a / b * a * a;
       c / a * b;
       continue;
-    } catch {
+    } catch e: Error {
       assert(false);
     }
   }
@@ -19,7 +19,7 @@ let caught = false;
 try {
   notThrower();
   raise Error("boom");
-} catch {
+} catch e {
   caught = true;
 }
 

--- a/laythe_vm/fixture/language/exception/nested_return.lay
+++ b/laythe_vm/fixture/language/exception/nested_return.lay
@@ -7,7 +7,7 @@ fn notThrower() {
     let c = a / b * a * a;
     c / a * b;
     return 10;
-  } catch {
+  } catch e {
     assert(false);
   }
 }
@@ -17,7 +17,7 @@ let caught = false;
 try {
   notThrower();
   raise Error("boom");
-} catch {
+} catch e: Error {
   caught = true;
 }
 

--- a/laythe_vm/fixture/language/exception/one_deep_catch.lay
+++ b/laythe_vm/fixture/language/exception/one_deep_catch.lay
@@ -5,6 +5,6 @@ fn raiser() {
 try {
   raiser();
   assert(false);
-} catch {
+} catch e {
   assert(true);
 }

--- a/laythe_vm/fixture/language/exception/top_level_catch.lay
+++ b/laythe_vm/fixture/language/exception/top_level_catch.lay
@@ -1,6 +1,6 @@
 try {
   raise Error("raise");
   assert(false);
-} catch {
+} catch e {
 
 }

--- a/laythe_vm/fixture/language/exception/top_level_catch_raise.lay
+++ b/laythe_vm/fixture/language/exception/top_level_catch_raise.lay
@@ -1,11 +1,11 @@
 try {
   raise Error("raise");
   assert(false);
-} catch {
+} catch e: Error {
   try {
     raise Error("raise");
     assert(false);
-  } catch {
+  } catch e: Error {
     assert(true);
   }
 }

--- a/laythe_vm/fixture/language/exception/two_deep_catch.lay
+++ b/laythe_vm/fixture/language/exception/two_deep_catch.lay
@@ -9,6 +9,6 @@ fn raiser() {
 try {
   outer();
   assert(false);
-} catch {
+} catch e: Error {
   assert(true);
 }

--- a/laythe_vm/fixture/language/native/signature_fixed_arity.lay
+++ b/laythe_vm/fixture/language/native/signature_fixed_arity.lay
@@ -2,13 +2,13 @@ let list = [];
 try {
   list.insert();
   assert(false);
-} catch {
+} catch e: Error {
   assert(true);
 }
 
 try {
   list.pop(10);
   assert(false);
-} catch {
+} catch e: Error {
   assert(true);
 }

--- a/laythe_vm/fixture/language/native/signature_type.lay
+++ b/laythe_vm/fixture/language/native/signature_type.lay
@@ -3,7 +3,7 @@ let list = [];
 try {
   list.insert(true, 10);
   assert(false);
-} catch {
+} catch e: Error {
   assert(true);
 }
 

--- a/laythe_vm/fixture/language/raise/raise_error.lay
+++ b/laythe_vm/fixture/language/raise/raise_error.lay
@@ -1,6 +1,6 @@
 try {
   raise Error("example");
   assert(false);
-} catch {
+} catch _ {
   assert(true);
 }

--- a/laythe_vm/fixture/language/regression/catch_laythe_stack_overflow.lay
+++ b/laythe_vm/fixture/language/regression/catch_laythe_stack_overflow.lay
@@ -5,7 +5,7 @@ for i in 1000.times() {
     let z;
 
     [][1];
-  } catch {
+  } catch _ {
 
   }
 }

--- a/laythe_vm/fixture/language/regression/native_stack_overvflow.lay
+++ b/laythe_vm/fixture/language/regression/native_stack_overvflow.lay
@@ -1,7 +1,7 @@
 for i in 100000.times() {
   try {
     [1].iter().map(|x| [][x]).list();
-  } catch {
+  } catch e: Error {
 
   }
 }

--- a/laythe_vm/fixture/std_lib/global/iter/skip.lay
+++ b/laythe_vm/fixture/std_lib/global/iter/skip.lay
@@ -13,13 +13,13 @@ for i in [1, 2, 3].iter().skip(2) {
 try {
   [].iter().skip(1.5);
   assert(false);
-} catch {
+} catch _ {
   assert(true);
 }
 
 try {
   [].iter().skip(-5);
   assert(false);
-} catch {
+} catch e: Error{
   assert(true);
 }

--- a/laythe_vm/fixture/std_lib/global/iter/take.lay
+++ b/laythe_vm/fixture/std_lib/global/iter/take.lay
@@ -13,13 +13,13 @@ for i in [1, 2, 3].iter().take(1) {
 try {
   [].iter().take(1.5);
   assert(false);
-} catch {
+} catch _ {
   assert(true);
 }
 
 try {
   [].iter().take(-5);
   assert(false);
-} catch {
+} catch e: Error {
   assert(true);
 }

--- a/laythe_vm/fixture/std_lib/global/str/index.lay
+++ b/laythe_vm/fixture/std_lib/global/str/index.lay
@@ -9,14 +9,14 @@ assertEq(testString[-testString.len()], "s");
 try {
   testString[50];
   assert(false);
-} catch { }
+} catch e { }
 
 try {
   testString[-50];
   assert(false);
-} catch { }
+} catch _ { }
 
 try {
   testString[1.5];
   assert(false);
-} catch { }
+} catch _: Error{ }

--- a/laythe_vm/fixture/std_lib/io/fs/removeFile.lay
+++ b/laythe_vm/fixture/std_lib/io/fs/removeFile.lay
@@ -8,6 +8,6 @@ removeFile(path);
 try {
   readFile(path);
   assertEq(true, false);
-} catch {
+} catch _: Error{
   assertEq(true, true);
 }

--- a/laythe_vm/src/compiler/ir/ast.rs
+++ b/laythe_vm/src/compiler/ir/ast.rs
@@ -579,18 +579,42 @@ impl<'a> Spanned for While<'a> {
 
 pub struct Try<'a> {
   pub block: Block<'a>,
-  pub catch: Block<'a>,
+  pub catches: Vec<'a, Catch<'a>>,
 }
 
 impl<'a> Try<'a> {
-  pub fn new(block: Block<'a>, catch: Block<'a>) -> Self {
-    Self { block, catch }
+  pub fn new(block: Block<'a>, catches: Vec<'a, Catch<'a>>) -> Self {
+    Self { block, catches }
   }
 }
 
 impl<'a> Spanned for Try<'a> {
   fn start(&self) -> u32 {
     self.block.start()
+  }
+
+  fn end(&self) -> u32 {
+    self.catches.last().unwrap().end()
+  }
+}
+
+
+pub struct Catch<'a> {
+  pub name: Token<'a>,
+  pub symbols: SymbolTable<'a>,
+  pub class: Option<Token<'a>>,
+  pub block: Block<'a>,
+}
+
+impl<'a> Catch<'a> {
+  pub fn new(name: Token<'a>, class: Option<Token<'a>>, symbols: SymbolTable<'a>, block: Block<'a>) -> Self {
+    Self { name, class, symbols, block }
+  }
+}
+
+impl<'a> Spanned for Catch<'a> {
+  fn start(&self) -> u32 {
+    self.name.start()
   }
 
   fn end(&self) -> u32 {

--- a/laythe_vm/src/compiler/ir/ast_printer.rs
+++ b/laythe_vm/src/compiler/ir/ast_printer.rs
@@ -57,6 +57,7 @@ pub trait Visitor<'a> {
   fn visit_continue(&mut self, continue_: &Token<'a>) -> Self::Result;
   fn visit_break(&mut self, break_: &Token<'a>) -> Self::Result;
   fn visit_try(&mut self, try_: &Try) -> Self::Result;
+  fn visit_catch(&mut self, try_: &Catch) -> Self::Result;
   fn visit_raise(&mut self, raise: &Raise) -> Self::Result;
   fn visit_block(&mut self, block: &Block) -> Self::Result;
 
@@ -469,8 +470,22 @@ impl<'a> Visitor<'a> for AstPrint {
 
     self.visit_block(&try_.block);
 
+    for catch in &try_.catches {
+      self.visit_catch(catch)
+    }
+  }
+
+  fn visit_catch(&mut self, catch: &Catch) -> Self::Result {
     self.buffer.push_str(" catch ");
-    self.visit_block(&try_.catch);
+
+    self.buffer.push_str(&catch.name.str());
+
+    if let Some(class) = &catch.class {
+      self.buffer.push_str(": ");
+      self.buffer.push_str(&class.str());
+    }
+
+    self.visit_block(&catch.block);
   }
 
   fn visit_raise(&mut self, raise: &Raise) -> Self::Result {
@@ -752,6 +767,10 @@ impl TypeVisitor for AstPrint {
 
     for member in trait_.members.iter() {
       self.visit_type_member(member);
+    }
+
+    for method in trait_.methods.iter() {
+      self.visit_type_method(method);
     }
 
     self.depth -= 1;

--- a/laythe_vm/tests/language.rs
+++ b/laythe_vm/tests/language.rs
@@ -315,6 +315,7 @@ fn exception() -> Result<(), std::io::Error> {
       "language/exception/one_deep_catch.lay",
       "language/exception/two_deep_catch.lay",
       "language/exception/top_level_catch_raise.lay",
+      "language/exception/multiple_catches.lay",
     ],
     VmExit::Ok,
   )?;


### PR DESCRIPTION
## Problem
Laythe has had exceptions for a while but the system was bare bones to say the least. Right now we can throw an Error and we can catch an Error but there isn't the ability to actually access that error when caught or to discriminate based on the Error class

## Solution
This PR creates and superficially supports an exceptions syntax where errors can be used and multiple catches can be employed. As an example we can now do the following

```laythe
try {

} catch e: SpecificError {
  print("Do the thing ${e.message}");
} catch e: Error { 
  print("Don't do the thing ${e.message}");
}
```

Today while we validate that the Error class exists and is in scope. We don't bind the error message and we ignore all but the last catch handle. These will be implemented in a later PR

