### PR TITLE
Optimize channel

### DIFF
--- a/laythe_core/src/object/channel/channel_queue.rs
+++ b/laythe_core/src/object/channel/channel_queue.rs
@@ -147,7 +147,7 @@ impl ChannelQueue {
 
           let waiter = find_runnable_waiter(&mut self.send_waiters);
 
-          return if self.is_sync() {
+          if self.is_sync() {
             ReceiveResult::EmptyBlock(waiter)
           } else {
             ReceiveResult::Empty(waiter)

--- a/laythe_core/src/object/channel/mod.rs
+++ b/laythe_core/src/object/channel/mod.rs
@@ -1,0 +1,362 @@
+mod channel_queue;
+
+use channel_queue::ChannelQueue;
+
+use super::{Fiber, ObjectKind};
+use crate::{
+  hooks::GcHooks,
+  managed::{AllocResult, Allocate, DebugHeap, DebugWrap, Gc, GcObj, Object, Trace},
+  value::Value,
+};
+use std::{fmt, io::Write};
+
+/// What type of channel is this
+#[derive(PartialEq, Clone, Debug)]
+enum ChannelKind {
+  /// This channel and both send and receive
+  BiDirectional,
+
+  /// This channel can only receive
+  ReceiveOnly,
+
+  /// This channel can only send
+  SendOnly,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum SendResult {
+  Ok,
+  NoSendAccess,
+  FullBlock(Option<GcObj<Fiber>>),
+  Full(Option<GcObj<Fiber>>),
+  Closed,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum ReceiveResult {
+  Ok(Value),
+  NoReceiveAccess,
+  EmptyBlock(Option<GcObj<Fiber>>),
+  Empty(Option<GcObj<Fiber>>),
+  Closed,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum CloseResult {
+  Ok,
+  AlreadyClosed,
+}
+
+impl Allocate<Gc<Self>> for ChannelQueue {
+  fn alloc(self) -> AllocResult<Gc<Self>> {
+    Gc::alloc_result(self)
+  }
+}
+
+#[derive(PartialEq, Clone)]
+pub struct Channel {
+  queue: Gc<ChannelQueue>,
+  kind: ChannelKind,
+}
+
+impl Channel {
+  /// Create a synchronous channel
+  pub fn sync(hooks: &GcHooks) -> Self {
+    Self {
+      queue: hooks.manage(ChannelQueue::sync()),
+      kind: ChannelKind::BiDirectional,
+    }
+  }
+
+  /// Create a channel with a fixed capacity
+  pub fn with_capacity(hooks: &GcHooks, capacity: usize) -> Self {
+    Self {
+      queue: hooks.manage(ChannelQueue::with_capacity(capacity)),
+      kind: ChannelKind::BiDirectional,
+    }
+  }
+
+  /// Create a read only channel
+  pub fn read_only(&self) -> Option<Self> {
+    match self.kind {
+      ChannelKind::BiDirectional | ChannelKind::ReceiveOnly => Some(Self {
+        queue: self.queue,
+        kind: ChannelKind::ReceiveOnly,
+      }),
+      ChannelKind::SendOnly => None,
+    }
+  }
+
+  /// Create a write only channel
+  pub fn write_only(&self) -> Option<Self> {
+    match self.kind {
+      ChannelKind::BiDirectional | ChannelKind::SendOnly => Some(Self {
+        queue: self.queue,
+        kind: ChannelKind::SendOnly,
+      }),
+      ChannelKind::ReceiveOnly => None,
+    }
+  }
+
+  /// Is this queue empty
+  #[inline]
+  pub fn is_empty(&self) -> bool {
+    self.queue.is_empty()
+  }
+
+  /// The capacity of the associated channel queue
+  #[inline]
+  pub fn len(&self) -> usize {
+    self.queue.len()
+  }
+
+  /// The capacity of the associated channel queue
+  #[inline]
+  pub fn capacity(&self) -> usize {
+    self.queue.capacity()
+  }
+
+  /// Close this channel queue
+  pub fn close(&mut self) -> CloseResult {
+    self.queue.close()
+  }
+
+  /// Is this channel queue closed
+  #[inline]
+  pub fn is_closed(&self) -> bool {
+    self.queue.is_closed()
+  }
+
+  /// Attempt to send a value into this channel.
+  /// the value can be reject either because the
+  /// channel is saturated or because the channel
+  /// has already been closed
+  #[inline]
+  pub fn send(&mut self, fiber: GcObj<Fiber>, val: Value) -> SendResult {
+    match self.kind {
+      ChannelKind::BiDirectional | ChannelKind::SendOnly => self.queue.send(fiber, val),
+      ChannelKind::ReceiveOnly => SendResult::NoSendAccess,
+    }
+  }
+
+  /// Attempt to receive a value from this channel.
+  /// If the channel is empty
+  #[inline]
+  pub fn receive(&mut self, fiber: GcObj<Fiber>) -> ReceiveResult {
+    match self.kind {
+      ChannelKind::BiDirectional | ChannelKind::ReceiveOnly => self.queue.receive(fiber),
+      ChannelKind::SendOnly => ReceiveResult::NoReceiveAccess,
+    }
+  }
+
+  /// Attempt to get a runnable waiter
+  /// from this channel
+  pub fn runnable_waiter(&mut self) -> Option<GcObj<Fiber>> {
+    self.queue.runnable_waiter()
+  }
+}
+
+impl fmt::Display for Channel {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "<Channel {self:p}>")
+  }
+}
+
+impl fmt::Debug for Channel {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    self.fmt_heap(f, 2)
+  }
+}
+
+impl Trace for Channel {
+  #[inline]
+  fn trace(&self) {
+    self.queue.trace()
+  }
+
+  fn trace_debug(&self, log: &mut dyn Write) {
+    self.queue.trace_debug(log)
+  }
+}
+
+impl DebugHeap for Channel {
+  fn fmt_heap(&self, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
+    f.debug_struct("Channel")
+      .field("queue", &DebugWrap(&self.queue, depth))
+      .field("kind", &self.kind)
+      .finish()
+  }
+}
+
+impl Object for Channel {
+  fn kind(&self) -> ObjectKind {
+    ObjectKind::Channel
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  mod channel {
+    use crate::{
+      hooks::{GcHooks, NoContext},
+      support::FiberBuilder,
+      val,
+    };
+
+    use super::*;
+
+    #[test]
+    fn sync() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let channel = Channel::sync(&hooks);
+      assert_eq!(channel.capacity(), 1);
+      assert_eq!(channel.len(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn with_zero_sized_capacity() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      Channel::with_capacity(&hooks, 0);
+    }
+
+    #[test]
+    fn with_nonzero_sized_capacity() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let channel = Channel::with_capacity(&hooks, 5);
+      assert_eq!(channel.capacity(), 5);
+      assert_eq!(channel.len(), 0);
+    }
+
+    #[test]
+    fn len() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let fiber = FiberBuilder::default().build(&hooks).unwrap();
+      let mut channel = Channel::with_capacity(&hooks, 5);
+
+      assert_eq!(channel.len(), 0);
+
+      channel.send(fiber, val!(1.0));
+      assert_eq!(channel.len(), 1);
+
+      channel.send(fiber, val!(1.0));
+      channel.send(fiber, val!(1.0));
+      channel.send(fiber, val!(1.0));
+      assert_eq!(channel.len(), 4);
+    }
+
+    #[test]
+    fn capacity() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let channel = Channel::with_capacity(&hooks, 5);
+
+      assert_eq!(channel.capacity(), 5);
+    }
+
+    #[test]
+    fn close() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let mut channel = Channel::with_capacity(&hooks, 1);
+
+      assert_eq!(channel.close(), CloseResult::Ok);
+      assert!(channel.is_closed());
+
+      assert_eq!(channel.close(), CloseResult::AlreadyClosed);
+      assert!(channel.is_closed())
+    }
+
+    #[test]
+    fn enqueue_with_no_write_access() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let fiber = FiberBuilder::default().build(&hooks).unwrap();
+      let mut channel = Channel::sync(&hooks).read_only().unwrap();
+
+      let r = channel.send(fiber, val!(10.0));
+
+      assert_eq!(r, SendResult::NoSendAccess);
+      assert_eq!(channel.len(), 0);
+    }
+
+    #[test]
+    fn dequeue_when_no_read_access() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let fiber = FiberBuilder::default().build(&hooks).unwrap();
+      let mut channel = Channel::sync(&hooks).write_only().unwrap();
+
+      let r = channel.receive(fiber);
+
+      assert_eq!(r, ReceiveResult::NoReceiveAccess);
+      assert_eq!(channel.len(), 0);
+    }
+
+    #[test]
+    fn bi_directional_to_read_only() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      assert!(Channel::with_capacity(&hooks, 1).read_only().is_some())
+    }
+
+    #[test]
+    fn bi_directional_to_write_only() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      assert!(Channel::with_capacity(&hooks, 1).write_only().is_some())
+    }
+
+    #[test]
+    fn read_only_to_read_only() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let read_only = Channel::with_capacity(&hooks, 1).read_only().unwrap();
+      assert!(read_only.read_only().is_some())
+    }
+
+    #[test]
+    fn read_only_to_write_only() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let read_only = Channel::with_capacity(&hooks, 1).read_only().unwrap();
+      assert!(read_only.write_only().is_none())
+    }
+
+    #[test]
+    fn write_only_to_read_only() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let write_only = Channel::with_capacity(&hooks, 1).write_only().unwrap();
+      assert!(write_only.read_only().is_none())
+    }
+
+    #[test]
+    fn write_only_to_write_only() {
+      let context = NoContext::default();
+      let hooks = GcHooks::new(&context);
+
+      let write_only = Channel::with_capacity(&hooks, 1).write_only().unwrap();
+      assert!(write_only.write_only().is_some())
+    }
+  }
+}

--- a/laythe_vm/fixture/benchmark/channel.lay
+++ b/laythe_vm/fixture/benchmark/channel.lay
@@ -8,7 +8,7 @@ let buffered = chan(100);
 launch test(sync);
 launch test(buffered);
 
-let n = 10000;
+let n = 1000000;
 
 let syncStart = clock();
 

--- a/laythe_vm/src/vm/basic.rs
+++ b/laythe_vm/src/vm/basic.rs
@@ -157,7 +157,7 @@ impl Vm {
         if self.fiber == self.main_fiber {
           Some(ExecutionSignal::Exit)
         } else {
-          if let Some(mut fiber) = Fiber::complete(self.fiber) {
+          if let Some(mut fiber) = self.fiber.complete() {
             fiber.unblock();
             self.fiber_queue.push_back(fiber);
           }


### PR DESCRIPTION
## Problem
Our channel is pretty unperformant in that we are doing a lot unnecessary work. Two things we are doing that has a pretty massive performance impact.

* We are keeping our waiters in a set. The idea here was to deduplicate multiple fibers. The issue is once a fiber is blocked by a channel it will only ever be in that one channel waiting so we shouldn't every have this case
* We eagerly remove completed waiters. This again requires a way to efficiently find the fiber in a the list of waiters for removal

## Solution
We move our waiters to `VecDeque` and treat them as simple queues. When we dequeue we now check if the fiber is complete which should be a simple equaity check.