### PR TITLE
Optimize property access

### DIFF
--- a/laythe_vm/src/byte_code.rs
+++ b/laythe_vm/src/byte_code.rs
@@ -175,6 +175,12 @@ pub enum SymbolicByteCode {
   /// Set a property on a class instance
   SetProperty(u16),
 
+  /// Get a property off a class instance
+  GetKnownProperty(u16),
+
+  /// Set a property on a class instance
+  SetKnownProperty(u16),
+
   /// Jump to end of if block if false
   JumpIfFalse(Label),
 
@@ -318,6 +324,8 @@ impl SymbolicByteCode {
       Self::SetCapture(_) => 2,
       Self::GetProperty(_) => 3,
       Self::SetProperty(_) => 3,
+      Self::GetKnownProperty(_) => 3,
+      Self::SetKnownProperty(_) => 3,
       Self::JumpIfFalse(_) => 3,
       Self::Jump(_) => 3,
       Self::Loop(_) => 3,
@@ -399,7 +407,9 @@ impl SymbolicByteCode {
       Self::GetCapture(_) => 1,
       Self::SetCapture(_) => 0,
       Self::GetProperty(_) => 0,
+      Self::GetKnownProperty(_) => 0,
       Self::SetProperty(_) => -1,
+      Self::SetKnownProperty(_) => -1,
       Self::JumpIfFalse(_) => -1,
       Self::Jump(_) => 0,
       Self::Loop(_) => 0,
@@ -526,6 +536,8 @@ impl<'a> ByteCodeEncoder<'a> {
         SymbolicByteCode::SetCapture(slot) => self.op_byte(ByteCode::SetCapture, *line, *slot),
         SymbolicByteCode::GetProperty(slot) => self.op_short(ByteCode::GetProperty, *line, *slot),
         SymbolicByteCode::SetProperty(slot) => self.op_short(ByteCode::SetProperty, *line, *slot),
+        SymbolicByteCode::GetKnownProperty(slot) => self.op_short(ByteCode::GetKnownProperty, *line, *slot),
+        SymbolicByteCode::SetKnownProperty(slot) => self.op_short(ByteCode::SetKnownProperty, *line, *slot),
         SymbolicByteCode::JumpIfFalse(target) => {
           let jump = label_offsets[target.0 as usize] - offset - 3;
           self.op_jump(ByteCode::JumpIfFalse, *line, jump)
@@ -833,6 +845,12 @@ pub enum ByteCode {
   /// Set a property on a class instance
   SetProperty,
 
+  /// Get a property off a class instance
+  GetKnownProperty,
+
+  /// Set a property on a class instance
+  SetKnownProperty,
+
   /// Jump to end of if block if false
   JumpIfFalse,
 
@@ -1075,6 +1093,12 @@ pub enum AlignedByteCode {
   /// Set a property on a class instance
   SetProperty(u16),
 
+  /// Get a property at a known offset for a class instance
+  GetKnownProperty(u16),
+
+  /// Set a property  at a known offset for a class instance
+  SetKnownProperty(u16),
+
   /// Jump to end of if block if false
   JumpIfFalse(u16),
 
@@ -1266,6 +1290,14 @@ impl AlignedByteCode {
       ),
       ByteCode::SetProperty => (
         Self::SetProperty(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::GetKnownProperty => (
+        Self::GetKnownProperty(decode_u16(&store[offset + 1..offset + 3])),
+        offset + 3,
+      ),
+      ByteCode::SetKnownProperty => (
+        Self::SetKnownProperty(decode_u16(&store[offset + 1..offset + 3])),
         offset + 3,
       ),
       ByteCode::JumpIfFalse => (

--- a/laythe_vm/src/compiler/ir/ast.rs
+++ b/laythe_vm/src/compiler/ir/ast.rs
@@ -4,7 +4,6 @@ use std::ops::Range;
 
 use super::{symbol_table::SymbolTable, token::Token};
 
-
 /// An object that can specify it's start and end position and optionally the full range
 /// Implementors of ranges only need to implement `start` ad `end`
 pub trait Spanned {
@@ -598,7 +597,6 @@ impl<'a> Spanned for Try<'a> {
   }
 }
 
-
 pub struct Catch<'a> {
   pub name: Token<'a>,
   pub symbols: SymbolTable<'a>,
@@ -607,8 +605,18 @@ pub struct Catch<'a> {
 }
 
 impl<'a> Catch<'a> {
-  pub fn new(name: Token<'a>, class: Option<Token<'a>>, symbols: SymbolTable<'a>, block: Block<'a>) -> Self {
-    Self { name, class, symbols, block }
+  pub fn new(
+    name: Token<'a>,
+    class: Option<Token<'a>>,
+    symbols: SymbolTable<'a>,
+    block: Block<'a>,
+  ) -> Self {
+    Self {
+      name,
+      class,
+      symbols,
+      block,
+    }
   }
 }
 
@@ -750,12 +758,12 @@ impl<'a> Spanned for Expr<'a> {
 }
 
 pub struct Assign<'a> {
-  pub lhs: Expr<'a>,
+  pub lhs: Atom<'a>,
   pub rhs: Expr<'a>,
 }
 
 impl<'a> Assign<'a> {
-  pub fn new(lhs: Expr<'a>, rhs: Expr<'a>) -> Self {
+  pub fn new(lhs: Atom<'a>, rhs: Expr<'a>) -> Self {
     Self { lhs, rhs }
   }
 }
@@ -771,12 +779,12 @@ impl<'a> Spanned for Assign<'a> {
 }
 
 pub struct Send<'a> {
-  pub lhs: Expr<'a>,
+  pub lhs: Atom<'a>,
   pub rhs: Expr<'a>,
 }
 
 impl<'a> Send<'a> {
-  pub fn new(lhs: Expr<'a>, rhs: Expr<'a>) -> Self {
+  pub fn new(lhs: Atom<'a>, rhs: Expr<'a>) -> Self {
     Self { lhs, rhs }
   }
 }
@@ -821,13 +829,13 @@ pub enum AssignBinaryOp {
 }
 
 pub struct AssignBinary<'a> {
-  pub lhs: Expr<'a>,
+  pub lhs: Atom<'a>,
   pub op: AssignBinaryOp,
   pub rhs: Expr<'a>,
 }
 
 impl<'a> AssignBinary<'a> {
-  pub fn new(lhs: Expr<'a>, op: AssignBinaryOp, rhs: Expr<'a>) -> Self {
+  pub fn new(lhs: Atom<'a>, op: AssignBinaryOp, rhs: Expr<'a>) -> Self {
     Self { lhs, op, rhs }
   }
 }
@@ -1044,6 +1052,15 @@ pub enum Primary<'a> {
   String(Token<'a>),
   Super(Super<'a>),
   True(Token<'a>),
+}
+
+impl<'a> Primary<'a> {
+  pub fn is_self(&self) -> bool {
+    match *self {
+      Self::Self_(_) => true,
+      _ => false,
+    }
+  }
 }
 
 impl<'a> Spanned for Primary<'a> {

--- a/laythe_vm/src/compiler/ir/ast_printer.rs
+++ b/laythe_vm/src/compiler/ir/ast_printer.rs
@@ -511,19 +511,19 @@ impl<'a> Visitor<'a> for AstPrint {
     self.buffer.push_str("}");
   }
   fn visit_assign(&mut self, assign: &Assign) -> Self::Result {
-    self.visit_expr(&assign.lhs);
+    self.visit_atom(&assign.lhs);
     self.buffer.push_str(" = ");
     self.visit_expr(&assign.rhs);
   }
 
   fn visit_drain(&mut self, assign: &Send) -> Self::Result {
-    self.visit_expr(&assign.lhs);
+    self.visit_atom(&assign.lhs);
     self.buffer.push_str(" <- ");
     self.visit_expr(&assign.rhs);
   }
 
   fn visit_assign_binary(&mut self, assign_binary: &AssignBinary) -> Self::Result {
-    self.visit_expr(&assign_binary.lhs);
+    self.visit_atom(&assign_binary.lhs);
     self.buffer.push(' ');
     match &assign_binary.op {
       AssignBinaryOp::Add => self.buffer.push_str("+="),

--- a/laythe_vm/src/compiler/mod.rs
+++ b/laythe_vm/src/compiler/mod.rs
@@ -27,7 +27,9 @@ use laythe_core::{
     INDEX_GET, INDEX_SET, ITER, ITER_VAR, OBJECT, SCRIPT, SELF, SUPER, UNINITIALIZED_VAR,
   },
   hooks::{GcContext, GcHooks, NoContext},
-  managed::{Allocator, AllocResult, Allocate, DebugHeap, Gc, GcStr, ListBuilder, Trace, TraceRoot},
+  managed::{
+    AllocResult, Allocate, Allocator, DebugHeap, Gc, GcStr, ListBuilder, Trace, TraceRoot,
+  },
   module,
   object::{self, FunBuilder, FunKind, Map},
   signature::Arity,
@@ -69,16 +71,16 @@ pub struct ClassAttributes {
   /// the fields present on this class
   fields: Vec<GcStr>,
 
-  /// The name of this class
-  name: GcStr,
+  /// Does this class have an explicit super class
+  has_explicit_super_class: bool,
 }
 
 impl ClassAttributes {
-  fn new(name: GcStr) -> Self {
+  fn new() -> Self {
     ClassAttributes {
       fun_kind: None,
       fields: vec![],
-      name,
+      has_explicit_super_class: false,
     }
   }
 
@@ -92,7 +94,7 @@ impl DebugHeap for ClassAttributes {
     f.debug_struct("ClassInfo")
       .field("fun_kind", &self.fun_kind)
       .field("fields", &self.fields)
-      .field("name", &self.name)
+      .field("has_explicit_super_class", &self.has_explicit_super_class)
       .finish()
   }
 }
@@ -105,12 +107,10 @@ impl Allocate<Gc<Self>> for ClassAttributes {
 
 impl Trace for ClassAttributes {
   fn trace(&self) {
-    self.name.trace();
     self.fields.iter().for_each(|field| field.trace());
   }
 
   fn trace_debug(&self, log: &mut dyn Write) {
-    self.name.trace_debug(log);
     self.fields.iter().for_each(|field| field.trace_debug(log));
   }
 }
@@ -936,7 +936,7 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
   }
 
   /// Compile a the base of an expression
-  fn primary(&mut self, primary: &'a Primary<'src>) {
+  fn primary(&mut self, primary: &'a Primary<'src>) -> bool {
     match primary {
       Primary::Channel(token) => self.channel(token),
       Primary::True(token) => self.true_(token),
@@ -954,6 +954,12 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
       Primary::List(list) => self.list(list),
       Primary::Tuple(tuple) => self.tuple(tuple),
       Primary::Map(map) => self.map(map),
+    }
+
+    if let Primary::Self_(_) = primary {
+      true
+    } else {
+      false
     }
   }
 
@@ -998,11 +1004,7 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
     self.define_variable(class_constant, class_state, class_name.end());
 
     // set this class as the current class compiler
-    let managed_class_name = self.gc.borrow_mut().manage_str(class_name.str(), self);
-    let class_attributes = self
-      .gc
-      .borrow_mut()
-      .manage(ClassAttributes::new(managed_class_name), self);
+    let mut class_attributes = self.gc.borrow_mut().manage(ClassAttributes::new(), self);
     let enclosing_class = mem::replace(&mut self.class_attributes, Some(class_attributes));
     if let Some(enclosing_class) = enclosing_class {
       self.gc.borrow_mut().push_root(enclosing_class);
@@ -1022,6 +1024,8 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
 
     // Load an explicit or implicit super class
     if let Some(super_class) = &class.super_class {
+      // mark that we have an explicit super class
+      class_attributes.has_explicit_super_class = true;
       self.variable_get(&super_class.type_ref.name);
     } else {
       self.variable_get(&Token::new(
@@ -1217,7 +1221,6 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
       let mut list = hooks.manage_obj(ListBuilder::new(&[], import.path.len()));
       hooks.push_root(list);
 
-
       for segment in &import.path {
         list.push(val!(hooks.manage_str(segment.str())), &hooks)
       }
@@ -1270,13 +1273,9 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
       self_.expr(&for_.iter);
       let expr_line = for_.iter.end();
 
-      // get constant for 'iter' method
-      let iter_method_const = self_.string_constant(ITER);
-
       // declare the hidden local $iter variable
       self_.declare_local_variable(ITER_VAR);
-      self_.emit_byte(SymbolicByteCode::Invoke((iter_method_const, 0)), expr_line);
-      self_.emit_byte(SymbolicByteCode::InvokeSlot, expr_line);
+      self_.emit_known_invoke(ITER, 0, expr_line);
       self_.define_local_variable(ITER_VAR, SymbolState::Initialized, expr_line);
 
       let item_line = for_.item.end();
@@ -1388,8 +1387,7 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
       Expr::Atom(atom) => match atom.trailers.last() {
         Some(Trailer::Call(call)) => {
           // emit instruction for everything but the actual call
-          self.primary(&atom.primary);
-          self.apply_trailers(&atom.trailers[..atom.trailers.len() - 1]);
+          self.apply_atom(&atom.primary, &atom.trailers[..atom.trailers.len() - 1]);
 
           // emit for each argument for the launch call
           for expr in &call.args {
@@ -1559,252 +1557,201 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
 
   /// Compile an assignment expression
   fn assign(&mut self, assign: &'a ast::Assign<'src>) {
-    match &assign.lhs {
-      Expr::Atom(atom) => match atom.trailers.last() {
-        // if we have trailers compile to last trailer and emit specialized
-        // set instruction
-        Some(last) => {
-          self.primary(&atom.primary);
-          self.apply_trailers(&atom.trailers[..atom.trailers.len() - 1]);
+    let primary = &assign.lhs.primary;
+    let trailers = &*assign.lhs.trailers;
 
-          match last {
-            Trailer::Index(index) => {
-              self.expr(&assign.rhs);
-              self.expr(&index.index);
+    match trailers.last() {
+      // if we have trailers compile to last trailer and emit specialized
+      // set instruction
+      Some(last) => {
+        self.apply_atom(&primary, &trailers[..trailers.len() - 1]);
 
-              self.emit_known_invoke(INDEX_SET, 2, assign.rhs.end());
-            },
-            Trailer::Access(access) => {
-              if self.fun_kind == FunKind::Initializer && atom.trailers.len() == 1 {
-                if let Primary::Self_(_) = atom.primary {
-                  let mut class_info = self.class_attributes.unwrap();
-
-                  if !class_info.fields.iter().any(|f| *f == access.prop.str()) {
-                    let field = self.gc.borrow_mut().manage_str(access.prop.str(), self);
-                    class_info.add_field(field);
-                  }
-                }
-              }
-
-              let name = self.identifier_constant(access.prop.str());
-
-              self.expr(&assign.rhs);
-              self.emit_byte(SymbolicByteCode::SetProperty(name), access.end());
-              self.emit_byte(SymbolicByteCode::PropertySlot, access.end());
-            },
-            Trailer::Call(_) => {
-              unreachable!("Unexpected expression on left hand side of assignment.")
-            },
-          }
-        },
-        None => match &atom.primary {
-          Primary::Ident(name) => {
+        match last {
+          Trailer::Index(index) => {
             self.expr(&assign.rhs);
-            self.variable_set(name);
+            self.expr(&index.index);
+
+            self.emit_known_invoke(INDEX_SET, 2, assign.rhs.end());
           },
-          Primary::InstanceAccess(instance_access) => {
-            self.instance_access_self(instance_access);
-            let property = instance_access.property();
-
-            if self.fun_kind == FunKind::Initializer {
-              let mut class_info = self.class_attributes.unwrap();
-
-              if !class_info.fields.iter().any(|f| *f == property) {
-                let field = self.gc.borrow_mut().manage_str(property, self);
-                class_info.add_field(field);
+          Trailer::Access(access) => {
+            let class = if primary.is_self() && trailers.len() == 1 {
+              if self.fun_kind == FunKind::Initializer {
+                self.record_field(&access.prop.str());
               }
-            }
-
-            let name = self.identifier_constant(property);
+              self.class_attributes
+            } else {
+              None
+            };
 
             self.expr(&assign.rhs);
-            self.emit_byte(SymbolicByteCode::SetProperty(name), instance_access.end());
-            self.emit_byte(SymbolicByteCode::PropertySlot, instance_access.end());
+            self.property_set(access.prop.str(), class, access.end());
           },
           _ => unreachable!("Unexpected expression on left hand side of assignment."),
-        },
+        }
       },
-      _ => unreachable!("Unexpected expression on left hand side of assignment."),
+      None => match &primary {
+        Primary::Ident(name) => {
+          self.expr(&assign.rhs);
+          self.variable_set(name);
+        },
+        Primary::InstanceAccess(instance_access) => {
+          self.instance_access_self(instance_access);
+          let property = instance_access.property();
+
+          if self.fun_kind == FunKind::Initializer {
+            self.record_field(&property);
+          }
+
+          self.expr(&assign.rhs);
+          self.property_set(&property, self.class_attributes, instance_access.end());
+        },
+        _ => unreachable!("Unexpected expression on left hand side of assignment."),
+      },
     }
   }
 
   fn send(&mut self, send: &'a ast::Send<'src>) {
     self.expr(&send.rhs);
 
-    match &send.lhs {
-      Expr::Atom(atom) => match atom.trailers.last() {
-        // if we have trailers compile to last trailer and emit specialized
-        // set instruction
-        Some(last) => {
-          self.primary(&atom.primary);
-          self.apply_trailers(&atom.trailers[..atom.trailers.len() - 1]);
+    let primary = &send.lhs.primary;
+    let trailers = &*send.lhs.trailers;
 
-          match last {
-            Trailer::Index(index) => {
-              // self.expr(&send.rhs);
-              self.expr(&index.index);
+    match trailers.last() {
+      // if we have trailers compile to last trailer and emit specialized
+      // set instruction
+      Some(last) => {
+        self.apply_atom(&primary, &trailers[..trailers.len() - 1]);
 
-              self.emit_known_invoke(INDEX_GET, 1, index.end());
-              self.emit_byte(SymbolicByteCode::Send, send.lhs.end())
-            },
-            Trailer::Access(access) => {
-              if self.fun_kind == FunKind::Initializer && atom.trailers.len() == 1 {
-                if let Primary::Self_(_) = atom.primary {
-                  let mut class_info = self.class_attributes.unwrap();
+        match last {
+          Trailer::Index(index) => {
+            self.expr(&index.index);
 
-                  if !class_info.fields.iter().any(|f| *f == access.prop.str()) {
-                    let field = self.gc.borrow_mut().manage_str(access.prop.str(), self);
-                    class_info.add_field(field);
-                  }
-                }
-              }
-
-              let name = self.identifier_constant(access.prop.str());
-
-              self.emit_byte(SymbolicByteCode::GetProperty(name), access.end());
-              self.emit_byte(SymbolicByteCode::PropertySlot, access.end());
-
-              self.emit_byte(SymbolicByteCode::Send, send.lhs.end())
-            },
-            Trailer::Call(_) => {
-              unreachable!("Unexpected expression on left hand side of send.")
-            },
-          }
-        },
-        None => match &atom.primary {
-          Primary::Ident(name) => {
-            self.variable_get(name);
-
+            self.emit_known_invoke(INDEX_GET, 1, index.end());
             self.emit_byte(SymbolicByteCode::Send, send.lhs.end())
           },
-          Primary::InstanceAccess(instance_access) => {
-            self.instance_access_self(instance_access);
-            let property = instance_access.property();
-
-            if self.fun_kind == FunKind::Initializer {
-              let mut class_info = self.class_attributes.unwrap();
-
-              if !class_info.fields.iter().any(|f| *f == property) {
-                let field = self.gc.borrow_mut().manage_str(property, self);
-                class_info.add_field(field);
+          Trailer::Access(access) => {
+            let class = if primary.is_self() && trailers.len() == 1 {
+              if self.fun_kind == FunKind::Initializer {
+                self.record_field(&access.prop.str());
               }
-            }
+              self.class_attributes
+            } else {
+              None
+            };
 
-            let name = self.identifier_constant(instance_access.property());
-
-            self.emit_byte(SymbolicByteCode::GetProperty(name), instance_access.end());
-            self.emit_byte(SymbolicByteCode::PropertySlot, instance_access.end());
-
+            self.property_get(access.prop.str(), class, access.end());
             self.emit_byte(SymbolicByteCode::Send, send.lhs.end())
           },
-          _ => unreachable!("Unexpected expression on left hand side of assignment."),
-        },
+          Trailer::Call(_) => {
+            unreachable!("Unexpected expression on left hand side of send.")
+          },
+        }
       },
-      _ => unreachable!("Unexpected expression on left hand side of assignment."),
+      None => match &primary {
+        Primary::Ident(name) => {
+          self.variable_get(name);
+
+          self.emit_byte(SymbolicByteCode::Send, send.lhs.end())
+        },
+        Primary::InstanceAccess(instance_access) => {
+          self.instance_access_self(instance_access);
+          let property = instance_access.property();
+
+          if self.fun_kind == FunKind::Initializer {
+            self.record_field(&property);
+          }
+
+          self.property_get(
+            instance_access.property(),
+            self.class_attributes,
+            instance_access.end(),
+          );
+          self.emit_byte(SymbolicByteCode::Send, send.lhs.end())
+        },
+        _ => unreachable!("Unexpected expression on left hand side of assignment."),
+      },
     }
   }
 
   /// Compile a binary assignment expression
   fn assign_binary(&mut self, assign_binary: &'a ast::AssignBinary<'src>) {
-    let binary_op = |comp: &mut Compiler<'a, 'src>| match &assign_binary.op {
-      ast::AssignBinaryOp::Add => comp.emit_byte(SymbolicByteCode::Add, assign_binary.rhs.end()),
-      ast::AssignBinaryOp::Sub => {
-        comp.emit_byte(SymbolicByteCode::Subtract, assign_binary.rhs.end())
-      },
-      ast::AssignBinaryOp::Mul => {
-        comp.emit_byte(SymbolicByteCode::Multiply, assign_binary.rhs.end())
-      },
-      ast::AssignBinaryOp::Div => comp.emit_byte(SymbolicByteCode::Divide, assign_binary.rhs.end()),
+    let binary_op = match &assign_binary.op {
+      ast::AssignBinaryOp::Add => SymbolicByteCode::Add,
+      ast::AssignBinaryOp::Sub => SymbolicByteCode::Subtract,
+      ast::AssignBinaryOp::Mul => SymbolicByteCode::Multiply,
+      ast::AssignBinaryOp::Div => SymbolicByteCode::Divide,
     };
 
-    match &assign_binary.lhs {
-      Expr::Atom(atom) => match atom.trailers.last() {
-        // if we have trailers compile to last trailer and emit specialized
-        // set instruction
-        Some(last) => {
-          self.primary(&atom.primary);
-          self.apply_trailers(&atom.trailers[..atom.trailers.len() - 1]);
+    let primary = &assign_binary.lhs.primary;
+    let trailers = &*assign_binary.lhs.trailers;
 
-          match last {
-            Trailer::Index(index) => {
-              self.emit_byte(SymbolicByteCode::Dup, assign_binary.lhs.end());
+    match trailers.last() {
+      // if we have trailers compile to last trailer and emit specialized
+      // set instruction
+      Some(last) => {
+        self.apply_atom(&primary, &trailers[..trailers.len() - 1]);
 
-              self.expr(&index.index);
+        match last {
+          Trailer::Index(index) => {
+            self.emit_byte(SymbolicByteCode::Dup, assign_binary.lhs.end());
 
-              self.emit_known_invoke(INDEX_GET, 1, assign_binary.rhs.end());
+            self.expr(&index.index);
 
-              self.expr(&assign_binary.rhs);
-              binary_op(self);
+            self.emit_known_invoke(INDEX_GET, 1, assign_binary.rhs.end());
 
-              self.expr(&index.index);
-
-              self.emit_known_invoke(INDEX_SET, 2, assign_binary.rhs.end());
-            },
-            Trailer::Access(access) => {
-              if self.fun_kind == FunKind::Initializer && atom.trailers.len() == 1 {
-                if let Primary::Self_(_) = atom.primary {
-                  let mut class_info = self.class_attributes.unwrap();
-
-                  if !class_info.fields.iter().any(|f| *f == access.prop.str()) {
-                    let field = self.gc.borrow_mut().manage_str(access.prop.str(), self);
-                    class_info.add_field(field);
-                  }
-                }
-              }
-
-              let name = self.identifier_constant(access.prop.str());
-
-              self.emit_byte(SymbolicByteCode::Dup, access.end());
-              self.emit_byte(SymbolicByteCode::GetProperty(name), access.end());
-              self.emit_byte(SymbolicByteCode::PropertySlot, access.end());
-
-              self.expr(&assign_binary.rhs);
-              binary_op(self);
-
-              self.emit_byte(SymbolicByteCode::SetProperty(name), access.end());
-              self.emit_byte(SymbolicByteCode::PropertySlot, access.end());
-            },
-            Trailer::Call(_) => {
-              unreachable!("Unexpected expression on left hand side of assignment.")
-            },
-          }
-        },
-        None => match &atom.primary {
-          Primary::Ident(name) => {
-            self.variable_get(name);
             self.expr(&assign_binary.rhs);
-            binary_op(self);
-            self.variable_set(name);
+            self.emit_byte(binary_op, assign_binary.rhs.start());
+
+            self.expr(&index.index);
+
+            self.emit_known_invoke(INDEX_SET, 2, assign_binary.rhs.end());
           },
-          Primary::InstanceAccess(instance_access) => {
-            self.instance_access_self(instance_access);
-            let property = instance_access.property();
-
-            if self.fun_kind == FunKind::Initializer {
-              let mut class_info = self.class_attributes.unwrap();
-
-              if !class_info.fields.iter().any(|f| *f == property) {
-                let field = self.gc.borrow_mut().manage_str(property, self);
-                class_info.add_field(field);
+          Trailer::Access(access) => {
+            let class = if primary.is_self() && trailers.len() == 1 {
+              if self.fun_kind == FunKind::Initializer {
+                self.record_field(&access.prop.str());
               }
-            }
+              self.class_attributes
+            } else {
+              None
+            };
 
-            let name = self.identifier_constant(property);
-
-            self.emit_byte(SymbolicByteCode::Dup, instance_access.end());
-            self.emit_byte(SymbolicByteCode::GetProperty(name), instance_access.end());
-            self.emit_byte(SymbolicByteCode::PropertySlot, instance_access.end());
+            self.emit_byte(SymbolicByteCode::Dup, access.end());
+            self.property_get(&access.prop.str(), class, access.end());
 
             self.expr(&assign_binary.rhs);
-            binary_op(self);
+            self.emit_byte(binary_op, assign_binary.rhs.start());
 
-            self.emit_byte(SymbolicByteCode::SetProperty(name), instance_access.end());
-            self.emit_byte(SymbolicByteCode::PropertySlot, instance_access.end());
+            self.property_set(&access.prop.str(), self.class_attributes, access.end());
           },
           _ => unreachable!("Unexpected expression on left hand side of assignment."),
-        },
+        }
       },
-      _ => unreachable!("Unexpected expression on left hand side of assignment."),
+      None => match &primary {
+        Primary::Ident(name) => {
+          self.variable_get(name);
+          self.expr(&assign_binary.rhs);
+          self.emit_byte(binary_op, assign_binary.rhs.start());
+          self.variable_set(name);
+        },
+        Primary::InstanceAccess(instance_access) => {
+          self.instance_access_self(instance_access);
+          let property = instance_access.property();
+
+          if self.fun_kind == FunKind::Initializer {
+            self.record_field(&property);
+          }
+
+          self.emit_byte(SymbolicByteCode::Dup, instance_access.end());
+          self.property_get(property, self.class_attributes, instance_access.end());
+
+          self.expr(&assign_binary.rhs);
+          self.emit_byte(binary_op, assign_binary.rhs.start());
+
+          self.property_set(property, self.class_attributes, instance_access.end());
+        },
+        _ => unreachable!("Unexpected expression on left hand side of assignment."),
+      },
     }
   }
 
@@ -1895,26 +1842,92 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
   }
 
   /// Compile an access expression
-  fn access(&mut self, access: &ast::Access) {
-    let name = self.identifier_constant(access.prop.str());
-    self.emit_byte(SymbolicByteCode::GetProperty(name), access.prop.end());
-    self.emit_byte(SymbolicByteCode::PropertySlot, access.end());
+  fn access(&mut self, access: &ast::Access, is_self: bool) {
+    let class = if is_self { self.class_attributes } else { None };
+
+    self.property_get(access.prop.str(), class, access.prop.end());
+  }
+
+  /// Emit the instruction to get a property onto the stack from the instance
+  /// This method handle the optimized and non optimized case. In the optimized case
+  /// we emit an instruction for a property at a know offset. For the non optimized case
+  /// We emit the generic get property and place a property for runtime optimization
+  fn property_get(&mut self, field: &str, class: Option<Gc<ClassAttributes>>, offset: u32) {
+    match class {
+      Some(class) => {
+        if let Some(position) = self.find_known_field(&field, class) {
+          if class.has_explicit_super_class {
+            let name = self.identifier_constant(field);
+            self.emit_byte(SymbolicByteCode::GetProperty(name), offset);
+            self.emit_byte(SymbolicByteCode::PropertySlot, offset);
+          } else {
+            self.emit_byte(SymbolicByteCode::GetKnownProperty(position as u16), offset);
+          }
+        } else {
+          let name = self.identifier_constant(field);
+          self.emit_byte(SymbolicByteCode::GetProperty(name), offset);
+          self.emit_byte(SymbolicByteCode::PropertySlot, offset);
+        }
+      },
+      None => {
+        let name = self.identifier_constant(field);
+        self.emit_byte(SymbolicByteCode::GetProperty(name), offset);
+        self.emit_byte(SymbolicByteCode::PropertySlot, offset);
+      },
+    }
+  }
+
+  /// Emit the instruction to set a property onto the stack from the instance
+  /// This method handle the optimized and non optimized case. In the optimized case
+  /// we emit an instruction for a property at a know offset. For the non optimized case
+  /// We emit the generic get property and place a property for runtime optimization
+  fn property_set(&mut self, field: &str, class: Option<Gc<ClassAttributes>>, offset: u32) {
+    match class {
+      Some(class) => {
+        if let Some(position) = self.find_known_field(&field, class) {
+          if class.has_explicit_super_class {
+            let name = self.identifier_constant(field);
+            self.emit_byte(SymbolicByteCode::SetProperty(name), offset);
+            self.emit_byte(SymbolicByteCode::PropertySlot, offset);
+          } else {
+            self.emit_byte(SymbolicByteCode::SetKnownProperty(position as u16), offset);
+          }
+        } else {
+          let name = self.identifier_constant(field);
+          self.emit_byte(SymbolicByteCode::SetProperty(name), offset);
+          self.emit_byte(SymbolicByteCode::PropertySlot, offset);
+        }
+      },
+      None => {
+        let name = self.identifier_constant(field);
+        self.emit_byte(SymbolicByteCode::SetProperty(name), offset);
+        self.emit_byte(SymbolicByteCode::PropertySlot, offset);
+      },
+    }
   }
 
   /// Compile an atom expression
   fn atom(&mut self, atom: &'a ast::Atom<'src>) {
-    self.primary(&atom.primary);
-    self.apply_trailers(&atom.trailers);
+    self.apply_atom(&atom.primary, &atom.trailers);
+  }
+
+  /// Apply the components of the atom
+  fn apply_atom(&mut self, primary: &'a ast::Primary<'src>, trailers: &'a [Trailer<'src>]) -> bool {
+    let is_self = self.primary(&primary);
+    self.apply_trailers(is_self, &trailers);
+    is_self
   }
 
   /// Compile trailers onto a base primary
-  fn apply_trailers(&mut self, trailers: &'a [Trailer<'src>]) {
+  fn apply_trailers(&mut self, mut is_self: bool, trailers: &'a [Trailer<'src>]) {
     for trailer in trailers.iter() {
       match trailer {
         Trailer::Call(call) => self.call(call),
         Trailer::Index(index) => self.index(index),
-        Trailer::Access(access) => self.access(access),
+        Trailer::Access(access) => self.access(access, is_self),
       }
+
+      is_self = false
     }
   }
 
@@ -2000,10 +2013,11 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
   /// Compile instance access
   fn instance_access(&mut self, instance_access: &ast::InstanceAccess<'src>) {
     if self.instance_access_self(instance_access) {
-      let name = self.identifier_constant(instance_access.property());
-
-      self.emit_byte(SymbolicByteCode::GetProperty(name), instance_access.end());
-      self.emit_byte(SymbolicByteCode::PropertySlot, instance_access.end());
+      self.property_get(
+        instance_access.property(),
+        self.class_attributes,
+        instance_access.end(),
+      );
     }
   }
 
@@ -2034,6 +2048,22 @@ impl<'a, 'src: 'a> Compiler<'a, 'src> {
         None
       })
       .is_some()
+  }
+
+  /// Record a field if it's new
+  fn record_field(&mut self, field: &str) {
+    let mut class_info = self.class_attributes.unwrap();
+
+    if !class_info.fields.iter().any(|f| *f == field) {
+      let field = self.gc.borrow_mut().manage_str(field, self);
+      class_info.add_field(field);
+    }
+  }
+
+  /// Attempt to find a known field returning it's
+  /// class offset if found
+  fn find_known_field(&mut self, field: &str, class: Gc<ClassAttributes>) -> Option<usize> {
+    class.fields.iter().position(|f| f == field)
   }
 
   /// Compile the self token
@@ -2186,7 +2216,7 @@ mod test {
   };
   use laythe_core::{
     hooks::{GcHooks, NoContext},
-    managed::{NoGc, NO_GC, GcObj},
+    managed::{GcObj, NoGc, NO_GC},
     object::{Class, ObjectKind},
   };
   use laythe_env::stdio::{support::StdioTestContainer, Stdio};
@@ -2935,8 +2965,7 @@ mod test {
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::True),
-            ByteCodeTest::Code(AlignedByteCode::SetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(0)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Drop),
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
@@ -2949,8 +2978,7 @@ mod test {
           2,
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
-            ByteCodeTest::Code(AlignedByteCode::GetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(1)),
+            ByteCodeTest::Code(AlignedByteCode::GetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
           ],
         )),
@@ -3009,8 +3037,7 @@ mod test {
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::True),
-            ByteCodeTest::Code(AlignedByteCode::SetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(0)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Drop),
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
@@ -3023,8 +3050,7 @@ mod test {
           2,
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
-            ByteCodeTest::Code(AlignedByteCode::GetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(1)),
+            ByteCodeTest::Code(AlignedByteCode::GetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
           ],
         )),
@@ -3083,8 +3109,7 @@ mod test {
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::True),
-            ByteCodeTest::Code(AlignedByteCode::SetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(0)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Drop),
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
@@ -3097,8 +3122,7 @@ mod test {
           2,
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
-            ByteCodeTest::Code(AlignedByteCode::GetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(1)),
+            ByteCodeTest::Code(AlignedByteCode::GetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
           ],
         )),
@@ -3149,18 +3173,15 @@ mod test {
           4,
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
-            ByteCodeTest::Code(AlignedByteCode::Constant(1)),
-            ByteCodeTest::Code(AlignedByteCode::SetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(0)),
+            ByteCodeTest::Code(AlignedByteCode::Constant(0)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Drop),
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::Dup),
-            ByteCodeTest::Code(AlignedByteCode::GetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(1)),
-            ByteCodeTest::Code(AlignedByteCode::Constant(2)),
+            ByteCodeTest::Code(AlignedByteCode::GetKnownProperty(0)),
+            ByteCodeTest::Code(AlignedByteCode::Constant(1)),
             ByteCodeTest::Code(AlignedByteCode::Divide),
-            ByteCodeTest::Code(AlignedByteCode::SetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(2)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Drop),
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
@@ -3203,18 +3224,15 @@ mod test {
           4,
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
-            ByteCodeTest::Code(AlignedByteCode::Constant(1)),
-            ByteCodeTest::Code(AlignedByteCode::SetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(0)),
+            ByteCodeTest::Code(AlignedByteCode::Constant(0)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Drop),
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::Dup),
-            ByteCodeTest::Code(AlignedByteCode::GetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(1)),
-            ByteCodeTest::Code(AlignedByteCode::Constant(2)),
+            ByteCodeTest::Code(AlignedByteCode::GetKnownProperty(0)),
+            ByteCodeTest::Code(AlignedByteCode::Constant(1)),
             ByteCodeTest::Code(AlignedByteCode::Divide),
-            ByteCodeTest::Code(AlignedByteCode::SetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(2)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Drop),
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
@@ -3223,6 +3241,60 @@ mod test {
         ByteCodeTest::Code(AlignedByteCode::Method(2)),
         ByteCodeTest::Code(AlignedByteCode::Field(4)),
         ByteCodeTest::Code(AlignedByteCode::DropN(2)),
+        ByteCodeTest::Code(AlignedByteCode::Nil),
+        ByteCodeTest::Code(AlignedByteCode::Return),
+      ],
+    );
+  }
+
+  #[test]
+  fn property_access_outside_class() {
+    let example = "
+    class A {
+      init() {
+        self.a = 10;
+      }
+    }
+
+    let a = A();
+    a.a = 20;
+  ";
+
+    let context = NoContext::default();
+    let fun = test_compile(example, &context);
+
+    assert_fun_bytecode(
+      &fun,
+      4,
+      &vec![
+        ByteCodeTest::Code(AlignedByteCode::Class(0)),
+        ByteCodeTest::Code(AlignedByteCode::DefineGlobal(0)),
+        ByteCodeTest::Code(AlignedByteCode::GetGlobal(1)),
+        ByteCodeTest::Code(AlignedByteCode::GetGlobal(0)),
+        ByteCodeTest::Code(AlignedByteCode::Inherit),
+        ByteCodeTest::Fun((
+          3,
+          3,
+          vec![
+            ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
+            ByteCodeTest::Code(AlignedByteCode::Constant(0)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
+            ByteCodeTest::Code(AlignedByteCode::Drop),
+            ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
+            ByteCodeTest::Code(AlignedByteCode::Return),
+          ],
+        )),
+        ByteCodeTest::Code(AlignedByteCode::Method(2)),
+        ByteCodeTest::Code(AlignedByteCode::Field(4)),
+        ByteCodeTest::Code(AlignedByteCode::DropN(2)),
+        ByteCodeTest::Code(AlignedByteCode::GetGlobal(0)),
+        ByteCodeTest::Code(AlignedByteCode::Call(0)),
+        ByteCodeTest::Code(AlignedByteCode::DefineGlobal(4)),
+        ByteCodeTest::Code(AlignedByteCode::GetGlobal(4)),
+        ByteCodeTest::Code(AlignedByteCode::Constant(5)),
+        ByteCodeTest::Code(AlignedByteCode::SetProperty(4)),
+        ByteCodeTest::Code(AlignedByteCode::Slot(0)),
+        ByteCodeTest::Code(AlignedByteCode::Drop),
         ByteCodeTest::Code(AlignedByteCode::Nil),
         ByteCodeTest::Code(AlignedByteCode::Return),
       ],
@@ -3335,6 +3407,84 @@ mod test {
   }
 
   #[test]
+  fn class_with_super() {
+    let example = "
+    class A {
+      init() {
+        @a = 10;
+      }
+    }
+
+    class B: A {
+      init() {
+        super.init();
+        @b = 10;
+      }
+    }
+  ";
+
+    let context = NoContext::default();
+    let fun = test_compile(example, &context);
+
+    assert_fun_bytecode(
+      &fun,
+      4,
+      &vec![
+        ByteCodeTest::Code(AlignedByteCode::Class(0)),
+        ByteCodeTest::Code(AlignedByteCode::DefineGlobal(0)),
+        ByteCodeTest::Code(AlignedByteCode::GetGlobal(1)),
+        ByteCodeTest::Code(AlignedByteCode::GetGlobal(0)),
+        ByteCodeTest::Code(AlignedByteCode::Inherit),
+        ByteCodeTest::Fun((
+          3,
+          3,
+          vec![
+            ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
+            ByteCodeTest::Code(AlignedByteCode::Constant(0)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
+            ByteCodeTest::Code(AlignedByteCode::Drop),
+            ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
+            ByteCodeTest::Code(AlignedByteCode::Return),
+          ],
+        )),
+        ByteCodeTest::Code(AlignedByteCode::Method(2)),
+        ByteCodeTest::Code(AlignedByteCode::Field(4)),
+        ByteCodeTest::Code(AlignedByteCode::DropN(2)),
+        ByteCodeTest::Code(AlignedByteCode::Class(5)),
+        ByteCodeTest::Code(AlignedByteCode::DefineGlobal(5)),
+        ByteCodeTest::Code(AlignedByteCode::GetGlobal(0)),
+        ByteCodeTest::Code(AlignedByteCode::Box(1)),
+        ByteCodeTest::Code(AlignedByteCode::GetGlobal(5)),
+        ByteCodeTest::Code(AlignedByteCode::Inherit),
+        ByteCodeTest::Fun((
+          6,
+          3,
+          vec![
+            ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
+            ByteCodeTest::Code(AlignedByteCode::GetCapture(0)),
+            ByteCodeTest::Code(AlignedByteCode::GetSuper(0)),
+            ByteCodeTest::Code(AlignedByteCode::Call(0)),
+            ByteCodeTest::Code(AlignedByteCode::Drop),
+            ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
+            ByteCodeTest::Code(AlignedByteCode::Constant(1)),
+            ByteCodeTest::Code(AlignedByteCode::SetProperty(2)),
+            ByteCodeTest::Code(AlignedByteCode::Slot(0)),
+            ByteCodeTest::Code(AlignedByteCode::Drop),
+            ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
+            ByteCodeTest::Code(AlignedByteCode::Return),
+          ],
+        )),
+        ByteCodeTest::Code(AlignedByteCode::CaptureIndex(CaptureIndex::Local(1))),
+        ByteCodeTest::Code(AlignedByteCode::Method(2)),
+        ByteCodeTest::Code(AlignedByteCode::Field(7)),
+        ByteCodeTest::Code(AlignedByteCode::DropN(2)),
+        ByteCodeTest::Code(AlignedByteCode::Nil),
+        ByteCodeTest::Code(AlignedByteCode::Return),
+      ],
+    );
+  }
+
+  #[test]
   fn class_instance_access_with_captures() {
     let example = "
       class A {
@@ -3368,8 +3518,7 @@ mod test {
           vec![
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::True),
-            ByteCodeTest::Code(AlignedByteCode::SetProperty(0)),
-            ByteCodeTest::Code(AlignedByteCode::Slot(0)),
+            ByteCodeTest::Code(AlignedByteCode::SetKnownProperty(0)),
             ByteCodeTest::Code(AlignedByteCode::Drop),
             ByteCodeTest::Code(AlignedByteCode::GetLocal(0)),
             ByteCodeTest::Code(AlignedByteCode::Return),
@@ -3387,8 +3536,7 @@ mod test {
               2,
               vec![
                 ByteCodeTest::Code(AlignedByteCode::GetCapture(0)),
-                ByteCodeTest::Code(AlignedByteCode::GetProperty(0)),
-                ByteCodeTest::Code(AlignedByteCode::Slot(1)),
+                ByteCodeTest::Code(AlignedByteCode::GetKnownProperty(0)),
                 ByteCodeTest::Code(AlignedByteCode::Return),
               ],
             )),

--- a/laythe_vm/src/compiler/resolver.rs
+++ b/laythe_vm/src/compiler/resolver.rs
@@ -722,18 +722,18 @@ impl<'a, 'src> Resolver<'a, 'src> {
 
   /// Resolve an assignment expression
   fn assign(&mut self, assign: &mut ast::Assign<'src>) {
-    self.expr(&mut assign.lhs);
+    self.atom(&mut assign.lhs);
     self.expr(&mut assign.rhs);
   }
 
   fn send(&mut self, send: &mut ast::Send<'src>) {
-    self.expr(&mut send.lhs);
+    self.atom(&mut send.lhs);
     self.expr(&mut send.rhs);
   }
 
   /// Resolve a binary assignment expression
   fn assign_binary(&mut self, assign_binary: &mut ast::AssignBinary<'src>) {
-    self.expr(&mut assign_binary.lhs);
+    self.atom(&mut assign_binary.lhs);
     self.expr(&mut assign_binary.rhs);
   }
 

--- a/laythe_vm/src/debug.rs
+++ b/laythe_vm/src/debug.rs
@@ -15,7 +15,7 @@ pub fn print_symbolic_code(
   chunk_builder: &ChunkBuilder,
   name: &str,
 ) -> io::Result<()> {
-    use std::u16;
+  use std::u16;
 
   let stdout = stdio.stdout();
   writeln!(stdout)?;
@@ -191,6 +191,12 @@ pub fn print_byte_code(
     SymbolicByteCode::GetProperty(slot) => {
       symbolic_property_instruction(stdio.stdout(), "GetProperty", chunk, slot, offset)
     },
+    SymbolicByteCode::SetKnownProperty(slot) => {
+      short_instruction(stdio.stdout(), "SetKnownProperty", slot, offset)
+    },
+    SymbolicByteCode::GetKnownProperty(slot) => {
+      short_instruction(stdio.stdout(), "GetKnownProperty", slot, offset)
+    },
     SymbolicByteCode::Jump(jump) => symbolic_jump_instruction(stdio.stdout(), "Jump", jump, offset),
     SymbolicByteCode::JumpIfFalse(jump) => {
       symbolic_jump_instruction(stdio.stdout(), "JumpIfFalse", jump, offset)
@@ -200,9 +206,13 @@ pub fn print_byte_code(
       symbolic_push_handler_instruction(stdio.stdout(), "PushHandler", slots, jump, offset)
     },
     SymbolicByteCode::PopHandler => simple_instruction(stdio.stdout(), "PopHandler", offset),
-    SymbolicByteCode::CheckHandler(jump) => symbolic_jump_instruction(stdio.stdout(), "CheckHandler", jump, offset),
+    SymbolicByteCode::CheckHandler(jump) => {
+      symbolic_jump_instruction(stdio.stdout(), "CheckHandler", jump, offset)
+    },
     SymbolicByteCode::FinishUnwind => simple_instruction(stdio.stdout(), "FinishUnwind", offset),
-    SymbolicByteCode::ContinueUnwind => simple_instruction(stdio.stdout(), "ContinueUnwind", offset),
+    SymbolicByteCode::ContinueUnwind => {
+      simple_instruction(stdio.stdout(), "ContinueUnwind", offset)
+    },
     SymbolicByteCode::Raise => simple_instruction(stdio.stdout(), "Raise", offset),
     SymbolicByteCode::GetError => simple_instruction(stdio.stdout(), "GetError", offset),
     SymbolicByteCode::Equal => simple_instruction(stdio.stdout(), "Equal", offset),
@@ -526,6 +536,12 @@ pub fn disassemble_instruction(
     AlignedByteCode::GetProperty(slot) => {
       constant_instruction_with_slot(stdio.stdout(), "GetProperty", chunk, slot, offset)
     },
+    AlignedByteCode::SetKnownProperty(slot) => {
+      short_instruction(stdio.stdout(), "SetKnownProperty", slot, offset)
+    },
+    AlignedByteCode::GetKnownProperty(slot) => {
+      short_instruction(stdio.stdout(), "GetKnownProperty", slot, offset)
+    },
     AlignedByteCode::Jump(jump) => jump_instruction(stdio.stdout(), "Jump", 1, jump, offset),
     AlignedByteCode::JumpIfFalse(jump) => {
       jump_instruction(stdio.stdout(), "JumpIfFalse", 1, jump, offset)
@@ -534,7 +550,9 @@ pub fn disassemble_instruction(
     AlignedByteCode::PushHandler((slots, jump)) => {
       push_handler_instruction(stdio.stdout(), "PushHandler", slots, jump, offset)
     },
-    AlignedByteCode::CheckHandler(jump) => jump_instruction(stdio.stdout(), "CheckHandler", 1, jump, offset),
+    AlignedByteCode::CheckHandler(jump) => {
+      jump_instruction(stdio.stdout(), "CheckHandler", 1, jump, offset)
+    },
     AlignedByteCode::PopHandler => simple_instruction(stdio.stdout(), "PopHandler", offset),
     AlignedByteCode::FinishUnwind => simple_instruction(stdio.stdout(), "FinishUnwind", offset),
     AlignedByteCode::ContinueUnwind => simple_instruction(stdio.stdout(), "ContinueUnwind", offset),

--- a/laythe_vm/src/vm/mod.rs
+++ b/laythe_vm/src/vm/mod.rs
@@ -235,9 +235,7 @@ impl Vm {
           let file_id = self.files.upsert(managed_path, source_content);
           self.pop_roots(2);
 
-          if let ExecutionResult::Exit(code) = self.interpret(true, main_module, &source, file_id) {
-            return (code as i32, VmExit::Ok);
-          }
+          self.interpret(true, main_module, &source, file_id);
         },
         Err(error) => panic!("{}", error),
       }
@@ -386,6 +384,8 @@ impl Vm {
           ByteCode::SetCapture => self.op_set_capture(),
           ByteCode::GetProperty => self.op_get_property(),
           ByteCode::SetProperty => self.op_set_property(),
+          ByteCode::GetKnownProperty => self.op_get_known_property(),
+          ByteCode::SetKnownProperty => self.op_set_known_property(),
           ByteCode::Import => self.op_import(),
           ByteCode::ImportSymbol => self.op_import_symbol(),
           ByteCode::Export => self.op_export(),


### PR DESCRIPTION
## Problem
We know even with inline caching that property access in may cases can be faster. Today even without an type checker in limited cases we know what the receiver will be already. In this case this is calls to `self.foo` or `@foo` inside of classes which don't have an explicit subtype. In this limited but very common case we know the layout of the instance at compile time.

## Solution
Once we've identified that we are in fact in this special case we can emit more specialized instructions which are currently called `GetKnownProperty` and `SetKnownProperty`. These instructions are again only used inside the class when it doesn't subtype. For instruction outside of the class or those that do subclass we just emit our original pattern. 

The potential for further speedup is clear but would require more infrastructure to know the type and layout of instances in more situations. 