### PR TITLE
Actually allow error subclasses

### DIFF
--- a/laythe_vm/fixture/language/raise/raise_error.lay
+++ b/laythe_vm/fixture/language/raise/raise_error.lay
@@ -1,5 +1,5 @@
 try {
-  raise Error("example");
+  raise RuntimeError("example");
   assert(false);
 } catch _ {
   assert(true);

--- a/laythe_vm/fixture/language/raise/raise_error_subclass.lay
+++ b/laythe_vm/fixture/language/raise/raise_error_subclass.lay
@@ -1,0 +1,11 @@
+class MyError: Error {}
+
+try {
+  let error = MyError("example");
+  assertEq(error.message, "example");
+
+  raise error;
+  assert(false);
+} catch _ {
+  assert(true);
+}

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -524,7 +524,7 @@ impl Vm {
     if_let_obj!(ObjectKind::Instance(exception) = (exception) {
       let class = exception.class();
 
-      if class == self.builtin.errors.error {
+      if class.is_subclass(self.builtin.errors.error) {
         self.set_error(exception)
       } else {
         self.runtime_error(

--- a/laythe_vm/tests/language.rs
+++ b/laythe_vm/tests/language.rs
@@ -1016,6 +1016,7 @@ fn raise() -> Result<(), std::io::Error> {
   test_file_exits(
     &vec![
       "language/raise/raise_error.lay",
+      "language/raise/raise_error_subclass.lay",
     ],
     VmExit::Ok,
   )?;


### PR DESCRIPTION
## Problem
It seems I never made it possible to actually raise something other than the base `Error`

## Solution
Allows the user to raise anything that subclasses `Error`