### PR TITLE
Update actions to non-deprecated

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,19 +13,19 @@ jobs:
   test:
     name: Test Laythe with Rust ${{ matrix.rust }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest] # windows-latest failing cwd test
         rust: [stable, nightly]
-    
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions/checkout@v4
+    - uses: hecrj/setup-rust-action@v2
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
     - run: cargo test
 
   lint:
@@ -36,23 +36,23 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: cargo clippy
 
   bench:
     name: Benching Laythe with Rust ${{ matrix.rust }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-  
+
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         rust: [stable, nightly]
-        
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions/checkout@v4
+    - uses: hecrj/setup-rust-action@v2
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
     - run: cargo bench --workspace --all


### PR DESCRIPTION
## Summary
Update GH actions to latest version to drop deprecation warnings.