### PR TITLE
Minor collection changes

### DIFF
--- a/laythe_core/src/captures.rs
+++ b/laythe_core/src/captures.rs
@@ -2,18 +2,17 @@ use std::fmt;
 
 use crate::{
   hooks::GcHooks,
-  managed::{DebugHeap, DebugWrap, GcObj, Trace, Tuple},
+  managed::{Array, DebugHeap, DebugWrap, GcObj, Trace},
   object::LyBox,
-  val,
   value::Value,
 };
 
 #[derive(PartialEq, Eq, Clone, Copy)]
-pub struct Captures(Tuple);
+pub struct Captures(Array<GcObj<LyBox>>);
 
 impl Captures {
   pub fn new(hooks: &GcHooks, captures: &[GcObj<LyBox>]) -> Self {
-    Self(hooks.manage_obj::<Tuple, &[Value]>(&captures.iter().map(|c| val!(*c)).collect::<Vec<Value>>()))
+    Self(hooks.manage(captures))
   }
 
   #[inline]
@@ -28,17 +27,17 @@ impl Captures {
 
   #[inline]
   pub fn get_capture(&self, index: usize) -> GcObj<LyBox> {
-    self.0[index].to_obj().to_box()
+    self.0[index]
   }
 
   #[inline]
   pub fn get_capture_value(&self, index: usize) -> Value {
-    self.0[index].to_obj().to_box().value
+    self.0[index].value
   }
 
   #[inline]
   pub fn set_capture_value(&mut self, index: usize, value: Value) {
-    self.0[index].to_obj().to_box().value = value;
+    self.0[index].value = value;
   }
 }
 

--- a/laythe_core/src/managed/allocation.rs
+++ b/laythe_core/src/managed/allocation.rs
@@ -23,7 +23,7 @@ impl<T: 'static> Allocation<T> {
   pub fn new(data: T) -> Self {
     Self {
       data,
-      header: Header::new(false),
+      header: Header::new(),
     }
   }
 }

--- a/laythe_core/src/managed/gc_array.rs
+++ b/laythe_core/src/managed/gc_array.rs
@@ -369,7 +369,7 @@ impl<T, H> Drop for GcArrayHandle<T, H> {
 
 impl<T: 'static + Trace + Copy + DebugHeap> Allocate<GcArray<T, Header>> for &[T] {
   fn alloc(self) -> AllocResult<GcArray<T, Header>> {
-    let handle = GcArrayHandle::from_slice(self, Header::new(false));
+    let handle = GcArrayHandle::from_slice(self, Header::new());
     let reference = handle.value();
     let size = handle.size();
 

--- a/laythe_core/src/managed/gc_obj.rs
+++ b/laythe_core/src/managed/gc_obj.rs
@@ -6,7 +6,7 @@ use super::{
   utils::{
     get_array_len_offset, get_list_cap_offset, get_offset, make_array_layout, make_obj_layout,
   },
-  AllocateObj, GcStr, Instance, List, Mark, Marked, Tuple, Unmark,
+  AllocateObj, GcStr, Instance, LyList, Mark, Marked, Tuple, Unmark,
 };
 use crate::{
   managed::{
@@ -358,7 +358,7 @@ impl GcObject {
   }
 
   #[inline]
-  pub fn to_list(self) -> List {
+  pub fn to_list(self) -> LyList {
     unsafe { GcList::from_alloc_ptr(self.ptr) }
   }
 

--- a/laythe_core/src/managed/header.rs
+++ b/laythe_core/src/managed/header.rs
@@ -14,9 +14,9 @@ pub struct Header {
 }
 
 impl Header {
-  pub fn new(marked: bool) -> Self {
+  pub fn new() -> Self {
     Self {
-      marked: AtomicBool::new(marked),
+      marked: AtomicBool::new(false),
     }
   }
 }

--- a/laythe_core/src/managed/mod.rs
+++ b/laythe_core/src/managed/mod.rs
@@ -99,7 +99,7 @@ pub use allocation::Allocation;
 pub use allocator::{Allocator, NoGc, NO_GC};
 pub use gc::Gc;
 pub use gc_array::Array;
-pub use gc_list::{IndexedResult, List, ListBuilder, ListLocation};
+pub use gc_list::{IndexedResult, ListBuilder, ListLocation, LyList, List};
 pub use gc_obj::{GcObj, GcObject, GcObjectHandle, Object};
 pub use gc_str::GcStr;
 pub use instance::Instance;

--- a/laythe_core/src/module/mod.rs
+++ b/laythe_core/src/module/mod.rs
@@ -13,7 +13,7 @@ use crate::{
   hooks::GcHooks,
   list,
   managed::{
-    AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcObj, GcStr, Instance, List, ListLocation,
+    AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcObj, GcStr, Instance, LyList, ListLocation,
     Trace,
   },
   object::{Class, Map},
@@ -48,7 +48,7 @@ pub struct Module {
   symbols_by_name: Map<GcStr, usize>,
 
   /// All the symbols
-  symbols: List,
+  symbols: LyList,
 
   /// The path this module is located at
   path: GcStr,

--- a/laythe_core/src/object/fiber/mod.rs
+++ b/laythe_core/src/object/fiber/mod.rs
@@ -8,7 +8,7 @@ use crate::{
   constants::SCRIPT,
   hooks::GcHooks,
   if_let_obj,
-  managed::{DebugHeap, DebugWrap, GcObj, Instance, List, ListLocation, Object, Trace},
+  managed::{DebugHeap, DebugWrap, GcObj, Instance, ListLocation, LyList, Object, Trace},
   match_obj, val,
   value::{Value, VALUE_NIL},
 };
@@ -167,7 +167,7 @@ impl Fiber {
         });
       }
 
-      fn forward_list(value: &mut Value, list: List) {
+      fn forward_list(value: &mut Value, list: LyList) {
         if let ListLocation::Forwarded(gc_list) = list.state() {
           *value = val!(gc_list)
         }

--- a/laythe_core/src/value.rs
+++ b/laythe_core/src/value.rs
@@ -82,7 +82,7 @@ pub use self::boxed::*;
 #[cfg(not(feature = "nan_boxing"))]
 mod unboxed {
   use crate::{
-    managed::{DebugHeap, DebugWrap, GcObj, GcObject, GcStr, Instance, Trace, Tuple, List},
+    managed::{DebugHeap, DebugWrap, GcObj, GcObject, GcStr, Instance, LyList, Trace, Tuple},
     object::{
       Channel, Class, Closure, Enumerator, Fiber, Fun, LyBox, Map, Method, Native, ObjectKind,
     },
@@ -311,8 +311,8 @@ mod unboxed {
     }
   }
 
-  impl From<List> for Value {
-    fn from(managed: List) -> Value {
+  impl From<LyList> for Value {
+    fn from(managed: LyList) -> Value {
       Value::Obj(managed.degrade())
     }
   }
@@ -497,7 +497,7 @@ mod unboxed {
 mod boxed {
   use super::{Nil, ValueKind};
   use crate::{
-    managed::{DebugHeap, GcObj, GcObject, GcStr, Instance, Trace, Tuple, List},
+    managed::{DebugHeap, GcObj, GcObject, GcStr, Instance, LyList, Trace, Tuple},
     object::{
       Channel, Class, Closure, Enumerator, Fiber, Fun, LyBox, Map, Method, Native, ObjectKind,
     },
@@ -734,8 +734,8 @@ mod boxed {
     }
   }
 
-  impl From<List> for Value {
-    fn from(managed: List) -> Value {
+  impl From<LyList> for Value {
+    fn from(managed: LyList) -> Value {
       Self(managed.to_usize() as u64 | TAG_OBJ)
     }
   }
@@ -845,7 +845,12 @@ mod boxed {
 mod test {
   use super::*;
   use crate::{
-    captures::Captures, hooks::{GcHooks, NoContext}, list, managed::{Allocator, Gc, GcObj, GcStr, NO_GC}, module::Module, object::{Class, Closure, Fun, Map, ObjectKind}
+    captures::Captures,
+    hooks::{GcHooks, NoContext},
+    list,
+    managed::{Allocator, Gc, GcObj, GcStr, NO_GC},
+    module::Module,
+    object::{Class, Closure, Fun, Map, ObjectKind},
   };
 
   const VALUE_VARIANTS: [ValueKind; 4] = [

--- a/laythe_lib/src/env/utils.rs
+++ b/laythe_lib/src/env/utils.rs
@@ -6,7 +6,7 @@ use crate::{
 use laythe_core::{
   hooks::{GcHooks, Hooks},
   list,
-  managed::{Gc, GcObj, List, Trace},
+  managed::{Gc, GcObj, LyList, Trace},
   module::Module,
   object::{LyNative, Native, NativeMetaBuilder},
   signature::Arity,
@@ -33,7 +33,7 @@ native!(Args, ARGS_META);
 impl LyNative for Args {
   fn call(&self, hooks: &mut Hooks, _args: &[Value]) -> Call {
     let io = hooks.as_io();
-    let mut list: List = hooks.manage_obj(list!());
+    let mut list: LyList = hooks.manage_obj(list!());
     hooks.push_root(list);
 
     for arg in io.env().args() {

--- a/laythe_lib/src/global/primitives/list.rs
+++ b/laythe_lib/src/global/primitives/list.rs
@@ -7,7 +7,7 @@ use laythe_core::{
   constants::{INDEX_GET, INDEX_SET},
   hooks::{GcHooks, Hooks},
   if_let_obj, list,
-  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, IndexedResult, List, ListBuilder, Trace},
+  managed::{DebugHeap, DebugWrap, Gc, GcObj, GcStr, IndexedResult, LyList, ListBuilder, Trace},
   module::Module,
   object::{Enumerate, Enumerator, LyNative, Native, NativeMetaBuilder, ObjectKind},
   signature::{Arity, ParameterBuilder, ParameterKind},
@@ -333,7 +333,7 @@ impl ListSlice {
   }
 }
 
-fn determine_index(list: &List, index: f64) -> Result<usize, String> {
+fn determine_index(list: &LyList, index: f64) -> Result<usize, String> {
   if index.fract() != 0.0 {
     return Err("Index must be an integer.".to_string());
   }
@@ -659,13 +659,13 @@ impl LyNative for ListCollect {
 
 #[derive(Debug)]
 struct ListIterator {
-  list: List,
+  list: LyList,
   index: usize,
   current: Value,
 }
 
 impl ListIterator {
-  fn new(list: List) -> Self {
+  fn new(list: LyList) -> Self {
     Self {
       current: VALUE_NIL,
       list,

--- a/laythe_vm/src/vm/ops.rs
+++ b/laythe_vm/src/vm/ops.rs
@@ -6,7 +6,7 @@ use laythe_core::{
   captures::Captures,
   hooks::{GcHooks, Hooks},
   if_let_obj, list,
-  managed::{Array, Gc, GcObj, GcStr, List, Tuple},
+  managed::{Array, Gc, GcObj, GcStr, LyList, Tuple},
   match_obj,
   module::Import,
   object::{
@@ -1020,7 +1020,7 @@ impl Vm {
     result
   }
 
-  fn extract_import_path(&mut self, path: List) -> Vec<GcStr> {
+  fn extract_import_path(&mut self, path: LyList) -> Vec<GcStr> {
     path
       .iter()
       .map(|segment| segment.to_obj().to_str())


### PR DESCRIPTION
## Problem
I would like to work on convert more of the internal collections to using GcArray or GcList under the hood. I had originally started looking at Fiber when I realized I wanted to work on a bit of the design there before diving in. Specfically I want to take a deeper look at the relationship of channels and fibers.

## Solution
Int his PR I do two small things
* I create an version of GcList which can work with something other than a `Value` for the many other cases we may have
* I see some low hanging fruit with Captures where we can store the LyBox unwrapped instead of wrapped.