### PR TITLE
Simplify native calls

### DIFF
--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -170,7 +170,7 @@ impl Fun {
       // if fixed we need exactly the correct amount
       Arity::Fixed(arity) => {
         if arg_count != arity {
-          return Err(hooks.manage_str(&format!(
+          return Err(hooks.manage_str(format!(
             "{} expected {} argument(s) but received {}.",
             self.name(),
             arity,
@@ -181,7 +181,7 @@ impl Fun {
       // if variadic and ending with ... take arity +
       Arity::Variadic(arity) => {
         if arg_count < arity {
-          return Err(hooks.manage_str(&format!(
+          return Err(hooks.manage_str(format!(
             "{} expected at least {} argument(s) but got {}.",
             self.name(),
             arity,
@@ -192,7 +192,7 @@ impl Fun {
       // if defaulted we need between the min and max
       Arity::Default(min_arity, max_arity) => {
         if arg_count < min_arity {
-          return Err(hooks.manage_str(&format!(
+          return Err(hooks.manage_str(format!(
             "{} expected at least {} argument(s) but got {}.",
             self.name(),
             min_arity,
@@ -200,7 +200,7 @@ impl Fun {
           )));
         }
         if arg_count > max_arity {
-          return Err(hooks.manage_str(&format!(
+          return Err(hooks.manage_str(format!(
             "{} expected at most {} argument(s) but got {}.",
             self.name(),
             max_arity,

--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -165,12 +165,12 @@ impl Fun {
   }
 
   #[inline]
-  pub fn check_if_valid_call(&self, hooks: &GcHooks, arg_count: u8) -> Result<(), GcStr> {
+  pub fn check_if_valid_call<'a, F: FnOnce() -> GcHooks<'a>>(&self, hooks_gen: F, arg_count: u8) -> Result<(), GcStr> {
     match self.arity {
       // if fixed we need exactly the correct amount
       Arity::Fixed(arity) => {
         if arg_count != arity {
-          return Err(hooks.manage_str(format!(
+          return Err(hooks_gen().manage_str(format!(
             "{} expected {} argument(s) but received {}.",
             self.name(),
             arity,
@@ -181,7 +181,7 @@ impl Fun {
       // if variadic and ending with ... take arity +
       Arity::Variadic(arity) => {
         if arg_count < arity {
-          return Err(hooks.manage_str(format!(
+          return Err(hooks_gen().manage_str(format!(
             "{} expected at least {} argument(s) but got {}.",
             self.name(),
             arity,
@@ -192,7 +192,7 @@ impl Fun {
       // if defaulted we need between the min and max
       Arity::Default(min_arity, max_arity) => {
         if arg_count < min_arity {
-          return Err(hooks.manage_str(format!(
+          return Err(hooks_gen().manage_str(format!(
             "{} expected at least {} argument(s) but got {}.",
             self.name(),
             min_arity,
@@ -200,7 +200,7 @@ impl Fun {
           )));
         }
         if arg_count > max_arity {
-          return Err(hooks.manage_str(format!(
+          return Err(hooks_gen().manage_str(format!(
             "{} expected at most {} argument(s) but got {}.",
             self.name(),
             max_arity,

--- a/laythe_core/src/object/fun.rs
+++ b/laythe_core/src/object/fun.rs
@@ -164,10 +164,61 @@ impl Fun {
     self.name = new_name;
   }
 
-  /// Arity of this function
   #[inline]
-  pub fn arity(&self) -> &Arity {
-    &self.arity
+  pub fn check_if_valid_call(&self, hooks: &GcHooks, arg_count: u8) -> Result<(), GcStr> {
+    match self.arity {
+      // if fixed we need exactly the correct amount
+      Arity::Fixed(arity) => {
+        if arg_count != arity {
+          return Err(hooks.manage_str(&format!(
+            "{} expected {} argument(s) but received {}.",
+            self.name(),
+            arity,
+            arg_count,
+          )));
+        }
+      },
+      // if variadic and ending with ... take arity +
+      Arity::Variadic(arity) => {
+        if arg_count < arity {
+          return Err(hooks.manage_str(&format!(
+            "{} expected at least {} argument(s) but got {}.",
+            self.name(),
+            arity,
+            arg_count,
+          )));
+        }
+      },
+      // if defaulted we need between the min and max
+      Arity::Default(min_arity, max_arity) => {
+        if arg_count < min_arity {
+          return Err(hooks.manage_str(&format!(
+            "{} expected at least {} argument(s) but got {}.",
+            self.name(),
+            min_arity,
+            arg_count,
+          )));
+        }
+        if arg_count > max_arity {
+          return Err(hooks.manage_str(&format!(
+            "{} expected at most {} argument(s) but got {}.",
+            self.name(),
+            max_arity,
+            arg_count,
+          )));
+        }
+      },
+    };
+    Ok(())
+  }
+
+  #[inline]
+  pub fn parameter_count(&self) -> u8 {
+    match self.arity {
+      Arity::Default(req, _) => req,
+      Arity::Fixed(req) => req,
+      Arity::Variadic(req) => req,
+    }
   }
 
   /// Code for the function body

--- a/laythe_core/src/object/native.rs
+++ b/laythe_core/src/object/native.rs
@@ -152,7 +152,7 @@ impl Native {
       // if fixed we need exactly the correct amount
       Arity::Fixed(arity) => {
         if args_count != arity as usize {
-          return Err(hooks.manage_str(&format!(
+          return Err(hooks.manage_str(format!(
             "{} expected {} argument(s) but received {}.",
             self.name(),
             self.real_arg_count(arity as usize),
@@ -162,7 +162,7 @@ impl Native {
 
         for (argument, parameter) in args.iter().zip(parameters.iter()) {
           if !parameter.kind.is_valid(*argument) {
-            return Err(hooks.manage_str(&format!(
+            return Err(hooks.manage_str(format!(
               "{}'s parameter \"{}\" required a {} but received a {}.",
               self.name(),
               parameter.name,
@@ -175,7 +175,7 @@ impl Native {
       // if variadic and ending with ... take arity +
       Arity::Variadic(arity) => {
         if args_count < arity as usize {
-          return Err(hooks.manage_str(&format!(
+          return Err(hooks.manage_str(format!(
             "{} expected at least {} argument(s) but received {}.",
             self.name(),
             self.real_arg_count(arity as usize),
@@ -188,7 +188,7 @@ impl Native {
         if arity != 0 {
           for (argument, parameter) in args.iter().zip(parameters.iter()).take(arity as usize) {
             if !parameter.kind.is_valid(*argument) {
-              return Err(hooks.manage_str(&format!(
+              return Err(hooks.manage_str(format!(
                 "{}'s parameter \"{}\" required a {} but received a {}.",
                 self.name(),
                 parameter.name,
@@ -201,7 +201,7 @@ impl Native {
 
         for argument in args[arity as usize..].iter() {
           if !variadic_type.kind.is_valid(*argument) {
-            return Err(hooks.manage_str(&format!(
+            return Err(hooks.manage_str(format!(
               "{}'s parameter \"{}\" required a {} but received a {}.",
               self.name(),
               variadic_type.name,
@@ -214,7 +214,7 @@ impl Native {
       // if defaulted we need between the min and max
       Arity::Default(min_arity, max_arity) => {
         if args_count < min_arity as usize {
-          return Err(hooks.manage_str(&format!(
+          return Err(hooks.manage_str(format!(
             "{} expected at least {} argument(s) but received {}.",
             self.name(),
             self.real_arg_count(min_arity as usize),
@@ -222,7 +222,7 @@ impl Native {
           )));
         }
         if args_count > max_arity as usize {
-          return Err(hooks.manage_str(&format!(
+          return Err(hooks.manage_str(format!(
             "{} expected at most {} argument(s) but received {}.",
             self.name(),
             self.real_arg_count(max_arity as usize),

--- a/laythe_core/src/signature.rs
+++ b/laythe_core/src/signature.rs
@@ -70,10 +70,10 @@ impl Arity {
   }
 
   pub fn required_parameter(&self) -> usize {
-    match self {
-      &Self::Fixed(i) => i as usize,
-      &Self::Variadic(i) => i as usize + 1,
-      &Self::Default(_, i) => i as usize,
+    match *self {
+      Self::Fixed(i) => i as usize,
+      Self::Variadic(i) => i as usize + 1,
+      Self::Default(_, i) => i as usize,
     }
   }
 }

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -1011,7 +1011,6 @@ mod test {
     let fun2 = value.to_obj().to_fun();
 
     assert_eq!(fun.name(), fun2.name());
-    assert_eq!(fun.arity(), fun2.arity());
   }
 
   #[test]

--- a/laythe_lib/src/env/utils.rs
+++ b/laythe_lib/src/env/utils.rs
@@ -1,6 +1,14 @@
 use crate::{native, support::export_and_insert, StdResult};
 use laythe_core::{
-  hooks::{GcHooks, Hooks}, list, managed::{Gc, GcObj, List, Trace}, module::Module, object::{LyNative, Native, NativeMetaBuilder}, signature::Arity, val, value::Value, Call
+  hooks::{GcHooks, Hooks},
+  list,
+  managed::{Gc, GcObj, List, Trace},
+  module::Module,
+  object::{LyNative, Native, NativeMetaBuilder},
+  signature::Arity,
+  val,
+  value::Value,
+  Call,
 };
 use std::io::Write;
 
@@ -28,7 +36,7 @@ pub fn define_env_module(_: &GcHooks, _: &mut Module) -> StdResult<()> {
 native!(Args, ARGS_META);
 
 impl LyNative for Args {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     let io = hooks.as_io();
     let mut list: List = hooks.manage_obj(list!());
     hooks.push_root(list);
@@ -46,7 +54,7 @@ impl LyNative for Args {
 native!(Cwd, CWD_META);
 
 impl LyNative for Cwd {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     let io = hooks.as_io();
     match io.env().current_dir() {
       Ok(path) => match path.to_str() {
@@ -60,41 +68,11 @@ impl LyNative for Cwd {
 
 #[cfg(test)]
 mod test {
-  use super::*;
-
   mod args {
-    use super::*;
-    use crate::support::MockedContext;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let stdout_write = Args::native(&hooks);
-
-      assert_eq!(stdout_write.meta().name, "args");
-      assert_eq!(stdout_write.meta().signature.arity, Arity::Fixed(0));
-    }
-
     // TODO: call
   }
 
   mod cwd {
-    use super::*;
-    use crate::support::MockedContext;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let stdout_write = Cwd::native(&hooks);
-
-      assert_eq!(stdout_write.meta().name, "cwd");
-      assert_eq!(stdout_write.meta().signature.arity, Arity::Fixed(0));
-    }
-
     // TODO: call
   }
 }

--- a/laythe_lib/src/global/primitives/bool.rs
+++ b/laythe_lib/src/global/primitives/bool.rs
@@ -39,8 +39,8 @@ pub fn define_bool_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
 native!(BoolStr, BOOL_STR);
 
 impl LyNative for BoolStr {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    if this.unwrap() == VALUE_TRUE {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    if args[0] == VALUE_TRUE {
       Call::Ok(val!(hooks.manage_str("true")))
     } else {
       Call::Ok(val!(hooks.manage_str("false")))
@@ -57,17 +57,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let bool_str = BoolStr::native(&hooks);
-
-      assert_eq!(bool_str.meta().name, "str");
-      assert_eq!(bool_str.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -77,8 +66,8 @@ mod test {
       let b_true = val!(true);
       let b_false = val!(false);
 
-      let result1 = bool_str.call(&mut hooks, Some(b_true), &[]);
-      let result2 = bool_str.call(&mut hooks, Some(b_false), &[]);
+      let result1 = bool_str.call(&mut hooks, &[b_true]);
+      let result2 = bool_str.call(&mut hooks, &[b_false]);
 
       assert_eq!(result1.unwrap().to_obj().to_str(), "true");
       assert_eq!(result2.unwrap().to_obj().to_str(), "false");

--- a/laythe_lib/src/global/primitives/class.rs
+++ b/laythe_lib/src/global/primitives/class.rs
@@ -42,9 +42,8 @@ pub fn create_class_class(hooks: &GcHooks, object: GcObj<Class>) -> GcObj<Class>
 native!(ClassSuperCls, CLASS_SUPER_CLS);
 
 impl LyNative for ClassSuperCls {
-  fn call(&self, _hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let super_class = this
-      .unwrap()
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
+    let super_class = args[0]
       .to_obj()
       .to_class()
       .super_class()
@@ -58,8 +57,8 @@ impl LyNative for ClassSuperCls {
 native!(ClassStr, CLASS_STR);
 
 impl LyNative for ClassStr {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let class = this.unwrap().to_obj().to_class();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let class = args[0].to_obj().to_class();
 
     Call::Ok(val!(hooks.manage_str(format!(
       "<class {} {:p}>",
@@ -72,8 +71,8 @@ impl LyNative for ClassStr {
 native!(ClassName, CLASS_NAME);
 
 impl LyNative for ClassName {
-  fn call(&self, _hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let class = this.unwrap().to_obj().to_class();
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
+    let class = args[0].to_obj().to_class();
     Call::Ok(val!(class.name()))
   }
 }
@@ -85,17 +84,6 @@ mod test {
 
   mod super_cls {
     use super::*;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let class_super_class = ClassSuperCls::native(&hooks);
-
-      assert_eq!(class_super_class.meta().name, "superCls");
-      assert_eq!(class_super_class.meta().signature.arity, Arity::Fixed(0));
-    }
 
     #[test]
     fn call() {
@@ -112,8 +100,8 @@ mod test {
       let class_value = val!(class);
       let super_class_value = val!(super_class);
 
-      let result1 = class_super_class.call(&mut hooks, Some(class_value), &[]);
-      let result2 = class_super_class.call(&mut hooks, Some(super_class_value), &[]);
+      let result1 = class_super_class.call(&mut hooks, &[class_value]);
+      let result2 = class_super_class.call(&mut hooks, &[super_class_value]);
 
       match result1 {
         Call::Ok(r) => assert_eq!(r, super_class_value),
@@ -130,17 +118,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let class_str = ClassStr::native(&hooks);
-
-      assert_eq!(class_str.meta().name, "str");
-      assert_eq!(class_str.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -150,24 +127,13 @@ mod test {
 
       let class_value = val!(class);
 
-      let result = class_str.call(&mut hooks, Some(class_value), &[]).unwrap();
+      let result = class_str.call(&mut hooks, &[class_value]).unwrap();
       assert!(result.to_obj().to_str().contains("<class someClass"));
     }
   }
 
   mod name {
     use super::*;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let class_str = ClassName::native(&hooks);
-
-      assert_eq!(class_str.meta().name, "name");
-      assert_eq!(class_str.meta().signature.arity, Arity::Fixed(0));
-    }
 
     #[test]
     fn call() {
@@ -179,7 +145,7 @@ mod test {
 
       let class_value = val!(class);
 
-      let result = class_str.call(&mut hooks, Some(class_value), &[]).unwrap();
+      let result = class_str.call(&mut hooks, &[class_value]).unwrap();
       assert_eq!(result.to_obj().to_str(), "someClass");
     }
   }

--- a/laythe_lib/src/global/primitives/fiber.rs
+++ b/laythe_lib/src/global/primitives/fiber.rs
@@ -39,8 +39,8 @@ pub fn define_fiber_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> 
 native!(FiberStr, FIBER_STR);
 
 impl LyNative for FiberStr {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let this = this.unwrap();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let this = args[0];
     let class = hooks.get_class(this);
     let fiber = this.to_obj().to_fiber();
 
@@ -63,17 +63,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let fiber_str = FiberStr::native(&hooks);
-
-      assert_eq!(fiber_str.meta().name, "str");
-      assert_eq!(fiber_str.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::with_std(&[]).expect("std lib failure");
       let mut hooks = Hooks::new(&mut context);
@@ -85,7 +74,7 @@ mod test {
         .build(&hooks.as_gc())
         .unwrap();
 
-      let result = fiber_str.call(&mut hooks, Some(val!(fiber)), &[]).unwrap();
+      let result = fiber_str.call(&mut hooks, &[val!(fiber)]).unwrap();
       assert!(result.to_obj().to_str().contains("<Fiber "));
     }
   }

--- a/laythe_lib/src/global/primitives/nil.rs
+++ b/laythe_lib/src/global/primitives/nil.rs
@@ -40,7 +40,7 @@ pub fn define_nil_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
 native!(NilStr, NIL_STR);
 
 impl LyNative for NilStr {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     Call::Ok(val!(hooks.manage_str("nil")))
   }
 }
@@ -55,23 +55,12 @@ mod test {
     use laythe_core::value::VALUE_NIL;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let nil_str = NilStr::native(&hooks);
-
-      assert_eq!(nil_str.meta().name, "str");
-      assert_eq!(nil_str.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
       let nil_str = NilStr::native(&hooks.as_gc());
 
-      let result = nil_str.call(&mut hooks, Some(VALUE_NIL), &[]);
+      let result = nil_str.call(&mut hooks, &[VALUE_NIL]);
       match result {
         Call::Ok(r) => assert_eq!(*r.to_obj().to_str(), "nil".to_string()),
         _ => assert!(false),

--- a/laythe_lib/src/global/primitives/number.rs
+++ b/laythe_lib/src/global/primitives/number.rs
@@ -102,39 +102,39 @@ pub fn define_number_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()>
 native!(NumberStr, NUMBER_STR);
 
 impl LyNative for NumberStr {
-  fn call(&self, hook: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    Call::Ok(val!(hook.manage_str(this.unwrap().to_num().to_string())))
+  fn call(&self, hook: &mut Hooks, args: &[Value]) -> Call {
+    Call::Ok(val!(hook.manage_str(args[0].to_num().to_string())))
   }
 }
 
 native!(NumberFloor, NUMBER_FLOOR);
 
 impl LyNative for NumberFloor {
-  fn call(&self, _hook: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    Call::Ok(val!(this.unwrap().to_num().floor()))
+  fn call(&self, _hook: &mut Hooks, args: &[Value]) -> Call {
+    Call::Ok(val!(args[0].to_num().floor()))
   }
 }
 
 native!(NumberCeil, NUMBER_CEIL);
 
 impl LyNative for NumberCeil {
-  fn call(&self, _hook: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    Call::Ok(val!(this.unwrap().to_num().ceil()))
+  fn call(&self, _hook: &mut Hooks, args: &[Value]) -> Call {
+    Call::Ok(val!(args[0].to_num().ceil()))
   }
 }
 
 native!(NumberRound, NUMBER_ROUND);
 
 impl LyNative for NumberRound {
-  fn call(&self, _hook: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    Call::Ok(val!(this.unwrap().to_num().round()))
+  fn call(&self, _hook: &mut Hooks, args: &[Value]) -> Call {
+    Call::Ok(val!(args[0].to_num().round()))
   }
 }
 
 native_with_error!(NumberParse, NUMBER_PARSE);
 
 impl LyNative for NumberParse {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     let str = args[0].to_obj().to_str();
     match str.parse::<f64>() {
       Ok(num) => Call::Ok(val!(num)),
@@ -146,7 +146,7 @@ impl LyNative for NumberParse {
 native!(NumberCmp, NUMBER_CMP);
 
 impl LyNative for NumberCmp {
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[0].to_num() - args[1].to_num()))
   }
 }
@@ -154,8 +154,8 @@ impl LyNative for NumberCmp {
 native_with_error!(NumberTimes, NUMBER_TIMES);
 
 impl LyNative for NumberTimes {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let max = this.unwrap().to_num();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let max = args[0].to_num();
     if max < 0.0 || max.fract() != 0.0 {
       return self.call_error(hooks, "times requires a positive integer.");
     }
@@ -221,11 +221,11 @@ impl DebugHeap for TimesIterator {
 native_with_error!(NumberUntil, NUMBER_UNTIL);
 
 impl LyNative for NumberUntil {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let start = this.unwrap().to_num();
-    let end = _args[0].to_num();
-    let stride = if _args.len() > 1 {
-      _args[1].to_num()
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let start = args[0].to_num();
+    let end = args[1].to_num();
+    let stride = if args.len() > 2 {
+      args[2].to_num()
     } else {
       1.0
     };
@@ -303,24 +303,13 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let number_str = NumberStr::native(&hooks);
-
-      assert_eq!(number_str.meta().name, "str");
-      assert_eq!(number_str.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let number_str = NumberStr::native(&hooks.as_gc());
 
-      let result = number_str.call(&mut hooks, Some(val!(10.0)), &[]);
+      let result = number_str.call(&mut hooks, &[val!(10.0)]);
       match result {
         Call::Ok(r) => assert_eq!(*r.to_obj().to_str(), "10".to_string()),
         _ => assert!(false),
@@ -333,18 +322,6 @@ mod test {
     use crate::support::{test_error_class, MockedContext};
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let error = val!(test_error_class(&hooks));
-      let number_times = NumberTimes::native(&hooks, error);
-
-      assert_eq!(number_times.meta().name, "times");
-      assert_eq!(number_times.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::new(&[val!(5.0)]);
       let mut hooks = Hooks::new(&mut context);
@@ -352,7 +329,7 @@ mod test {
       let error = val!(test_error_class(&hooks.as_gc()));
       let number_times = NumberTimes::native(&hooks.as_gc(), error);
 
-      let result = number_times.call(&mut hooks, Some(val!(3.0)), &[]);
+      let result = number_times.call(&mut hooks, &[val!(3.0)]);
       match result {
         Call::Ok(r) => {
           let mut number_times = r.to_obj().to_enumerator();
@@ -366,7 +343,7 @@ mod test {
           assert_eq!(number_times.current(), val!(2.0));
 
           assert_eq!(number_times.next(&mut hooks).unwrap(), val!(false));
-        }
+        },
         _ => assert!(false),
       }
     }
@@ -377,25 +354,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let number_cmp = NumberCmp::native(&hooks);
-
-      assert_eq!(number_cmp.meta().name, "cmp");
-      assert_eq!(number_cmp.meta().signature.arity, Arity::Fixed(2));
-      assert_eq!(
-        number_cmp.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-      assert_eq!(
-        number_cmp.meta().signature.parameters[1].kind,
-        ParameterKind::Number
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -403,7 +361,7 @@ mod test {
       let number_cmp = NumberCmp::native(&hooks.as_gc());
 
       let result = number_cmp
-        .call(&mut hooks, None, &[val!(5.0), val!(3.0)])
+        .call(&mut hooks, &[val!(5.0), val!(3.0)])
         .unwrap();
 
       assert_eq!(result, val!(2.0));
@@ -415,26 +373,13 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let number_floor = NumberFloor::native(&hooks);
-
-      assert_eq!(number_floor.meta().name, "floor");
-      assert_eq!(number_floor.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let number_floor = NumberFloor::native(&hooks.as_gc());
 
-      let result = number_floor
-        .call(&mut hooks, Some(val!(10.5)), &[])
-        .unwrap();
+      let result = number_floor.call(&mut hooks, &[val!(10.5)]).unwrap();
       assert_eq!(result.to_num(), 10.0);
     }
   }
@@ -444,24 +389,13 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let number_ceil = NumberCeil::native(&hooks);
-
-      assert_eq!(number_ceil.meta().name, "ceil");
-      assert_eq!(number_ceil.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let number_ceil = NumberCeil::native(&hooks.as_gc());
 
-      let result = number_ceil.call(&mut hooks, Some(val!(10.5)), &[]).unwrap();
+      let result = number_ceil.call(&mut hooks, &[val!(10.5)]).unwrap();
       assert_eq!(result.to_num(), 11.0);
     }
   }
@@ -471,26 +405,13 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let number_round = NumberRound::native(&hooks);
-
-      assert_eq!(number_round.meta().name, "round");
-      assert_eq!(number_round.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let number_round = NumberRound::native(&hooks.as_gc());
 
-      let result = number_round
-        .call(&mut hooks, Some(val!(10.3)), &[])
-        .unwrap();
+      let result = number_round.call(&mut hooks, &[val!(10.3)]).unwrap();
       assert_eq!(result.to_num(), 10.0);
     }
   }
@@ -498,22 +419,6 @@ mod test {
   mod parse {
     use super::*;
     use crate::support::{test_error_class, MockedContext};
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let number_parse = NumberParse::native(&hooks, error);
-
-      assert_eq!(number_parse.meta().name, "parse");
-      assert_eq!(number_parse.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        number_parse.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
 
     #[test]
     fn call() {
@@ -524,7 +429,7 @@ mod test {
       let number_parse = NumberParse::native(&hooks.as_gc(), error);
 
       let args = val!(hooks.manage_str("1"));
-      let result = number_parse.call(&mut hooks, None, &[args]).unwrap();
+      let result = number_parse.call(&mut hooks, &[args]).unwrap();
 
       assert_eq!(result, val!(1.0));
     }
@@ -535,26 +440,6 @@ mod test {
     use crate::support::{test_error_class, MockedContext};
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let number_until = NumberUntil::native(&hooks, error);
-
-      assert_eq!(number_until.meta().name, "until");
-      assert_eq!(number_until.meta().signature.arity, Arity::Default(1, 2));
-      assert_eq!(
-        number_until.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-      assert_eq!(
-        number_until.meta().signature.parameters[1].kind,
-        ParameterKind::Number
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::new(&[val!(5.0)]);
       let mut hooks = Hooks::new(&mut context);
@@ -562,7 +447,7 @@ mod test {
 
       let number_until = NumberUntil::native(&hooks.as_gc(), error);
 
-      let result = number_until.call(&mut hooks, Some(val!(2.0)), &[val!(6.0), val!(2.0)]);
+      let result = number_until.call(&mut hooks, &[val!(2.0), val!(6.0), val!(2.0)]);
       match result {
         Call::Ok(r) => {
           let mut number_until = r.to_obj().to_enumerator();
@@ -573,7 +458,7 @@ mod test {
           assert_eq!(number_until.current(), val!(4.0));
 
           assert_eq!(number_until.next(&mut hooks).unwrap(), val!(false));
-        }
+        },
         _ => assert!(false),
       }
     }

--- a/laythe_lib/src/global/primitives/object.rs
+++ b/laythe_lib/src/global/primitives/object.rs
@@ -15,14 +15,14 @@ use std::io::Write;
 pub const OBJECT_CLASS_NAME: &str = OBJECT;
 
 const OBJECT_EQUALS: NativeMetaBuilder = NativeMetaBuilder::method("equals", Arity::Fixed(1))
-  .with_params(&[ParameterBuilder::new("other", ParameterKind::Any)]);
+  .with_params(&[ParameterBuilder::new("other", ParameterKind::Object)]);
 
 const OBJECT_CLASS: NativeMetaBuilder = NativeMetaBuilder::method("cls", Arity::Fixed(0));
 
 const OBJECT_STR: NativeMetaBuilder = NativeMetaBuilder::method("str", Arity::Fixed(0));
 
 const OBJECT_IS_A: NativeMetaBuilder = NativeMetaBuilder::method("isA?", Arity::Fixed(1))
-  .with_params(&[ParameterBuilder::new("class", ParameterKind::Class)]);
+  .with_params(&[ParameterBuilder::new("class", ParameterKind::Object)]);
 
 pub fn create_object_class(hooks: &GcHooks) -> GcObj<Class> {
   let name = hooks.manage_str(OBJECT_CLASS_NAME);
@@ -54,24 +54,24 @@ pub fn create_object_class(hooks: &GcHooks) -> GcObj<Class> {
 native!(ObjectEquals, OBJECT_EQUALS);
 
 impl LyNative for ObjectEquals {
-  fn call(&self, _hooks: &mut Hooks, this: Option<Value>, args: &[Value]) -> Call {
-    Call::Ok(val!(this.unwrap() == args[0]))
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
+    Call::Ok(val!(args[0] == args[1]))
   }
 }
 
 native!(ObjectCls, OBJECT_CLASS);
 
 impl LyNative for ObjectCls {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    Call::Ok(val!(hooks.get_class(this.unwrap())))
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    Call::Ok(val!(hooks.get_class(args[0])))
   }
 }
 
 native!(ObjectStr, OBJECT_STR);
 
 impl LyNative for ObjectStr {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let this = this.unwrap();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let this = args[0];
     let class = hooks.get_class(this);
 
     let string = match this.kind() {
@@ -131,9 +131,9 @@ impl LyNative for ObjectStr {
 native!(ObjectIsA, OBJECT_IS_A);
 
 impl LyNative for ObjectIsA {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, args: &[Value]) -> Call {
-    let self_class = hooks.get_class(this.unwrap());
-    let class = args[0].to_obj().to_class();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let self_class = hooks.get_class(args[0]);
+    let class = args[1].to_obj().to_class();
 
     Call::Ok(val!(self_class.is_subclass(class)))
   }
@@ -148,21 +148,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let object_equals = ObjectEquals::native(&hooks);
-
-      assert_eq!(object_equals.meta().name, "equals");
-      assert_eq!(object_equals.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        object_equals.meta().signature.parameters[0].kind,
-        ParameterKind::Any
-      )
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -172,8 +157,8 @@ mod test {
       let b_false = val!(false);
       let ten_2 = val!(10.0);
 
-      let result1 = object_equals.call(&mut hooks, Some(ten_1), &[ten_2]);
-      let result2 = object_equals.call(&mut hooks, Some(ten_2), &[b_false]);
+      let result1 = object_equals.call(&mut hooks, &[ten_1, ten_2]);
+      let result2 = object_equals.call(&mut hooks, &[ten_2, b_false]);
 
       match result1 {
         Call::Ok(r) => assert_eq!(r.to_bool(), true),
@@ -191,17 +176,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let object_cls = ObjectCls::native(&hooks);
-
-      assert_eq!(object_cls.meta().name, "cls");
-      assert_eq!(object_cls.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::with_std(&[]).unwrap();
       let mut hooks = Hooks::new(&mut context);
@@ -209,7 +183,7 @@ mod test {
 
       let ten = val!(10.0);
 
-      let result = object_cls.call(&mut hooks, Some(ten), &[]).unwrap();
+      let result = object_cls.call(&mut hooks, &[ten]).unwrap();
       assert_eq!(
         result.to_obj().to_class().name(),
         hooks.manage_str("Number")
@@ -222,17 +196,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let object_str = ObjectStr::native(&hooks);
-
-      assert_eq!(object_str.meta().name, "str");
-      assert_eq!(object_str.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::with_std(&[]).unwrap();
       let mut hooks = Hooks::new(&mut context);
@@ -240,7 +203,7 @@ mod test {
 
       let ten = val!(10.0);
 
-      let result = object_str.call(&mut hooks, Some(ten), &[]);
+      let result = object_str.call(&mut hooks, &[ten]);
 
       match result {
         Call::Ok(r) => assert_eq!(r.to_obj().to_str(), "<Number 10>"),
@@ -250,23 +213,10 @@ mod test {
   }
 
   mod is_a {
+    use laythe_core::value::{VALUE_FALSE, VALUE_TRUE};
+
     use super::*;
     use crate::support::MockedContext;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let object_is_a = ObjectIsA::native(&hooks);
-
-      assert_eq!(object_is_a.meta().name, "isA?");
-      assert_eq!(object_is_a.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        object_is_a.meta().signature.parameters[0].kind,
-        ParameterKind::Class
-      )
-    }
 
     #[test]
     fn call() {
@@ -280,39 +230,19 @@ mod test {
       let mut hooks = Hooks::new(&mut context);
       let object_is_a = ObjectIsA::native(&hooks.as_gc());
 
-      let result1 = object_is_a.call(&mut hooks, Some(ten), &[error]);
-      let result2 = object_is_a.call(&mut hooks, Some(ten), &[object]);
-      let result3 = object_is_a.call(&mut hooks, Some(error), &[object]);
-      let result4 = object_is_a.call(&mut hooks, Some(error), &[error]);
-      let result5 = object_is_a.call(&mut hooks, Some(object), &[object]);
-      let result6 = object_is_a.call(&mut hooks, Some(object), &[error]);
+      let result1 = object_is_a.call(&mut hooks, &[ten, error]);
+      let result2 = object_is_a.call(&mut hooks, &[ten, object]);
+      let result3 = object_is_a.call(&mut hooks, &[error, object]);
+      let result4 = object_is_a.call(&mut hooks, &[error, error]);
+      let result5 = object_is_a.call(&mut hooks, &[object, object]);
+      let result6 = object_is_a.call(&mut hooks, &[object, error]);
 
-      match result1 {
-        Call::Ok(r) => assert_eq!(r.to_bool(), false),
-        _ => assert!(false),
-      }
-      match result2 {
-        Call::Ok(r) => assert_eq!(r.to_bool(), true),
-        _ => assert!(false),
-      }
-
-      match result3 {
-        Call::Ok(r) => assert_eq!(r.to_bool(), true),
-        _ => assert!(false),
-      }
-      match result4 {
-        Call::Ok(r) => assert_eq!(r.to_bool(), false),
-        _ => assert!(false),
-      }
-
-      match result5 {
-        Call::Ok(r) => assert_eq!(r.to_bool(), true),
-        _ => assert!(false),
-      }
-      match result6 {
-        Call::Ok(r) => assert_eq!(r.to_bool(), false),
-        _ => assert!(false),
-      }
+      assert_eq!(result1, Call::Ok(VALUE_FALSE));
+      assert_eq!(result2, Call::Ok(VALUE_TRUE));
+      assert_eq!(result3, Call::Ok(VALUE_TRUE));
+      assert_eq!(result4, Call::Ok(VALUE_FALSE));
+      assert_eq!(result5, Call::Ok(VALUE_TRUE));
+      assert_eq!(result6, Call::Ok(VALUE_FALSE));
     }
   }
 }

--- a/laythe_lib/src/global/primitives/string.rs
+++ b/laythe_lib/src/global/primitives/string.rs
@@ -131,25 +131,25 @@ pub fn define_string_class(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()>
 native!(StringStr, STRING_STR);
 
 impl LyNative for StringStr {
-  fn call(&self, _hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    Call::Ok(this.unwrap())
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
+    Call::Ok(args[0])
   }
 }
 
 native!(StringLen, STRING_LEN);
 
 impl LyNative for StringLen {
-  fn call(&self, _hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    Call::Ok(val!(this.unwrap().to_obj().to_str().chars().count() as f64))
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
+    Call::Ok(val!(args[0].to_obj().to_str().chars().count() as f64))
   }
 }
 
 native_with_error!(StringIndexGet, STRING_INDEX_GET);
 
 impl LyNative for StringIndexGet {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, args: &[Value]) -> Call {
-    let this = this.unwrap().to_obj().to_str();
-    let index = args[0].to_num();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let this = args[0].to_obj().to_str();
+    let index = args[1].to_num();
 
     // eliminate non integers
     if index.fract() != 0.0 {
@@ -182,17 +182,17 @@ impl LyNative for StringIndexGet {
 native!(StringHas, STRING_HAS);
 
 impl LyNative for StringHas {
-  fn call(&self, _hooks: &mut Hooks, this: Option<Value>, args: &[Value]) -> Call {
-    let str = this.unwrap().to_obj().to_str();
-    Call::Ok(val!(str.contains(&*args[0].to_obj().to_str())))
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
+    let str = args[0].to_obj().to_str();
+    Call::Ok(val!(str.contains(&*args[1].to_obj().to_str())))
   }
 }
 
 native!(StringUpCase, STRING_UP_CASE);
 
 impl LyNative for StringUpCase {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let str = this.unwrap().to_obj().to_str();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let str = args[0].to_obj().to_str();
     Call::Ok(val!(hooks.manage_str(str.to_uppercase())))
   }
 }
@@ -200,8 +200,8 @@ impl LyNative for StringUpCase {
 native!(StringDownCase, STRING_DOWN_CASE);
 
 impl LyNative for StringDownCase {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let str = this.unwrap().to_obj().to_str();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let str = args[0].to_obj().to_str();
     Call::Ok(val!(hooks.manage_str(str.to_lowercase())))
   }
 }
@@ -209,9 +209,9 @@ impl LyNative for StringDownCase {
 native!(StringSplit, STRING_SPLIT);
 
 impl LyNative for StringSplit {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, args: &[Value]) -> Call {
-    let separator = args[0].to_obj().to_str();
-    let str = this.unwrap().to_obj().to_str();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let separator = args[1].to_obj().to_str();
+    let str = args[0].to_obj().to_str();
 
     let inner_iter: Box<dyn Enumerate> = Box::new(SplitIterator::new(str, separator));
     let iter = Enumerator::new(inner_iter);
@@ -300,14 +300,14 @@ impl DebugHeap for SplitIterator {
 native_with_error!(StringSlice, STRING_SLICE);
 
 impl LyNative for StringSlice {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     // get underlying string slice
-    let string = this.unwrap().to_obj().to_str();
+    let string = args[0].to_obj().to_str();
 
     let (start, end) = match args.len() {
-      0 => (0.0, string.len() as f64),
-      1 => (args[0].to_num(), string.len() as f64),
-      2 => (args[0].to_num(), args[1].to_num()),
+      1 => (0.0, string.len() as f64),
+      2 => (args[1].to_num(), string.len() as f64),
+      3 => (args[1].to_num(), args[2].to_num()),
       _ => panic!("string slice should only been passed 0, 1 or 2 parameters"),
     };
 
@@ -357,8 +357,8 @@ impl StringSlice {
 native!(StringTrim, STRING_TRIM);
 
 impl LyNative for StringTrim {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let string = this.unwrap().to_obj().to_str();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let string = args[0].to_obj().to_str();
 
     Call::Ok(val!(hooks.manage_str(string.trim())))
   }
@@ -367,8 +367,8 @@ impl LyNative for StringTrim {
 native!(StringTrimStart, STRING_TRIM_START);
 
 impl LyNative for StringTrimStart {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let string = this.unwrap().to_obj().to_str();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let string = args[0].to_obj().to_str();
 
     Call::Ok(val!(hooks.manage_str(string.trim_start())))
   }
@@ -377,8 +377,8 @@ impl LyNative for StringTrimStart {
 native!(StringTrimEnd, STRING_TRIM_END);
 
 impl LyNative for StringTrimEnd {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let string = this.unwrap().to_obj().to_str();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let string = args[0].to_obj().to_str();
 
     Call::Ok(val!(hooks.manage_str(string.trim_end())))
   }
@@ -387,8 +387,8 @@ impl LyNative for StringTrimEnd {
 native!(StringIter, STRING_ITER);
 
 impl LyNative for StringIter {
-  fn call(&self, hooks: &mut Hooks, this: Option<Value>, _args: &[Value]) -> Call {
-    let str = this.unwrap().to_obj().to_str();
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
+    let str = args[0].to_obj().to_str();
 
     let inner_iter: Box<dyn Enumerate> = Box::new(StringIterator::new(str));
     let iter = Enumerator::new(inner_iter);
@@ -480,24 +480,13 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_str = StringStr::native(&hooks);
-
-      assert_eq!(string_str.meta().name, "str");
-      assert_eq!(string_str.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
       let string_str = StringStr::native(&hooks.as_gc());
 
       let this = val!(hooks.manage_str("test".to_string()));
-      let result = string_str.call(&mut hooks, Some(this), &[]);
+      let result = string_str.call(&mut hooks, &[this]);
       match result {
         Call::Ok(r) => assert_eq!(*r.to_obj().to_str(), "test".to_string()),
         _ => assert!(false),
@@ -510,22 +499,6 @@ mod test {
     use crate::support::{test_error_class, MockedContext};
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let error = val!(test_error_class(&hooks));
-      let index_get = StringIndexGet::native(&hooks, error);
-
-      assert_eq!(index_get.meta().name, "[]");
-      assert_eq!(index_get.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        index_get.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -534,7 +507,7 @@ mod test {
       let string_index_get = StringIndexGet::native(&hooks.as_gc(), error);
 
       let this = val!(hooks.manage_str("test".to_string()));
-      let result = string_index_get.call(&mut hooks, Some(this), &[val!(0.0)]);
+      let result = string_index_get.call(&mut hooks, &[this, val!(0.0)]);
       match result {
         Call::Ok(r) => assert_eq!(*r.to_obj().to_str(), "t".to_string()),
         _ => assert!(false),
@@ -547,17 +520,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_len = StringLen::native(&hooks);
-
-      assert_eq!(string_len.meta().name, "len");
-      assert_eq!(string_len.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -565,7 +527,7 @@ mod test {
       let string_len = StringLen::native(&hooks.as_gc());
       let this = val!(hooks.manage_str("abc"));
 
-      let result = string_len.call(&mut hooks, Some(this), &[]);
+      let result = string_len.call(&mut hooks, &[this]);
 
       match result {
         Call::Ok(r) => {
@@ -581,21 +543,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_has = StringHas::native(&hooks);
-
-      assert_eq!(string_has.meta().name, "has");
-      assert_eq!(string_has.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        string_has.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -605,10 +552,10 @@ mod test {
       let arg1 = val!(hooks.manage_str("a"));
       let arg2 = val!(hooks.manage_str("z"));
 
-      let r = string_has.call(&mut hooks, Some(this), &[arg1]).unwrap();
+      let r = string_has.call(&mut hooks, &[this, arg1]).unwrap();
       assert_eq!(r, val!(true));
 
-      let r = string_has.call(&mut hooks, Some(this), &[arg2]).unwrap();
+      let r = string_has.call(&mut hooks, &[this, arg2]).unwrap();
       assert_eq!(r, val!(false));
     }
   }
@@ -618,17 +565,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_up_case = StringUpCase::native(&hooks);
-
-      assert_eq!(string_up_case.meta().name, "upCase");
-      assert_eq!(string_up_case.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -636,7 +572,7 @@ mod test {
       let string_up_case = StringUpCase::native(&hooks.as_gc());
       let this = val!(hooks.manage_str("abc"));
 
-      let result = string_up_case.call(&mut hooks, Some(this), &[]).unwrap();
+      let result = string_up_case.call(&mut hooks, &[this]).unwrap();
       assert_eq!(result, val!(hooks.manage_str("ABC")));
     }
   }
@@ -646,17 +582,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_down_case = StringDownCase::native(&hooks);
-
-      assert_eq!(string_down_case.meta().name, "downCase");
-      assert_eq!(string_down_case.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -664,7 +589,7 @@ mod test {
       let string_down_case = StringDownCase::native(&hooks.as_gc());
       let this = val!(hooks.manage_str("ABC"));
 
-      let result = string_down_case.call(&mut hooks, Some(this), &[]).unwrap();
+      let result = string_down_case.call(&mut hooks, &[this]).unwrap();
       assert_eq!(result, val!(hooks.manage_str("abc")));
     }
   }
@@ -672,26 +597,6 @@ mod test {
   mod slice {
     use super::*;
     use crate::support::{test_error_class, MockedContext};
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let error = val!(test_error_class(&hooks));
-      let string_slice = StringSlice::native(&hooks, error);
-
-      assert_eq!(string_slice.meta().name, "slice");
-      assert_eq!(string_slice.meta().signature.arity, Arity::Default(0, 2));
-      assert_eq!(
-        string_slice.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-      assert_eq!(
-        string_slice.meta().signature.parameters[1].kind,
-        ParameterKind::Number
-      );
-    }
 
     #[test]
     fn call() {
@@ -703,7 +608,7 @@ mod test {
       let this = val!(hooks.manage_str("abc123"));
 
       let r = string_slice
-        .call(&mut hooks, Some(this), &[val!(-5.0), val!(3.0)])
+        .call(&mut hooks, &[this, val!(-5.0), val!(3.0)])
         .unwrap();
       assert!(r.is_obj_kind(ObjectKind::String));
       assert_eq!(r.to_obj().to_str(), "bc");
@@ -715,17 +620,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_slice = StringTrim::native(&hooks);
-
-      assert_eq!(string_slice.meta().name, "trim");
-      assert_eq!(string_slice.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -733,7 +627,7 @@ mod test {
       let string_slice = StringTrim::native(&hooks.as_gc());
       let this = val!(hooks.manage_str("  abc  "));
 
-      let r = string_slice.call(&mut hooks, Some(this), &[]).unwrap();
+      let r = string_slice.call(&mut hooks, &[this]).unwrap();
       assert!(r.is_obj_kind(ObjectKind::String));
       assert_eq!(r.to_obj().to_str(), "abc");
     }
@@ -744,17 +638,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_slice = StringTrimStart::native(&hooks);
-
-      assert_eq!(string_slice.meta().name, "trimStart");
-      assert_eq!(string_slice.meta().signature.arity, Arity::Fixed(0));
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -762,7 +645,7 @@ mod test {
       let string_slice = StringTrimStart::native(&hooks.as_gc());
       let this = val!(hooks.manage_str("  abc  "));
 
-      let r = string_slice.call(&mut hooks, Some(this), &[]).unwrap();
+      let r = string_slice.call(&mut hooks, &[this]).unwrap();
       assert!(r.is_obj_kind(ObjectKind::String));
       assert_eq!(r.to_obj().to_str(), "abc  ");
     }
@@ -773,16 +656,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_slice = StringTrimEnd::native(&hooks);
-
-      assert_eq!(string_slice.meta().name, "trimEnd");
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -790,7 +663,7 @@ mod test {
       let string_slice = StringTrimEnd::native(&hooks.as_gc());
       let this = val!(hooks.manage_str("  abc  "));
 
-      let r = string_slice.call(&mut hooks, Some(this), &[]).unwrap();
+      let r = string_slice.call(&mut hooks, &[this]).unwrap();
       assert!(r.is_obj_kind(ObjectKind::String));
       assert_eq!(r.to_obj().to_str(), "  abc");
     }
@@ -799,17 +672,6 @@ mod test {
   mod iter {
     use super::*;
     use crate::support::MockedContext;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_iter = StringIter::native(&hooks);
-
-      assert_eq!(string_iter.meta().name, "iter");
-      assert_eq!(string_iter.meta().signature.arity, Arity::Fixed(0));
-    }
 
     #[test]
     fn call() {
@@ -822,13 +684,13 @@ mod test {
       let contained = val!(hooks.manage_str("ome".to_string()));
       let not_contained = val!(hooks.manage_str("other".to_string()));
 
-      let result = string_str.call(&mut hooks, Some(this), &[contained]);
+      let result = string_str.call(&mut hooks, &[this, contained]);
       match result {
         Call::Ok(r) => assert!(r.to_bool()),
         _ => assert!(false),
       }
 
-      let result = string_str.call(&mut hooks, Some(this), &[not_contained]);
+      let result = string_str.call(&mut hooks, &[this, not_contained]);
       match result {
         Call::Ok(r) => assert!(!r.to_bool()),
         _ => assert!(false),
@@ -843,21 +705,6 @@ mod test {
     use crate::support::MockedContext;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let string_split = StringSplit::native(&hooks);
-
-      assert_eq!(string_split.meta().name, "split");
-      assert_eq!(string_split.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        string_split.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
@@ -867,9 +714,7 @@ mod test {
       let this = val!(hooks.manage_str("some string here"));
       let separator = val!(hooks.manage_str(" "));
 
-      let result = string_split
-        .call(&mut hooks, Some(this), &[separator])
-        .unwrap();
+      let result = string_split.call(&mut hooks, &[this, separator]).unwrap();
       assert!(result.is_obj_kind(ObjectKind::Enumerator));
 
       let mut iter = result.to_obj().to_enumerator();

--- a/laythe_lib/src/global/support/mod.rs
+++ b/laythe_lib/src/global/support/mod.rs
@@ -15,7 +15,7 @@ const TEST_META: NativeMetaBuilder = NativeMetaBuilder::fun("test", Arity::Fixed
 native!(TestNative, TEST_META);
 
 impl LyNative for TestNative {
-  fn call(&self, _: &mut Hooks, _this: Option<Value>, _: &[Value]) -> Call {
+  fn call(&self, _: &mut Hooks, _: &[Value]) -> Call {
     Call::Ok(VALUE_NIL)
   }
 }

--- a/laythe_lib/src/global/time/clock.rs
+++ b/laythe_lib/src/global/time/clock.rs
@@ -25,7 +25,7 @@ pub fn declare_clock_funs(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> 
 native!(Clock, CLOCK_META);
 
 impl LyNative for Clock {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     let io = hooks.as_io();
     let time = io.time();
 
@@ -42,17 +42,6 @@ mod test {
   use crate::support::MockedContext;
 
   #[test]
-  fn new() {
-    let mut context = MockedContext::default();
-    let hooks = GcHooks::new(&mut context);
-
-    let clock = Clock::native(&hooks);
-
-    assert_eq!(clock.meta().name, "clock");
-    assert_eq!(clock.meta().signature.arity, Arity::Fixed(0));
-  }
-
-  #[test]
   fn call() {
     let mut context = MockedContext::default();
     let mut hooks = Hooks::new(&mut context);
@@ -60,8 +49,8 @@ mod test {
 
     let values = &[];
 
-    let result1 = clock.call(&mut hooks, None, values).unwrap();
-    let result2 = clock.call(&mut hooks, None, values).unwrap();
+    let result1 = clock.call(&mut hooks, values).unwrap();
+    let result2 = clock.call(&mut hooks, values).unwrap();
 
     if result1.is_num() && result2.is_num() {
       assert!(result1.to_num() <= result2.to_num());

--- a/laythe_lib/src/io/fs/utils.rs
+++ b/laythe_lib/src/io/fs/utils.rs
@@ -33,7 +33,11 @@ const REMOVE_FILE: NativeMetaBuilder = NativeMetaBuilder::fun("removeFile", Arit
   .with_params(&[ParameterBuilder::new("path", ParameterKind::String)])
   .with_stack();
 
-pub fn declare_fs_module(_hooks: &GcHooks, _module: Gc<Module>, _std: Gc<Package>) -> StdResult<()> {
+pub fn declare_fs_module(
+  _hooks: &GcHooks,
+  _module: Gc<Module>,
+  _std: Gc<Package>,
+) -> StdResult<()> {
   Ok(())
 }
 
@@ -69,7 +73,7 @@ pub fn define_fs_module(hooks: &GcHooks, module: Gc<Module>, std: Gc<Package>) -
 native_with_error!(ReadFile, READ_FILE);
 
 impl LyNative for ReadFile {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     let io = hooks.as_io();
     let path = args[0].to_obj().to_str();
 
@@ -83,7 +87,7 @@ impl LyNative for ReadFile {
 native_with_error!(WriteFile, WRITE_FILE);
 
 impl LyNative for WriteFile {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     let io = hooks.as_io();
     let path = args[0].to_obj().to_str();
     let contents = args[1].to_obj().to_str();
@@ -98,7 +102,7 @@ impl LyNative for WriteFile {
 native_with_error!(RemoveFile, REMOVE_FILE);
 
 impl LyNative for RemoveFile {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     let io = hooks.as_io();
     let path = args[0].to_obj().to_str();
 
@@ -111,74 +115,15 @@ impl LyNative for RemoveFile {
 
 #[cfg(test)]
 mod test {
-  use super::*;
-
   mod read_file {
-    use super::*;
-    use crate::support::{test_error_class, MockedContext};
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stdout_write = ReadFile::native(&hooks, error);
-
-      assert_eq!(stdout_write.meta().name, "readFile");
-      assert_eq!(stdout_write.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        stdout_write.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
-
     // TODO: call
   }
 
   mod write_file {
-    use super::*;
-    use crate::support::{test_error_class, MockedContext};
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stdout_write = WriteFile::native(&hooks, error);
-
-      assert_eq!(stdout_write.meta().name, "writeFile");
-      assert_eq!(stdout_write.meta().signature.arity, Arity::Fixed(2));
-      assert_eq!(
-        stdout_write.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-      assert_eq!(
-        stdout_write.meta().signature.parameters[1].kind,
-        ParameterKind::String
-      );
-    }
+    // TODO: call
   }
 
   mod remove_file {
-    use super::*;
-    use crate::support::{test_error_class, MockedContext};
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stdout_write = RemoveFile::native(&hooks, error);
-
-      assert_eq!(stdout_write.meta().name, "removeFile");
-      assert_eq!(stdout_write.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        stdout_write.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
+    // TODO: call
   }
 }

--- a/laythe_lib/src/io/stdio/stderr.rs
+++ b/laythe_lib/src/io/stdio/stderr.rs
@@ -74,12 +74,12 @@ pub fn define_stderr(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) 
 native_with_error!(StderrWrite, STDERR_WRITE);
 
 impl LyNative for StderrWrite {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     let io = hooks.as_io();
     let mut stdio = io.stdio();
     let stderr = stdio.stderr();
 
-    match stderr.write_all(args[0].to_obj().to_str().as_bytes()) {
+    match stderr.write_all(args[1].to_obj().to_str().as_bytes()) {
       Ok(_) => Call::Ok(VALUE_NIL),
       Err(err) => self.call_error(hooks, err.to_string()),
     }
@@ -89,12 +89,12 @@ impl LyNative for StderrWrite {
 native_with_error!(StderrWriteln, STDERR_WRITELN);
 
 impl LyNative for StderrWriteln {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     let io = hooks.as_io();
     let mut stdio = io.stdio();
     let stderr = stdio.stderr();
 
-    match writeln!(stderr, "{}", &*args[0].to_obj().to_str()) {
+    match writeln!(stderr, "{}", &*args[1].to_obj().to_str()) {
       Ok(_) => Call::Ok(VALUE_NIL),
       Err(err) => self.call_error(hooks, err.to_string()),
     }
@@ -104,7 +104,7 @@ impl LyNative for StderrWriteln {
 native_with_error!(StderrFlush, STDERR_FLUSH);
 
 impl LyNative for StderrFlush {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     let io = hooks.as_io();
     let mut stdio = io.stdio();
     let stderr = stdio.stderr();
@@ -126,21 +126,6 @@ mod test {
     use laythe_env::stdio::support::StdioTestContainer;
     use std::{str, sync::Arc};
 
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stderr_write = StderrWrite::native(&hooks, error);
-
-      assert_eq!(stderr_write.meta().name, "write");
-      assert_eq!(stderr_write.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        stderr_write.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
 
     #[test]
     fn call() {
@@ -153,7 +138,7 @@ mod test {
       let stderr_write = StderrWrite::native(&hooks.as_gc(), error);
 
       let string = val!(hooks.manage_str("some string".to_string()));
-      let result = stderr_write.call(&mut hooks, Some(VALUE_NIL), &[string]);
+      let result = stderr_write.call(&mut hooks, &[VALUE_NIL, string]);
 
       assert!(result.is_ok());
       assert!(result.unwrap().is_nil());
@@ -170,21 +155,6 @@ mod test {
     use laythe_env::stdio::support::StdioTestContainer;
     use std::{str, sync::Arc};
 
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stderr_writeln = StderrWriteln::native(&hooks, error);
-
-      assert_eq!(stderr_writeln.meta().name, "writeln");
-      assert_eq!(stderr_writeln.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        stderr_writeln.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
 
     #[test]
     fn call() {
@@ -197,7 +167,7 @@ mod test {
       let stderr_write = StderrWriteln::native(&hooks.as_gc(), error);
 
       let string = val!(hooks.manage_str("some string"));
-      let result = stderr_write.call(&mut hooks, Some(VALUE_NIL), &[string]);
+      let result = stderr_write.call(&mut hooks, &[VALUE_NIL, string]);
 
       assert!(result.is_ok());
       assert!(result.unwrap().is_nil());

--- a/laythe_lib/src/io/stdio/stdin.rs
+++ b/laythe_lib/src/io/stdio/stdin.rs
@@ -63,7 +63,7 @@ pub fn define_stdin(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) -
 native_with_error!(StdinRead, STDIN_READ);
 
 impl LyNative for StdinRead {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     let io = hooks.as_io();
     let mut stdio = io.stdio();
     let stdin = stdio.stdin();
@@ -79,7 +79,7 @@ impl LyNative for StdinRead {
 native_with_error!(StdinReadLine, STDIN_READ_LINE);
 
 impl LyNative for StdinReadLine {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     let io = hooks.as_io();
     let stdio = io.stdio();
 
@@ -105,21 +105,8 @@ mod test {
   mod read {
     use super::*;
     use crate::support::{test_error_class, MockedContext};
-    use laythe_core::value::VALUE_NIL;
     use laythe_env::stdio::support::StdioTestContainer;
     use std::sync::Arc;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stdin_read = StdinRead::native(&hooks, error);
-
-      assert_eq!(stdin_read.meta().name, "read");
-      assert_eq!(stdin_read.meta().signature.arity, Arity::Fixed(0));
-    }
 
     #[test]
     fn call() {
@@ -131,7 +118,7 @@ mod test {
 
       let stdin_read = StdinRead::native(&hooks.as_gc(), error);
 
-      let result = stdin_read.call(&mut hooks, Some(VALUE_NIL), &[]);
+      let result = stdin_read.call(&mut hooks, &[]);
 
       assert!(result.is_ok());
       let unwrapped = result.unwrap();
@@ -144,21 +131,8 @@ mod test {
   mod readlines {
     use super::*;
     use crate::support::{test_error_class, MockedContext};
-    use laythe_core::value::VALUE_NIL;
     use laythe_env::stdio::support::StdioTestContainer;
     use std::sync::Arc;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stdin_readline = StdinReadLine::native(&hooks, error);
-
-      assert_eq!(stdin_readline.meta().name, "readLine");
-      assert_eq!(stdin_readline.meta().signature.arity, Arity::Fixed(0));
-    }
 
     #[test]
     fn call() {
@@ -173,7 +147,7 @@ mod test {
 
       let stdin_readline = StdinReadLine::native(&hooks.as_gc(), error);
 
-      let result = stdin_readline.call(&mut hooks, Some(VALUE_NIL), &[]);
+      let result = stdin_readline.call(&mut hooks, &[]);
 
       assert!(result.is_ok());
       let unwrapped = result.unwrap();

--- a/laythe_lib/src/io/stdio/stdout.rs
+++ b/laythe_lib/src/io/stdio/stdout.rs
@@ -74,12 +74,12 @@ pub fn define_stdout(hooks: &GcHooks, module: Gc<Module>, package: Gc<Package>) 
 native_with_error!(StdoutWrite, STDOUT_WRITE);
 
 impl LyNative for StdoutWrite {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     let io = hooks.as_io();
     let mut stdio = io.stdio();
     let stdout = stdio.stdout();
 
-    match stdout.write_all(args[0].to_obj().to_str().as_bytes()) {
+    match stdout.write_all(args[1].to_obj().to_str().as_bytes()) {
       Ok(_) => Call::Ok(VALUE_NIL),
       Err(err) => self.call_error(hooks, err.to_string()),
     }
@@ -89,12 +89,12 @@ impl LyNative for StdoutWrite {
 native_with_error!(StdoutWriteln, STDOUT_WRITELN);
 
 impl LyNative for StdoutWriteln {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, args: &[Value]) -> Call {
     let io = hooks.as_io();
     let mut stdio = io.stdio();
     let stdout = stdio.stdout();
 
-    match writeln!(stdout, "{}", &*args[0].to_obj().to_str()) {
+    match writeln!(stdout, "{}", &*args[1].to_obj().to_str()) {
       Ok(_) => Call::Ok(VALUE_NIL),
       Err(err) => self.call_error(hooks, err.to_string()),
     }
@@ -104,7 +104,7 @@ impl LyNative for StdoutWriteln {
 native_with_error!(StdoutFlush, STDOUT_FLUSH);
 
 impl LyNative for StdoutFlush {
-  fn call(&self, hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     let io = hooks.as_io();
     let mut stdio = io.stdio();
     let stdout = stdio.stdout();
@@ -127,22 +127,6 @@ mod test {
     use std::{str, sync::Arc};
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stdout_write = StdoutWrite::native(&hooks, error);
-
-      assert_eq!(stdout_write.meta().name, "write");
-      assert_eq!(stdout_write.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        stdout_write.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
-
-    #[test]
     fn call() {
       let stdio_container = Arc::new(StdioTestContainer::default());
 
@@ -153,7 +137,7 @@ mod test {
       let stdout_write = StdoutWrite::native(&hooks.as_gc(), error);
 
       let string = val!(hooks.manage_str("some string".to_string()));
-      let result = stdout_write.call(&mut hooks, Some(VALUE_NIL), &[string]);
+      let result = stdout_write.call(&mut hooks, &[VALUE_NIL, string]);
 
       assert!(result.is_ok());
       assert!(result.unwrap().is_nil());
@@ -171,22 +155,6 @@ mod test {
     use std::{str, sync::Arc};
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-      let error = val!(test_error_class(&hooks));
-
-      let stdout_writeln = StdoutWriteln::native(&hooks, error);
-
-      assert_eq!(stdout_writeln.meta().name, "writeln");
-      assert_eq!(stdout_writeln.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        stdout_writeln.meta().signature.parameters[0].kind,
-        ParameterKind::String
-      );
-    }
-
-    #[test]
     fn call() {
       let stdio_container = Arc::new(StdioTestContainer::default());
 
@@ -197,7 +165,7 @@ mod test {
       let stdout_write = StdoutWriteln::native(&hooks.as_gc(), error);
 
       let string = val!(hooks.manage_str("some string".to_string()));
-      let result = stdout_write.call(&mut hooks, Some(VALUE_NIL), &[string]);
+      let result = stdout_write.call(&mut hooks, &[VALUE_NIL, string]);
 
       assert!(result.is_ok());
       assert!(result.unwrap().is_nil());

--- a/laythe_lib/src/math/utils.rs
+++ b/laythe_lib/src/math/utils.rs
@@ -52,17 +52,9 @@ const POW_META: NativeMetaBuilder = NativeMetaBuilder::fun("pow", Arity::Fixed(2
 const RAND_META: NativeMetaBuilder = NativeMetaBuilder::fun("rand", Arity::Fixed(0));
 
 pub fn declare_math_module(hooks: &GcHooks, module: Gc<Module>) -> StdResult<()> {
-  export_and_insert(
-    module,
-    hooks.manage_str(PI),
-    val!(std::f64::consts::PI),
-  )?;
+  export_and_insert(module, hooks.manage_str(PI), val!(std::f64::consts::PI))?;
 
-  export_and_insert(
-    module,
-    hooks.manage_str(E),
-    val!(std::f64::consts::E),
-  )?;
+  export_and_insert(module, hooks.manage_str(E), val!(std::f64::consts::E))?;
 
   export_and_insert(
     module,
@@ -127,12 +119,12 @@ native!(Sin, SIN_META);
 
 impl LyNative for Sin {
   #[cfg(not(feature = "wasm"))]
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[0].to_num().sin()))
   }
 
   #[cfg(feature = "wasm")]
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     use js_sys::Math::sin;
     Call::Ok(val!(sin(args[0].to_num())))
   }
@@ -142,12 +134,12 @@ native!(Cos, COS_META);
 
 impl LyNative for Cos {
   #[cfg(not(feature = "wasm"))]
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[0].to_num().cos()))
   }
 
   #[cfg(feature = "wasm")]
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     use js_sys::Math::cos;
     Call::Ok(val!(cos(args[0].to_num())))
   }
@@ -156,7 +148,7 @@ impl LyNative for Cos {
 native!(Ln, LN_META);
 
 impl LyNative for Ln {
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[0].to_num().ln()))
   }
 }
@@ -164,7 +156,7 @@ impl LyNative for Ln {
 native!(Abs, ABS_META);
 
 impl LyNative for Abs {
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[0].to_num().abs()))
   }
 }
@@ -172,7 +164,7 @@ impl LyNative for Abs {
 native!(Rem, REM_META);
 
 impl LyNative for Rem {
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[0].to_num() % args[1].to_num()))
   }
 }
@@ -180,7 +172,7 @@ impl LyNative for Rem {
 native!(Pow, POW_META);
 
 impl LyNative for Pow {
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[0].to_num().powf(args[1].to_num())))
   }
 }
@@ -188,7 +180,7 @@ impl LyNative for Pow {
 native!(Max, MAX_META);
 
 impl LyNative for Max {
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[1..]
       .iter()
       .map(|x| x.to_num())
@@ -199,7 +191,7 @@ impl LyNative for Max {
 native!(Min, MIN_META);
 
 impl LyNative for Min {
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, args: &[Value]) -> Call {
     Call::Ok(val!(args[1..]
       .iter()
       .map(|x| x.to_num())
@@ -211,7 +203,7 @@ native!(Rand, RAND_META);
 
 impl LyNative for Rand {
   #[cfg(not(feature = "wasm"))]
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, _args: &[Value]) -> Call {
     use rand::Rng;
     let mut rng = rand::thread_rng();
     let val: f64 = rng.gen_range(0.0..1.0);
@@ -219,7 +211,7 @@ impl LyNative for Rand {
   }
 
   #[cfg(feature = "wasm")]
-  fn call(&self, _hooks: &mut Hooks, _this: Option<Value>, _args: &[Value]) -> Call {
+  fn call(&self, _hooks: &mut Hooks, _args: &[Value]) -> Call {
     use js_sys::Math::random;
 
     #[allow(unused_unsafe)]
@@ -236,56 +228,22 @@ mod test {
     use super::*;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let ln = Abs::native(&hooks);
-
-      assert_eq!(ln.meta().name, "abs");
-      assert_eq!(ln.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        ln.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let abs = Abs::native(&hooks.as_gc());
 
-      let r = abs.call(&mut hooks, None, &[val!(-2.0)]).unwrap();
+      let r = abs.call(&mut hooks, &[val!(-2.0)]).unwrap();
       assert_eq!(r.to_num(), 2.0);
 
-      let r = abs.call(&mut hooks, None, &[val!(2.0)]).unwrap();
+      let r = abs.call(&mut hooks, &[val!(2.0)]).unwrap();
       assert_eq!(r.to_num(), 2.0)
     }
   }
 
   mod rem {
     use super::*;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let rem = Rem::native(&hooks);
-
-      assert_eq!(rem.meta().name, "rem");
-      assert_eq!(rem.meta().signature.arity, Arity::Fixed(2));
-      assert_eq!(
-        rem.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-      assert_eq!(
-        rem.meta().signature.parameters[1].kind,
-        ParameterKind::Number
-      );
-    }
 
     #[test]
     fn call() {
@@ -295,37 +253,22 @@ mod test {
       let rem = Rem::native(&hooks.as_gc());
       let values = &[val!(3.0), val!(2.0)];
 
-      let r = rem.call(&mut hooks, None, values).unwrap();
+      let r = rem.call(&mut hooks, values).unwrap();
       assert_eq!(r.to_num(), 1.0);
 
       let values = &[val!(-3.0), val!(2.0)];
 
-      let r = rem.call(&mut hooks, None, values).unwrap();
+      let r = rem.call(&mut hooks, values).unwrap();
       assert_eq!(r.to_num(), -1.0);
 
       let values = &[val!(3.0), val!(-2.0)];
-      let r = rem.call(&mut hooks, None, values).unwrap();
+      let r = rem.call(&mut hooks, values).unwrap();
       assert_eq!(r.to_num(), 1.0)
     }
   }
 
   mod sin {
     use super::*;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let sin = Sin::native(&hooks);
-
-      assert_eq!(sin.meta().name, "sin");
-      assert_eq!(sin.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        sin.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-    }
 
     #[test]
     fn call() {
@@ -335,28 +278,13 @@ mod test {
       let sin = Sin::native(&hooks.as_gc());
       let values = &[val!(std::f64::consts::PI)];
 
-      let r = sin.call(&mut hooks, None, values).unwrap();
+      let r = sin.call(&mut hooks, values).unwrap();
       assert!(r.to_num().abs() < 0.0000001)
     }
   }
 
   mod cos {
     use super::*;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let cos = Cos::native(&hooks);
-
-      assert_eq!(cos.meta().name, "cos");
-      assert_eq!(cos.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        cos.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-    }
 
     #[test]
     fn call() {
@@ -366,7 +294,7 @@ mod test {
       let cos = Cos::native(&hooks.as_gc());
       let values = &[val!(std::f64::consts::FRAC_PI_2)];
 
-      let r = cos.call(&mut hooks, None, values).unwrap();
+      let r = cos.call(&mut hooks, values).unwrap();
       assert!(r.to_num().abs() < 0.0000001);
     }
   }
@@ -375,45 +303,19 @@ mod test {
     use super::*;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let ln = Ln::native(&hooks);
-
-      assert_eq!(ln.meta().name, "ln");
-      assert_eq!(ln.meta().signature.arity, Arity::Fixed(1));
-      assert_eq!(
-        ln.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let ln = Ln::native(&hooks.as_gc());
       let values = &[val!(std::f64::consts::E)];
-      let r = ln.call(&mut hooks, None, values).unwrap();
+      let r = ln.call(&mut hooks, values).unwrap();
       assert!((r.to_num() - 1.0).abs() < 0.0000001);
     }
   }
 
   mod rand {
     use super::*;
-
-    #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let rand = Rand::native(&hooks);
-
-      assert_eq!(rand.meta().name, "rand");
-      assert_eq!(rand.meta().signature.arity, Arity::Fixed(0));
-    }
 
     #[test]
     fn call() {
@@ -423,7 +325,7 @@ mod test {
       let rand = Rand::native(&hooks.as_gc());
 
       for _ in 0..10 {
-        let r = rand.call(&mut hooks, None, &[]).unwrap();
+        let r = rand.call(&mut hooks, &[]).unwrap();
         let num = r.to_num();
         assert!(num >= 0.0 && num < 1.0);
       }
@@ -434,35 +336,16 @@ mod test {
     use super::*;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let max = Max::native(&hooks);
-
-      assert_eq!(max.meta().name, "max");
-      assert_eq!(max.meta().signature.arity, Arity::Variadic(1));
-      assert_eq!(
-        max.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-      assert_eq!(
-        max.meta().signature.parameters[1].kind,
-        ParameterKind::Number
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let max = Max::native(&hooks.as_gc());
 
-      assert_eq!(Ok(val!(1.0)), max.call(&mut hooks, None, &[val!(1.0)]));
+      assert_eq!(Ok(val!(1.0)), max.call(&mut hooks, &[val!(1.0)]));
       assert_eq!(
         Ok(val!(10.0)),
-        max.call(&mut hooks, None, &[val!(1.0), val!(10.0), val!(5.0)])
+        max.call(&mut hooks, &[val!(1.0), val!(10.0), val!(5.0)])
       );
     }
   }
@@ -471,35 +354,16 @@ mod test {
     use super::*;
 
     #[test]
-    fn new() {
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-      let min = Min::native(&hooks);
-
-      assert_eq!(min.meta().name, "min");
-      assert_eq!(min.meta().signature.arity, Arity::Variadic(1));
-      assert_eq!(
-        min.meta().signature.parameters[0].kind,
-        ParameterKind::Number
-      );
-      assert_eq!(
-        min.meta().signature.parameters[1].kind,
-        ParameterKind::Number
-      );
-    }
-
-    #[test]
     fn call() {
       let mut context = MockedContext::default();
       let mut hooks = Hooks::new(&mut context);
 
       let min = Min::native(&hooks.as_gc());
 
-      assert_eq!(Ok(val!(1.0)), min.call(&mut hooks, None, &[val!(1.0)]));
+      assert_eq!(Ok(val!(1.0)), min.call(&mut hooks, &[val!(1.0)]));
       assert_eq!(
         Ok(val!(1.0)),
-        min.call(&mut hooks, None, &[val!(1.0), val!(10.0), val!(5.0)])
+        min.call(&mut hooks, &[val!(1.0), val!(10.0), val!(5.0)])
       );
     }
   }

--- a/laythe_lib/src/support/mod.rs
+++ b/laythe_lib/src/support/mod.rs
@@ -155,7 +155,7 @@ mod test {
     io::Io,
     stdio::support::{IoStdioTest, StdioTestContainer},
   };
-  use std::{cell::RefCell, io::Write, iter::once, sync::Arc};
+  use std::{cell::RefCell, io::Write, sync::Arc};
 
   pub struct MockedContext {
     pub gc: RefCell<Allocator>,
@@ -253,21 +253,18 @@ mod test {
         return Err(LyError::Exit(1));
       }
 
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
       let result = match_obj!((&callable.to_obj()) {
         ObjectKind::Fun(fun) => {
-          fun.check_if_valid_call(&hooks, args.len() as u8)
+          fun.check_if_valid_call(|| GcHooks::new(self), args.len() as u8)
         },
         ObjectKind::Closure(closure) => {
-          closure.fun().check_if_valid_call(&hooks, args.len() as u8)
+          closure.fun().check_if_valid_call(|| GcHooks::new(self), args.len() as u8)
         },
         ObjectKind::Method(method) => {
-          method.method().to_obj().to_closure().fun().check_if_valid_call(&hooks, args.len() as u8)
+          method.method().to_obj().to_closure().fun().check_if_valid_call(|| GcHooks::new(self), args.len() as u8)
         },
         ObjectKind::Native(native) => {
-          native.check_if_valid_call(&hooks, args)
+          native.check_if_valid_call(|| GcHooks::new(self), args)
         },
         _ => return Err(LyError::Exit(1)),
       });
@@ -293,25 +290,21 @@ mod test {
         return Err(LyError::Exit(1));
       }
 
-      let mut context = MockedContext::default();
-      let hooks = GcHooks::new(&mut context);
-
-
       let result = match_obj!((&method.to_obj()) {
         ObjectKind::Fun(fun) => {
-          fun.check_if_valid_call(&hooks, args.len() as u8)
+          fun.check_if_valid_call(|| GcHooks::new(self), args.len() as u8)
         },
         ObjectKind::Closure(closure) => {
-          closure.fun().check_if_valid_call(&hooks, args.len() as u8)
+          closure.fun().check_if_valid_call(|| GcHooks::new(self), args.len() as u8)
         },
         ObjectKind::Method(method) => {
-          method.method().to_obj().to_closure().fun().check_if_valid_call(&hooks, args.len() as u8)
+          method.method().to_obj().to_closure().fun().check_if_valid_call(|| GcHooks::new(self), args.len() as u8)
         },
         ObjectKind::Native(native) => {
           let mut augmented_args = vec![this];
           augmented_args.extend_from_slice(args);
 
-          native.check_if_valid_call(&hooks, &augmented_args)
+          native.check_if_valid_call(|| GcHooks::new(self), &augmented_args)
         },
         _ => return Err(LyError::Exit(1)),
       });

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -1472,7 +1472,7 @@ impl Vm {
 
   /// check that the number of args is valid for the function arity
   unsafe fn check_arity(&mut self, fun: GcObj<Fun>, arg_count: u8) -> Option<ExecutionSignal> {
-    match fun.check_if_valid_call(&GcHooks::new(self), arg_count) {
+    match fun.check_if_valid_call(|| GcHooks::new(self), arg_count) {
       Ok(_) => None,
       Err(err) => Some(self.runtime_error(self.builtin.errors.runtime, err)),
     }
@@ -1484,7 +1484,7 @@ impl Vm {
     native: GcObj<Native>,
     args: &[Value],
   ) -> Option<ExecutionSignal> {
-    match native.check_if_valid_call(&GcHooks::new(self), args) {
+    match native.check_if_valid_call(|| GcHooks::new(self), args) {
       Ok(()) => None,
       Err(err) => Some(self.runtime_error(self.builtin.errors.runtime, err)),
     }

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -1,10 +1,21 @@
 use super::{source_loader::ImportResult, ExecutionSignal, Vm};
 use crate::{byte_code::CaptureIndex, constants::MAX_FRAME_SIZE};
 use laythe_core::{
-  captures::Captures, hooks::{GcHooks, Hooks}, if_let_obj, list, managed::{Array, Gc, GcObj, GcStr, List, Tuple}, match_obj, module::Import, object::{
-    Channel, Class, Closure, Fun, LyBox, Map, Method, Native, NativeMeta, ObjectKind,
-    ReceiveResult, SendResult,
-  }, signature::{ArityError, NativeEnvironment, ParameterKind, SignatureError}, to_obj_kind, utils::is_falsey, val, value::{Value, VALUE_NIL, VALUE_TRUE}, Call, LyError
+  captures::Captures,
+  hooks::{GcHooks, Hooks},
+  if_let_obj, list,
+  managed::{Array, Gc, GcObj, GcStr, List, Tuple},
+  match_obj,
+  module::Import,
+  object::{
+    Channel, Class, Closure, Fun, LyBox, Map, Method, Native, ObjectKind, ReceiveResult, SendResult,
+  },
+  signature::{NativeEnvironment, ParameterKind},
+  to_obj_kind,
+  utils::is_falsey,
+  val,
+  value::{Value, VALUE_NIL, VALUE_TRUE},
+  Call, LyError,
 };
 use laythe_core::{managed::GcObject, object::Fiber};
 use std::{cmp::Ordering, mem};
@@ -125,7 +136,7 @@ impl Vm {
     let capacity = self.fiber.pop();
 
     if !capacity.is_num() {
-      return self.runtime_error(
+      return self.runtime_error_from_str(
         self.builtin.errors.type_,
         &format!(
           "function \"chan\"'s parameter \"capacity\" required a number but received a {}.",
@@ -136,7 +147,7 @@ impl Vm {
 
     let capacity = capacity.to_num();
     if capacity.fract() != 0.0 || capacity < 1.0 {
-      return self.runtime_error(
+      return self.runtime_error_from_str(
         self.builtin.errors.type_,
         "buffer must be an positive integer.",
       );
@@ -163,7 +174,7 @@ impl Vm {
           ExecutionSignal::Ok
         }
         ReceiveResult::NoReceiveAccess => {
-          self.runtime_error(self.builtin.errors.value, "todo no read access")
+          self.runtime_error_from_str(self.builtin.errors.value, "todo no read access")
         }
         ReceiveResult::EmptyBlock(fiber) => {
           if let Some(mut fiber) = fiber.or_else(|| self.fiber.get_runnable())  {
@@ -193,7 +204,7 @@ impl Vm {
         }
       }
     } else {
-      self.runtime_error(
+      self.runtime_error_from_str(
         self.builtin.errors.type_,
         "Can only drain from a channel.",
       )
@@ -210,7 +221,7 @@ impl Vm {
 
       match channel.send(self.fiber, value) {
         SendResult::Ok => ExecutionSignal::Ok,
-        SendResult::NoSendAccess => self.runtime_error(
+        SendResult::NoSendAccess => self.runtime_error_from_str(
           self.builtin.errors.runtime,
           "Attempted to send into a receive only channel.",
         ),
@@ -241,13 +252,13 @@ impl Vm {
           self.fiber.sleep();
           ExecutionSignal::ContextSwitch
         }
-        SendResult::Closed => self.runtime_error(
+        SendResult::Closed => self.runtime_error_from_str(
           self.builtin.errors.runtime,
           "Attempted to send into a closed channel.",
         ),
       }
     } else {
-      self.runtime_error(self.builtin.errors.runtime, "Attempted to send into a non channel.")
+      self.runtime_error_from_str(self.builtin.errors.runtime, "Attempted to send into a non channel.")
     })
   }
 
@@ -346,7 +357,7 @@ impl Vm {
               .set_invoke_cache(inline_slot, class, method);
             self.resolve_call(method, arg_count)
           },
-          None => self.runtime_error(
+          None => self.runtime_error_from_str(
             self.builtin.errors.property,
             &format!(
               "Undefined property {} on class {}.",
@@ -398,7 +409,7 @@ impl Vm {
             .set_invoke_cache(inline_slot, super_class, method);
           self.resolve_call(method, arg_count)
         },
-        None => self.runtime_error(
+        None => self.runtime_error_from_str(
           self.builtin.errors.property,
           &format!(
             "Undefined property {} on class {}.",
@@ -424,7 +435,8 @@ impl Vm {
     let super_class = self.fiber.peek(1);
 
     if !super_class.is_obj() {
-      return self.runtime_error(self.builtin.errors.runtime, "Superclass must be a class.");
+      return self
+        .runtime_error_from_str(self.builtin.errors.runtime, "Superclass must be a class.");
     }
 
     let super_class = super_class.to_obj();
@@ -436,11 +448,11 @@ impl Vm {
         if ly_box.value.is_obj_kind(ObjectKind::Class) {
           ly_box.value.to_obj().to_class()
         } else {
-          return self.runtime_error(self.builtin.errors.runtime, "Superclass must be a class.");
+          return self.runtime_error_from_str(self.builtin.errors.runtime, "Superclass must be a class.");
         }
       },
       _ => {
-        return self.runtime_error(self.builtin.errors.runtime, "Superclass must be a class.");
+        return self.runtime_error_from_str(self.builtin.errors.runtime, "Superclass must be a class.");
       },
     });
 
@@ -516,7 +528,7 @@ impl Vm {
     if_let_obj!(ObjectKind::Class(error_class) = (error_class) {
       if !error_class.is_subclass(self.builtin.errors.error) {
         self.fiber.error_while_handling();
-        self.runtime_error(self.builtin.errors.type_, "Catch block must be blank or a subclass of Error.")
+        self.runtime_error_from_str(self.builtin.errors.type_, "Catch block must be blank or a subclass of Error.")
       } else {
 
         if !error.class().is_subclass(error_class) {
@@ -529,7 +541,7 @@ impl Vm {
 
     } else {
       self.fiber.error_while_handling();
-      self.runtime_error(self.builtin.errors.type_, "Catch block must be blank or a subclass of Error.")
+      self.runtime_error_from_str(self.builtin.errors.type_, "Catch block must be blank or a subclass of Error.")
     })
   }
 
@@ -539,9 +551,7 @@ impl Vm {
 
     match self.fiber.error() {
       Some(mut error) => {
-        let mut managed_backtrace: Tuple = self.manage_obj(
-          &*vec![VALUE_NIL; backtrace.len()]
-        );
+        let mut managed_backtrace: Tuple = self.manage_obj(&*vec![VALUE_NIL; backtrace.len()]);
 
         // attach the error so we good on a gc
         error[1] = val!(managed_backtrace);
@@ -581,13 +591,13 @@ impl Vm {
       if class.is_subclass(self.builtin.errors.error) {
         self.set_error(exception)
       } else {
-        self.runtime_error(
+        self.runtime_error_from_str(
           self.builtin.errors.runtime,
           "Can only raise an instance of Error",
         )
       }
     } else {
-      self.runtime_error(
+      self.runtime_error_from_str(
         self.builtin.errors.runtime,
         "Can only raise an instance of Error",
       )
@@ -638,7 +648,7 @@ impl Vm {
 
     let mut current_module = self.current_fun.module();
     if current_module.set_symbol(name, value).is_err() {
-      return self.runtime_error(
+      return self.runtime_error_from_str(
         self.builtin.errors.property,
         &format!("Undefined variable {name}"),
       );
@@ -709,7 +719,7 @@ impl Vm {
               instance[property_slot as usize] = value;
               ExecutionSignal::Ok
             },
-            None => self.runtime_error(
+            None => self.runtime_error_from_str(
               self.builtin.errors.property,
               &format!("Undefined property {} on class {}.", name, class.name()),
             ),
@@ -718,7 +728,7 @@ impl Vm {
       }
     });
 
-    self.runtime_error(
+    self.runtime_error_from_str(
       self.builtin.errors.runtime,
       "Only instances have settable fields.",
     )
@@ -733,7 +743,7 @@ impl Vm {
         self.fiber.push(gbl);
         ExecutionSignal::Ok
       },
-      None => self.runtime_error(
+      None => self.runtime_error_from_str(
         self.builtin.errors.runtime,
         &format!("Undefined variable {string}"),
       ),
@@ -841,7 +851,7 @@ impl Vm {
         let env = self.io.env();
         let resolved_path = env.current_dir().unwrap();
 
-        self.runtime_error(
+        self.runtime_error_from_str(
           self.builtin.errors.import,
           &format!(
             "Module {} not found in directory {:?}",
@@ -874,7 +884,7 @@ impl Vm {
           self.fiber.push(symbol);
           ExecutionSignal::Ok
         },
-        None => self.runtime_error(
+        None => self.runtime_error_from_str(
           self.builtin.errors.import,
           &format!(
             "Symbol {} not exported from module {}",
@@ -900,7 +910,7 @@ impl Vm {
             self.fiber.push(symbol);
             ExecutionSignal::Ok
           },
-          None => self.runtime_error(
+          None => self.runtime_error_from_str(
             self.builtin.errors.import,
             &format!(
               "Symbol {} not exported from module {}",
@@ -927,7 +937,7 @@ impl Vm {
         let env = self.io.env();
         let resolved_path = env.current_dir().unwrap();
 
-        self.runtime_error(
+        self.runtime_error_from_str(
           self.builtin.errors.import,
           &format!(
             "Module {} not found in directory {:?}",
@@ -943,7 +953,10 @@ impl Vm {
   }
 
   fn extract_import_path(&mut self, path: List) -> Vec<GcStr> {
-    path.iter().map(|segment| segment.to_obj().to_str()).collect()
+    path
+      .iter()
+      .map(|segment| segment.to_obj().to_str())
+      .collect()
   }
 
   fn full_import_path(&mut self, path_segments: &[GcStr]) -> GcStr {
@@ -980,7 +993,7 @@ impl Vm {
 
     match current_module.export_symbol(name) {
       Ok(_) => ExecutionSignal::Ok,
-      Err(error) => self.runtime_error(self.builtin.errors.export, &error.to_string()),
+      Err(error) => self.runtime_error_from_str(self.builtin.errors.export, &error.to_string()),
     }
   }
 
@@ -1006,7 +1019,7 @@ impl Vm {
       self.fiber.push(val!(-pop.to_num()));
       ExecutionSignal::Ok
     } else {
-      self.runtime_error(self.builtin.errors.runtime, "Operand must be a number.")
+      self.runtime_error_from_str(self.builtin.errors.runtime, "Operand must be a number.")
     }
   }
 
@@ -1034,7 +1047,7 @@ impl Vm {
       self.fiber.push(val!(string));
       ExecutionSignal::Ok
     } else {
-      self.runtime_error(
+      self.runtime_error_from_str(
         self.builtin.errors.runtime,
         "Operands must be two numbers or two strings.",
       )
@@ -1049,7 +1062,7 @@ impl Vm {
       return ExecutionSignal::Ok;
     }
 
-    self.runtime_error(self.builtin.errors.runtime, "Operands must be numbers.")
+    self.runtime_error_from_str(self.builtin.errors.runtime, "Operands must be numbers.")
   }
 
   pub(super) unsafe fn op_mul(&mut self) -> ExecutionSignal {
@@ -1060,7 +1073,7 @@ impl Vm {
       return ExecutionSignal::Ok;
     }
 
-    self.runtime_error(self.builtin.errors.runtime, "Operands must be numbers.")
+    self.runtime_error_from_str(self.builtin.errors.runtime, "Operands must be numbers.")
   }
 
   pub(super) unsafe fn op_div(&mut self) -> ExecutionSignal {
@@ -1071,7 +1084,7 @@ impl Vm {
       return ExecutionSignal::Ok;
     }
 
-    self.runtime_error(self.builtin.errors.runtime, "Operands must be numbers.")
+    self.runtime_error_from_str(self.builtin.errors.runtime, "Operands must be numbers.")
   }
 
   pub(super) unsafe fn op_and(&mut self) -> ExecutionSignal {
@@ -1115,7 +1128,7 @@ impl Vm {
       return ExecutionSignal::Ok;
     }
 
-    self.runtime_error(self.builtin.errors.runtime, "Operands must be numbers.")
+    self.runtime_error_from_str(self.builtin.errors.runtime, "Operands must be numbers.")
   }
 
   pub(super) unsafe fn op_less_equal(&mut self) -> ExecutionSignal {
@@ -1138,7 +1151,7 @@ impl Vm {
       return ExecutionSignal::Ok;
     }
 
-    self.runtime_error(
+    self.runtime_error_from_str(
       self.builtin.errors.runtime,
       "Operands must be numbers or strings.",
     )
@@ -1159,7 +1172,7 @@ impl Vm {
       return ExecutionSignal::Ok;
     }
 
-    self.runtime_error(
+    self.runtime_error_from_str(
       self.builtin.errors.runtime,
       "Operands must be numbers or strings.",
     )
@@ -1185,7 +1198,7 @@ impl Vm {
       return ExecutionSignal::Ok;
     }
 
-    self.runtime_error(
+    self.runtime_error_from_str(
       self.builtin.errors.runtime,
       "Operands must be numbers or strings.",
     )
@@ -1307,7 +1320,7 @@ impl Vm {
   pub(super) unsafe fn resolve_call(&mut self, callee: Value, arg_count: u8) -> ExecutionSignal {
     if !callee.is_obj() {
       let class_name = self.value_class(callee).name();
-      return self.runtime_error(
+      return self.runtime_error_from_str(
         self.builtin.errors.runtime,
         &format!("{class_name} is not callable."),
       );
@@ -1331,7 +1344,7 @@ impl Vm {
       },
       _ => {
         let class_name = self.value_class(callee).name();
-        self.runtime_error(
+        self.runtime_error_from_str(
           self.builtin.errors.runtime,
           &format!("{class_name} is not callable."),
         )
@@ -1348,7 +1361,7 @@ impl Vm {
       Some(init) => self.resolve_call(init, arg_count),
       None => {
         if arg_count != 0 {
-          self.runtime_error(
+          self.runtime_error_from_str(
             self.builtin.errors.runtime,
             &format!("Expected 0 arguments but got {arg_count}"),
           )
@@ -1361,26 +1374,23 @@ impl Vm {
 
   /// call a native function immediately returning the result
   unsafe fn call_native(&mut self, native: GcObj<Native>, arg_count: u8) -> ExecutionSignal {
-    let meta = native.meta();
     let mut fiber = self.fiber;
-    let args = fiber.stack_slice(arg_count as usize);
+
+    let args = match native.is_method() {
+      true => fiber.stack_slice(arg_count as usize + 1),
+      false => fiber.stack_slice(arg_count as usize),
+    };
 
     // check that the current function is called with the right number of args and types
-    if let Some(signal) = self.check_native_arity(meta, args) {
+    if let Some(signal) = self.check_native_arity(native, args) {
       return signal;
     }
-
-    let this = if meta.is_method {
-      Some(fiber.peek(arg_count as usize))
-    } else {
-      None
-    };
 
     #[cfg(debug_assertions)]
     let roots_before = self.gc().temp_roots();
 
-    match meta.environment {
-      NativeEnvironment::StackLess => match native.call(&mut Hooks::new(self), this, args) {
+    match native.environment() {
+      NativeEnvironment::StackLess => match native.call(&mut Hooks::new(self), args) {
         Call::Ok(value) => {
           fiber.drop_n(arg_count as usize + 1);
           fiber.push(value);
@@ -1397,19 +1407,16 @@ impl Vm {
       },
       NativeEnvironment::Normal => {
         let mut stub = self.native_fun_stubs.pop().unwrap_or_else(|| {
-          self.manage_obj(Fun::stub(&GcHooks::new(self), meta.name, self.global))
+          self.manage_obj(Fun::stub(&GcHooks::new(self), native.name(), self.global))
         });
-        stub.set_name(meta.name);
-        self.push_root(stub);
-
-        self.pop_roots(1);
-
+        stub.set_name(native.name());
         self.push_frame(stub, self.capture_stub, arg_count);
 
         // Because the stack can resize we need to store the values in a separate
-        // vec
+        // vec. TODO we should have a slice type which will keep the store alive.
+        // In general we should switch to using the new GcList
         let args = args.to_vec();
-        let result = native.call(&mut Hooks::new(self), this, &args);
+        let result = native.call(&mut Hooks::new(self), &args);
         self.native_fun_stubs.push(stub);
 
         match result {
@@ -1440,7 +1447,7 @@ impl Vm {
 
     // set the current current instruction pointer. check for overflow
     if self.fiber.frames().len() == MAX_FRAME_SIZE {
-      return self.runtime_error(self.builtin.errors.runtime, "Stack overflow.");
+      return self.runtime_error_from_str(self.builtin.errors.runtime, "Stack overflow.");
     }
 
     self.push_frame(closure.fun(), closure.captures(), arg_count);
@@ -1456,7 +1463,7 @@ impl Vm {
 
     // set the current current instruction pointer. check for overflow
     if self.fiber.frames().len() == MAX_FRAME_SIZE {
-      return self.runtime_error(self.builtin.errors.runtime, "Stack overflow.");
+      return self.runtime_error_from_str(self.builtin.errors.runtime, "Stack overflow.");
     }
 
     self.push_frame(fun, self.capture_stub, arg_count);
@@ -1465,118 +1472,21 @@ impl Vm {
 
   /// check that the number of args is valid for the function arity
   unsafe fn check_arity(&mut self, fun: GcObj<Fun>, arg_count: u8) -> Option<ExecutionSignal> {
-    match fun.arity().check(arg_count) {
+    match fun.check_if_valid_call(&GcHooks::new(self), arg_count) {
       Ok(_) => None,
-      Err(error) => match error {
-        ArityError::Fixed(arity) => Some(self.runtime_error(
-          self.builtin.errors.runtime,
-          &format!(
-            "{} expected {} argument(s) but got {}.",
-            fun.name(),
-            arity,
-            arg_count,
-          ),
-        )),
-        ArityError::Variadic(arity) => Some(self.runtime_error(
-          self.builtin.errors.runtime,
-          &format!(
-            "{} expected at least {} argument(s) but got {}.",
-            fun.name(),
-            arity,
-            arg_count,
-          ),
-        )),
-        ArityError::DefaultLow(arity) => Some(self.runtime_error(
-          self.builtin.errors.runtime,
-          &format!(
-            "{} expected at least {} argument(s) but got {}.",
-            fun.name(),
-            arity,
-            arg_count,
-          ),
-        )),
-        ArityError::DefaultHigh(arity) => Some(self.runtime_error(
-          self.builtin.errors.runtime,
-          &format!(
-            "{} expected at most {} argument(s) but got {}.",
-            fun.name(),
-            arity,
-            arg_count,
-          ),
-        )),
-      },
+      Err(err) => Some(self.runtime_error(self.builtin.errors.runtime, err)),
     }
   }
 
-  /// Check the arity of a native functio
+  /// Check the arity of a native function
   unsafe fn check_native_arity(
     &mut self,
-    native_meta: &NativeMeta,
+    native: GcObj<Native>,
     args: &[Value],
   ) -> Option<ExecutionSignal> {
-    match native_meta.signature.check(args) {
+    match native.check_if_valid_call(&GcHooks::new(self), args) {
       Ok(()) => None,
-      Err(err) => {
-        let callable_type = if native_meta.is_method {
-          "method"
-        } else {
-          "function"
-        };
-
-        match err {
-          SignatureError::LengthFixed(expected) => Some(self.runtime_error(
-            self.builtin.errors.runtime,
-            &format!(
-              "{} \"{}\" expected {} argument(s) but received {}.",
-              callable_type,
-              &*native_meta.name,
-              expected,
-              args.len(),
-            ),
-          )),
-          SignatureError::LengthVariadic(expected) => Some(self.runtime_error(
-            self.builtin.errors.runtime,
-            &format!(
-              "{} \"{}\" expected at least {} argument(s) but received {}.",
-              callable_type,
-              &*native_meta.name,
-              expected,
-              args.len(),
-            ),
-          )),
-          SignatureError::LengthDefaultLow(expected) => Some(self.runtime_error(
-            self.builtin.errors.runtime,
-            &format!(
-              "{} \"{}\" expected at least {} argument(s) but received {}.",
-              callable_type,
-              &*native_meta.name,
-              expected,
-              args.len(),
-            ),
-          )),
-          SignatureError::LengthDefaultHigh(expected) => Some(self.runtime_error(
-            self.builtin.errors.runtime,
-            &format!(
-              "{} \"{}\" expected at most {} argument(s) but received {}.",
-              callable_type,
-              &*native_meta.name,
-              expected,
-              args.len(),
-            ),
-          )),
-          SignatureError::TypeWrong(parameter) => Some(self.runtime_error(
-            self.builtin.errors.type_,
-            &format!(
-              "{} \"{}\"'s parameter \"{}\" required a {} but received a {}.",
-              callable_type,
-              &*native_meta.name,
-              &*native_meta.signature.parameters[parameter as usize].name,
-              native_meta.signature.parameters[parameter as usize].kind,
-              ParameterKind::from(args[parameter as usize])
-            ),
-          )),
-        }
-      },
+      Err(err) => Some(self.runtime_error(self.builtin.errors.runtime, err)),
     }
   }
 
@@ -1594,7 +1504,7 @@ impl Vm {
         self.fiber.peek_set(0, val!(bound));
         ExecutionSignal::Ok
       },
-      None => self.runtime_error(
+      None => self.runtime_error_from_str(
         self.builtin.errors.runtime,
         &format!("Undefined property {} on class {}.", name, class.name()),
       ),
@@ -1610,7 +1520,7 @@ impl Vm {
   ) -> ExecutionSignal {
     match class.get_method(&method_name) {
       Some(method) => self.resolve_call(method, arg_count),
-      None => self.runtime_error(
+      None => self.runtime_error_from_str(
         self.builtin.errors.property,
         &format!(
           "Undefined property {} on class {}.",
@@ -1627,7 +1537,7 @@ fn assert_roots(native: GcObj<Native>, roots_before: usize, roots_now: usize) {
   assert!(
     roots_before == roots_now,
     "Native function {} increased roots by {}.",
-    native.meta().name,
+    native.name(),
     roots_now - roots_before,
   );
 }


### PR DESCRIPTION
## Problem
Overall our api for native code is somewhat large and I would like to simplify it. I was hoping to simplify by remove the call_method method but that doesn't seem possible

## Solution
In this PR I really ended up doing two things
* Remove the this parameter and instead push everything into args
* Remove the tests which just reassert the data of the method.