### PR TITLE
Typed exceptions part 2

### DIFF
--- a/laythe_core/src/object/channel.rs
+++ b/laythe_core/src/object/channel.rs
@@ -5,13 +5,19 @@ use crate::{
   value::Value,
   LyHashSet,
 };
-use std::{collections::VecDeque};
+use std::collections::VecDeque;
 use std::{fmt, io::Write};
 
+/// What type of channel is this
 #[derive(PartialEq, Clone, Debug)]
 enum ChannelKind {
+  /// This channel and both send and receive
   BiDirectional,
+
+  /// This channel can only receive
   ReceiveOnly,
+
+  /// This channel can only send
   SendOnly,
 }
 
@@ -22,9 +28,14 @@ enum ChannelQueueState {
   ClosedEmpty,
 }
 
+/// What type of queue does
+/// this channel possess
 #[derive(PartialEq, Clone, Debug)]
 enum ChannelQueueKind {
+  /// This channel is sync and will context switch on each value
   Sync,
+
+  /// This channel is buffered and may not context switch immediately
   Buffered,
 }
 
@@ -156,7 +167,7 @@ impl ChannelQueue {
           self.send_waiters.insert(fiber);
           SendResult::Full(get_runnable_from_set(&mut self.receive_waiters))
         }
-      }
+      },
       ChannelQueueState::Closed | ChannelQueueState::ClosedEmpty => SendResult::Closed,
     }
   }
@@ -176,14 +187,14 @@ impl ChannelQueue {
           } else {
             ReceiveResult::Empty(get_runnable_from_set(&mut self.send_waiters))
           }
-        }
+        },
       },
       ChannelQueueState::Closed => match self.queue.pop_front() {
         Some(value) => ReceiveResult::Ok(value),
         None => {
           self.state = ChannelQueueState::ClosedEmpty;
           ReceiveResult::Closed
-        }
+        },
       },
       ChannelQueueState::ClosedEmpty => ReceiveResult::Closed,
     }
@@ -199,7 +210,7 @@ impl ChannelQueue {
         } else {
           get_runnable_from_set(&mut self.receive_waiters)
         }
-      }
+      },
       ChannelQueueKind::Buffered => {
         if self.is_empty() && !self.is_closed() {
           get_runnable_from_set(&mut self.send_waiters)
@@ -209,7 +220,7 @@ impl ChannelQueue {
           get_runnable_from_set(&mut self.receive_waiters)
             .or_else(|| get_runnable_from_set(&mut self.send_waiters))
         }
-      }
+      },
     }
   }
 
@@ -573,7 +584,7 @@ mod test {
             } else {
               assert!(false)
             }
-          }
+          },
           _ => assert!(false),
         }
 

--- a/laythe_core/src/object/fiber/mod.rs
+++ b/laythe_core/src/object/fiber/mod.rs
@@ -157,28 +157,28 @@ impl Fiber {
     self.state == FiberState::Pending
   }
 
-  /// Activate the current fiber
+  /// Activate this fiber
   #[inline]
   pub fn activate(&mut self) {
     assert_eq!(self.state, FiberState::Pending);
     self.state = FiberState::Running;
   }
 
-  /// Put the current fiber to sleep
+  /// Put this fiber to sleep
   #[inline]
   pub fn sleep(&mut self) {
     assert_eq!(self.state, FiberState::Running);
     self.state = FiberState::Pending;
   }
 
-  /// Put the current fiber to sleep
+  /// Block this fiber
   #[inline]
   pub fn block(&mut self) {
     assert_eq!(self.state, FiberState::Running);
     self.state = FiberState::Blocked;
   }
 
-  /// Put the current fiber to sleep
+  /// Unblock this fiber
   #[inline]
   pub fn unblock(&mut self) {
     assert!(matches!(

--- a/laythe_core/src/object/native.rs
+++ b/laythe_core/src/object/native.rs
@@ -1,7 +1,7 @@
 use crate::{
   hooks::{GcHooks, Hooks},
   managed::{DebugHeap, DebugWrap, GcStr, Object, Trace},
-  signature::{Arity, Environment, ParameterBuilder, Signature, SignatureBuilder},
+  signature::{Arity, NativeEnvironment, ParameterBuilder, Signature, SignatureBuilder},
   value::Value,
   Call,
 };
@@ -18,7 +18,7 @@ pub struct NativeMetaBuilder {
   pub is_method: bool,
 
   /// Does this
-  pub environment: Environment,
+  pub environment: NativeEnvironment,
 
   /// The signature of this native function or method
   pub signature: SignatureBuilder,
@@ -30,7 +30,7 @@ impl NativeMetaBuilder {
     NativeMetaBuilder {
       name,
       is_method: false,
-      environment: Environment::StackLess,
+      environment: NativeEnvironment::StackLess,
       signature: SignatureBuilder::new(arity),
     }
   }
@@ -40,7 +40,7 @@ impl NativeMetaBuilder {
     NativeMetaBuilder {
       name,
       is_method: true,
-      environment: Environment::StackLess,
+      environment: NativeEnvironment::StackLess,
       signature: SignatureBuilder::new(arity),
     }
   }
@@ -60,7 +60,7 @@ impl NativeMetaBuilder {
     Self {
       name: self.name,
       is_method: self.is_method,
-      environment: Environment::Normal,
+      environment: NativeEnvironment::Normal,
       signature: self.signature,
     }
   }
@@ -85,7 +85,7 @@ pub struct NativeMeta {
   pub is_method: bool,
 
   /// Does this
-  pub environment: Environment,
+  pub environment: NativeEnvironment,
 
   /// The signature of this native function or method
   pub signature: Signature,

--- a/laythe_core/src/signature.rs
+++ b/laythe_core/src/signature.rs
@@ -48,13 +48,13 @@ impl Arity {
         if arg_count != arity {
           return Err(ArityError::Fixed(arity));
         }
-      }
+      },
       // if variadic and ending with ... take arity +
       Self::Variadic(arity) => {
         if arg_count < arity {
           return Err(ArityError::Variadic(arity));
         }
-      }
+      },
       // if defaulted we need between the min and max
       Self::Default(min_arity, max_arity) => {
         if arg_count < min_arity {
@@ -63,7 +63,7 @@ impl Arity {
         if arg_count > max_arity {
           return Err(ArityError::DefaultHigh(max_arity));
         }
-      }
+      },
     }
 
     Ok(())
@@ -209,7 +209,7 @@ impl Display for ParameterKind {
 }
 
 #[derive(Clone, Debug, Copy)]
-pub enum Environment {
+pub enum NativeEnvironment {
   StackLess,
   Normal,
 }
@@ -291,7 +291,7 @@ impl Signature {
             return Err(SignatureError::TypeWrong(index as u8));
           }
         }
-      }
+      },
       // if variadic and ending with ... take arity +
       Arity::Variadic(arity) => {
         if count < arity as usize {
@@ -322,7 +322,7 @@ impl Signature {
             return Err(SignatureError::TypeWrong(arity + index as u8));
           }
         }
-      }
+      },
       // if defaulted we need between the min and max
       Arity::Default(min_arity, max_arity) => {
         if count < min_arity as usize {
@@ -337,7 +337,7 @@ impl Signature {
             return Err(SignatureError::TypeWrong(index as u8));
           }
         }
-      }
+      },
     }
 
     Ok(())

--- a/laythe_vm/src/debug.rs
+++ b/laythe_vm/src/debug.rs
@@ -527,6 +527,7 @@ pub fn disassemble_instruction(
       push_handler_instruction(stdio.stdout(), "PushHandler", slots, jump, offset)
     },
     AlignedByteCode::PopHandler => simple_instruction(stdio.stdout(), "PopHandler", offset),
+    AlignedByteCode::FinishUnwind => simple_instruction(stdio.stdout(), "FinishUnwind", offset),
     AlignedByteCode::Raise => simple_instruction(stdio.stdout(), "Raise", offset),
     AlignedByteCode::Equal => simple_instruction(stdio.stdout(), "Equal", offset),
     AlignedByteCode::NotEqual => simple_instruction(stdio.stdout(), "NotEqual", offset),

--- a/laythe_vm/src/vm/basic.rs
+++ b/laythe_vm/src/vm/basic.rs
@@ -1,4 +1,4 @@
-use super::{Vm, Signal};
+use super::{Vm, ExecutionSignal};
 use crate::cache::InlineCache;
 use laythe_core::{
   managed::{Allocate, DebugHeapRef, GcObj, GcStr, Instance, Object, Trace, Tuple},
@@ -143,7 +143,7 @@ impl Vm {
   /// Pop a frame off the call stack. If no frame remain
   /// return the exit signal otherwise set the instruction
   /// pointer and current function
-  pub(super) unsafe fn pop_frame(&mut self) -> Option<Signal> {
+  pub(super) unsafe fn pop_frame(&mut self) -> Option<ExecutionSignal> {
     match self.fiber.pop_frame() {
       Some(current_fun) => match current_fun {
         Some(current_fun) => {
@@ -153,13 +153,13 @@ impl Vm {
         },
         None => {
           if self.fiber == self.main_fiber {
-            Some(Signal::Exit)
+            Some(ExecutionSignal::Exit)
           } else {
             if let Some(mut fiber) = Fiber::complete(self.fiber) {
               fiber.unblock();
               self.fiber_queue.push_back(fiber);
             }
-            Some(Signal::ContextSwitch)
+            Some(ExecutionSignal::ContextSwitch)
           }
         },
       },

--- a/laythe_vm/src/vm/error.rs
+++ b/laythe_vm/src/vm/error.rs
@@ -56,7 +56,7 @@ impl Vm {
     };
 
     match self.fiber.stack_unwind(bottom_frame) {
-      UnwindResult::Handled(frame) => {
+      UnwindResult::PotentiallyHandled(frame) => {
         self.current_fun = frame.fun();
         self.ip = frame.ip();
         None

--- a/laythe_vm/src/vm/mod.rs
+++ b/laythe_vm/src/vm/mod.rs
@@ -366,6 +366,7 @@ impl Vm {
           ByteCode::Loop => self.op_loop(),
           ByteCode::PushHandler => self.op_push_handler(),
           ByteCode::PopHandler => self.op_pop_handler(),
+          ByteCode::FinishUnwind => self.op_finish_unwind(),
           ByteCode::Raise => self.op_raise(),
           ByteCode::DefineGlobal => self.op_define_global(),
           ByteCode::Box => self.op_box(),

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -513,6 +513,11 @@ impl Vm {
     ExecutionSignal::Ok
   }
 
+  pub(super) unsafe fn op_finish_unwind(&mut self) -> ExecutionSignal {
+    self.fiber.finish_unwind();
+    ExecutionSignal::Ok
+  }
+
   pub(super) unsafe fn op_raise(&mut self) -> ExecutionSignal {
     let exception = self.fiber.pop();
 


### PR DESCRIPTION
## Problem
In a world where catch block may conditionally work we need to be able to handle that conditional nature. That means we may need to continue to unwind if we don't have an appropriate handler or we may need to jump to a specific handler

## Solution
In a sort of pseudo code we'll basically want our execution to flow like this

```laythe
try {
  something()
} catch: Error1 { 
  // handle somehow 1 
} catch: Error2 { 
  // handle somehow 2
}

// We can think of this as

try {
  something();
} maybeCatch e: Error { // this is any error 
  if e.isA(Error1) { 
    forSureCatch();
    // handle somehow 1
  } else if e.isA(Error2) { 
    forSureCatch();
    // handle somehow 2
  } else { 
    continueUnwind();
  }
}
```

In the background we'll basically run some instructions to check if the error subclasses the error message handler. then run the handler. If non match then we'll continue the unwind.

This PR in particular implements what is described above as `forSureCatch`. We still ignore the catch variable and the other catches but have some of the need functionality in place. 